### PR TITLE
CB-192: Add link to Cover Art Archive on /artist and /release group

### DIFF
--- a/critiquebrainz/frontend/templates/artist.html
+++ b/critiquebrainz/frontend/templates/artist.html
@@ -161,8 +161,8 @@
     </div>
     <div id="cover-art-annotation">
       <span class="text-muted">
-      Cover arts provided by
-      <a href="https://coverartarchive.org/">Cover Art Archive</a>
+        Cover art provided by
+        <a href="https://coverartarchive.org/">Cover Art Archive</a>
       </span>
     </div>
   </div>

--- a/critiquebrainz/frontend/templates/artist.html
+++ b/critiquebrainz/frontend/templates/artist.html
@@ -159,6 +159,12 @@
       <div class="favicon-container"><img src="{{ url_for('static', filename='favicons/musicbrainz-16.ico') }}" /></div>
       <a href="//musicbrainz.org/artist/{{ artist.id }}"><em>{{ _('Edit on MusicBrainz') }}</em></a>
     </div>
+    <div id="cover-art-annotation">
+      <span class="text-muted">
+      Cover arts provided by
+      <a href="https://coverartarchive.org/">Cover Art Archive</a>
+      </span>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/critiquebrainz/frontend/templates/release_group.html
+++ b/critiquebrainz/frontend/templates/release_group.html
@@ -45,6 +45,12 @@
           .on("error", function () { $(this).attr("src", "/static/img/missing-art.png"); })
           .attr("src", "//coverartarchive.org/release-group/{{ id }}/front-250");
     </script>
+    <div id="cover-art-annotation">
+      <span class="text-muted">
+      Cover art provided by
+      <a href="https://coverartarchive.org/">Cover Art Archive</a>
+      </span>
+    </div>
     <div id="spotify-play-button">
       {% if spotify_mappings %}
         <iframe src="https://embed.spotify.com/?uri={{ spotify_mappings[0] }}&theme=white"

--- a/critiquebrainz/frontend/templates/release_group.html
+++ b/critiquebrainz/frontend/templates/release_group.html
@@ -47,8 +47,8 @@
     </script>
     <div id="cover-art-annotation">
       <span class="text-muted">
-      Cover art provided by
-      <a href="https://coverartarchive.org/">Cover Art Archive</a>
+        Cover art provided by
+        <a href="https://coverartarchive.org/">Cover Art Archive</a>
       </span>
     </div>
     <div id="spotify-play-button">


### PR DESCRIPTION
Neither https://critiquebrainz.org/artist/467f69b6-8d6d-4d2c-bfad-e89adf2806ff nor https://critiquebrainz.org/release-group/1bd3ecb6-e064-3eef-a850-25eb5c0a50ee have any mention of the CoverArtArchive, but both pull in cover art from it.   
I've added some annotations about CAA on both pages.
[GCI task](https://codein.withgoogle.com/dashboard/task-instances/6387195350876160/)
[#CB-192](http://tickets.musicbrainz.org/browse/CB-192)

