### PR TITLE
Make ReviewClasses less confusing.

### DIFF
--- a/critiquebrainz/data/constants.py
+++ b/critiquebrainz/data/constants.py
@@ -43,45 +43,4 @@ sorcerer = UserType(
 user_types = (blocked, spammer, noob, apprentice, sorcerer)
 
 
-# REVIEW CLASSES
-class ReviewClass(object):
 
-    def __init__(self, label, rating, upvote, downvote, mark_spam):
-        self.label = label
-        self.rating = rating
-        self.upvote = upvote
-        self.downvote = downvote
-        self.mark_spam = mark_spam
-
-    def is_instance(self, review):
-        return self.rating(review.rating)
-
-spam = ReviewClass(
-    label='Spam',
-    rating=lambda x: (x < -10),
-    upvote=(apprentice, sorcerer),
-    downvote=(noob, apprentice, sorcerer),
-    mark_spam=(apprentice, sorcerer))
-
-neutral = ReviewClass(
-    label='Neutral',
-    rating=lambda x: (x >= -10 and x < 10),
-    upvote=(noob, apprentice, sorcerer),
-    downvote=(noob, apprentice, sorcerer),
-    mark_spam=(apprentice, sorcerer))
-
-promising = ReviewClass(
-    label='Promising',
-    rating=lambda x: (x >= 10 and x < 30),
-    upvote=(spammer, noob, apprentice, sorcerer),
-    downvote=(noob, apprentice, sorcerer),
-    mark_spam=(apprentice, sorcerer))
-
-trusted = ReviewClass(
-    label='Trusted',
-    rating=lambda x: (x >= 30),
-    upvote=(spammer, noob, apprentice, sorcerer),
-    downvote=(apprentice, sorcerer),
-    mark_spam=(apprentice, sorcerer))
-
-review_classes = (spam, neutral, promising, trusted)

--- a/critiquebrainz/data/model/review.py
+++ b/critiquebrainz/data/model/review.py
@@ -68,7 +68,6 @@ class Review(db.Model, DeleteMixin):
             language=self.language,
             source=self.source,
             source_url=self.source_url,
-            review_class=self.review_class.label
         )
 
     @classmethod

--- a/critiquebrainz/data/model/review.py
+++ b/critiquebrainz/data/model/review.py
@@ -10,7 +10,6 @@ from sqlalchemy.dialects.postgresql import UUID
 from critiquebrainz.data.model.vote import Vote
 from critiquebrainz.data.model.revision import Revision
 from critiquebrainz.data.model.mixins import DeleteMixin
-from critiquebrainz.data.constants import review_classes
 from critiquebrainz import cache
 from werkzeug.exceptions import BadRequest
 from flask_babel import gettext
@@ -106,18 +105,7 @@ class Review(db.Model, DeleteMixin):
     def votes_negative_count(self):
         return self.last_revision.votes_negative_count
 
-    @property
-    def review_class(self):
-        """Returns class of this review."""
 
-        def get_review_class(review):
-            for c in review_classes:
-                if c.is_instance(review) is True:
-                    return c
-
-        if hasattr(self, '_review_class') is False:
-            self._review_class = get_review_class(self)
-        return self._review_class
 
     @property
     def rating(self):

--- a/critiquebrainz/frontend/review/views.py
+++ b/critiquebrainz/frontend/review/views.py
@@ -268,12 +268,7 @@ def vote_submit(review_id):
         flash(gettext("You are not allowed to rate this review because "
                       "your account has been blocked by a moderator."), 'error')
         return redirect(url_for('.entity', id=review_id))
-    if vote is True and current_user.user_type not in review.review_class.upvote:
-        flash(gettext("You are not allowed to rate this review."), 'error')
-        return redirect(url_for('.entity', id=review_id))
-    if vote is False and current_user.user_type not in review.review_class.downvote:
-        flash(gettext("You are not allowed to rate this review."), 'error')
-        return redirect(url_for('.entity', id=review_id))
+
     Vote.create(current_user, review, vote)  # overwrites an existing vote, if needed
 
     flash(gettext("You have rated this review!"), 'success')

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -289,10 +289,6 @@ def review_vote_put_handler(review_id, user):
         raise InvalidRequest(desc='You cannot rate your own review.')
     if user.is_vote_limit_exceeded is True and user.has_voted(review) is False:
         raise LimitExceeded('You have exceeded your limit of votes per day.')
-    if vote is True and user.user_type not in review.review_class.upvote:
-        raise InvalidRequest(desc='You are not allowed to upvote this review.')
-    if vote is False and user.user_type not in review.review_class.downvote:
-        raise InvalidRequest(desc='You are not allowed to downvote this review.')
     Vote.create(user, review, vote)  # overwrites an existing vote, if needed
     return jsonify(message='Request processed successfully')
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 apt-get update
-apt-get install -y build-essential python-pip python-dev memcached curl
+apt-get install -y build-essential python-pip python-dev memcached curl git
 
 # PostgreSQL
 PG_VERSION=9.1


### PR DESCRIPTION
Previous version of CritiqueBrainz used review classes for various features within the website. The problem is that these classes are not very useful and confusing. Now review_classes from critiquebrainz/data/constants.py and its' usages are removed.
My task on GCI : https://codein.withgoogle.com/dashboard/task-instances/5507485452468224/

Also git was missing in scripts/bootstrap.sh