### PR TITLE
Added note for drafts not being private and fixed ISE on reviewing event without place

### DIFF
--- a/critiquebrainz/data/model/user.py
+++ b/critiquebrainz/data/model/user.py
@@ -19,7 +19,7 @@ class User(db.Model, AdminMixin, DeleteMixin):
     created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     musicbrainz_id = db.Column(db.Unicode, unique=True)
     show_gravatar = db.Column(db.Boolean, nullable=False, server_default="False")
-    is_blocked = db.Column(db.Boolean, nullable=True, default=False)
+    is_blocked = db.Column(db.Boolean, nullable=False, default=False)
 
     spam_reports = db.relationship('SpamReport', cascade='delete', backref='user')
     clients = db.relationship('OAuthClient', cascade='delete', backref='user')

--- a/critiquebrainz/data/model/user.py
+++ b/critiquebrainz/data/model/user.py
@@ -19,7 +19,7 @@ class User(db.Model, AdminMixin, DeleteMixin):
     created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     musicbrainz_id = db.Column(db.Unicode, unique=True)
     show_gravatar = db.Column(db.Boolean, nullable=False, server_default="False")
-    is_blocked = db.Column(db.Boolean, nullable=False, default=False)
+    is_blocked = db.Column(db.Boolean, nullable=True, default=False)
 
     spam_reports = db.relationship('SpamReport', cascade='delete', backref='user')
     clients = db.relationship('OAuthClient', cascade='delete', backref='user')

--- a/critiquebrainz/frontend/messages.pot
+++ b/critiquebrainz/frontend/messages.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-08-08 00:35+0000\n"
+"POT-Creation-Date: 2015-12-13 13:25+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.1.1\n"
 
 #: critiquebrainz/frontend/apis/mbspotify.py:46
 msgid ""
@@ -75,6 +75,10 @@ msgstr ""
 
 #: critiquebrainz/frontend/artist/views.py:19
 msgid "Sorry, we couldn't find an artist with that MusicBrainz ID."
+msgstr ""
+
+#: critiquebrainz/frontend/event/views.py:19
+msgid "Sorry, we couldn't find a event with that MusicBrainz ID."
 msgstr ""
 
 #: critiquebrainz/frontend/log/forms.py:8
@@ -273,7 +277,7 @@ msgid "You need to choose a license!"
 msgstr ""
 
 #: critiquebrainz/frontend/review/forms.py:45
-#: critiquebrainz/frontend/templates/base.html:69
+#: critiquebrainz/frontend/templates/base.html:71
 msgid "Language"
 msgstr ""
 
@@ -286,137 +290,131 @@ msgid "No reviews to display."
 msgstr ""
 
 #: critiquebrainz/frontend/review/views.py:56
-#: critiquebrainz/frontend/review/views.py:85
-#: critiquebrainz/frontend/review/views.py:202
+#: critiquebrainz/frontend/review/views.py:90
+#: critiquebrainz/frontend/review/views.py:211
 msgid "Can't find a review with the specified ID."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:58
-#: critiquebrainz/frontend/review/views.py:87
-#: critiquebrainz/frontend/review/views.py:114
-#: critiquebrainz/frontend/review/views.py:133
-#: critiquebrainz/frontend/review/views.py:206
-#: critiquebrainz/frontend/review/views.py:251
-#: critiquebrainz/frontend/review/views.py:279
-#: critiquebrainz/frontend/review/views.py:294
-#: critiquebrainz/frontend/review/views.py:336
+#: critiquebrainz/frontend/review/views.py:59
+#: critiquebrainz/frontend/review/views.py:61
+#: critiquebrainz/frontend/review/views.py:92
+#: critiquebrainz/frontend/review/views.py:119
+#: critiquebrainz/frontend/review/views.py:138
+#: critiquebrainz/frontend/review/views.py:215
+#: critiquebrainz/frontend/review/views.py:260
+#: critiquebrainz/frontend/review/views.py:283
+#: critiquebrainz/frontend/review/views.py:298
+#: critiquebrainz/frontend/review/views.py:340
 msgid "Review has been hidden."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:67
+#: critiquebrainz/frontend/review/views.py:72
 msgid "You are viewing an old revision, the review has been updated since then."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:69
+#: critiquebrainz/frontend/review/views.py:74
 msgid "The revision you are looking for does not exist."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:93
+#: critiquebrainz/frontend/review/views.py:98
 msgid "The revision(s) you are looking for does not exist."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:152
-msgid "Please choose release group that you want to review."
+#: critiquebrainz/frontend/review/views.py:161
+msgid "Please choose an entity to review."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:156
+#: critiquebrainz/frontend/review/views.py:165
 msgid ""
 "You are not allowed to write new reviews because your account has been "
 "blocked by a moderator."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:163
-msgid "You have already published a review for this album!"
+#: critiquebrainz/frontend/review/views.py:172
+msgid "You have already published a review for this entity!"
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:170
+#: critiquebrainz/frontend/review/views.py:179
 msgid "You have exceeded your limit of reviews per day."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:178
+#: critiquebrainz/frontend/review/views.py:187
 msgid "Review has been saved!"
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:180
+#: critiquebrainz/frontend/review/views.py:189
 msgid "Review has been published!"
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:185
-msgid ""
-"You can only write a review for a release group that exists on "
-"MusicBrainz!"
+#: critiquebrainz/frontend/review/views.py:194
+msgid "You can only write a review for an entity that exists on MusicBrainz!"
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:204
+#: critiquebrainz/frontend/review/views.py:213
 msgid "Only author can edit this review."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:220
+#: critiquebrainz/frontend/review/views.py:229
 msgid "Review has been updated."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:232
+#: critiquebrainz/frontend/review/views.py:241
 msgid "Only the author or an admin can delete this review."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:235
+#: critiquebrainz/frontend/review/views.py:244
 msgid "Review has been deleted."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:253
+#: critiquebrainz/frontend/review/views.py:262
 msgid "You cannot rate your own review."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:256
+#: critiquebrainz/frontend/review/views.py:265
 msgid "You have exceeded your limit of votes per day."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:259
+#: critiquebrainz/frontend/review/views.py:268
 msgid ""
 "You are not allowed to rate this review because your account has been "
 "blocked by a moderator."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:263
-#: critiquebrainz/frontend/review/views.py:266
-msgid "You are not allowed to rate this review."
-msgstr ""
-
-#: critiquebrainz/frontend/review/views.py:270
+#: critiquebrainz/frontend/review/views.py:274
 msgid "You have rated this review!"
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:282
+#: critiquebrainz/frontend/review/views.py:286
 msgid "This review is not rated yet."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:285
+#: critiquebrainz/frontend/review/views.py:289
 msgid "You have deleted your vote for this review!"
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:296
+#: critiquebrainz/frontend/review/views.py:300
 msgid "You cannot report your own review."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:300
+#: critiquebrainz/frontend/review/views.py:304
 msgid ""
 "You are not allowed to report this review because your account has been "
 "blocked by a moderator."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:307
+#: critiquebrainz/frontend/review/views.py:311
 msgid "You have already reported this review."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:313
+#: critiquebrainz/frontend/review/views.py:317
 msgid "Review has been reported."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:326
+#: critiquebrainz/frontend/review/views.py:330
 msgid "Review is already hidden."
 msgstr ""
 
-#: critiquebrainz/frontend/review/views.py:348
+#: critiquebrainz/frontend/review/views.py:352
 msgid "Review has been unhidden."
 msgstr ""
 
@@ -425,7 +423,7 @@ msgid "About CritiqueBrainz"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/about.html:6
-#: critiquebrainz/frontend/templates/base.html:59
+#: critiquebrainz/frontend/templates/base.html:61
 #: critiquebrainz/frontend/templates/navbar.html:38
 msgid "About"
 msgstr ""
@@ -438,8 +436,8 @@ msgstr ""
 msgid ""
 "<strong>CritiqueBrainz is a repository for Creative Commons licensed "
 "music reviews.</strong>\n"
-"  Here you can read what others have written about an album or write your"
-" own review!\n"
+"  Here you can read what others have written about an album or event and "
+"write your own review!\n"
 "  It is based on data from MusicBrainz - open music encyclopedia."
 msgstr ""
 
@@ -516,13 +514,13 @@ msgstr[1] ""
 
 #: critiquebrainz/frontend/templates/artist.html:85
 #: critiquebrainz/frontend/templates/mapping/spotify.html:45
-#: critiquebrainz/frontend/templates/review/browse.html:42
+#: critiquebrainz/frontend/templates/review/browse.html:36
 msgid "Previous"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/artist.html:88
 #: critiquebrainz/frontend/templates/mapping/spotify.html:48
-#: critiquebrainz/frontend/templates/review/browse.html:45
+#: critiquebrainz/frontend/templates/review/browse.html:39
 msgid "Next"
 msgstr ""
 
@@ -556,25 +554,118 @@ msgid "External links"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/artist.html:160
+#: critiquebrainz/frontend/templates/event.html:128
 msgid "Edit on MusicBrainz"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/base.html:60
+#: critiquebrainz/frontend/templates/base.html:62
 msgid "Blog"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/base.html:61
+#: critiquebrainz/frontend/templates/base.html:63
 msgid "Developers"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/base.html:62
+#: critiquebrainz/frontend/templates/base.html:64
 #: critiquebrainz/frontend/templates/log/log.html:3
 #: critiquebrainz/frontend/templates/log/log.html:6
 msgid "Moderation log"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/base.html:64
+#: critiquebrainz/frontend/templates/base.html:66
 msgid "Reports"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/entity_review.html:3
+#: critiquebrainz/frontend/templates/mapping/confirm.html:13
+#: critiquebrainz/frontend/templates/mapping/report.html:13
+#, python-format
+msgid "%(album)s by %(artist)s"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/entity_review.html:4
+#: critiquebrainz/frontend/templates/log/action.html:5
+#: critiquebrainz/frontend/templates/reports/reports_results.html:9
+#: critiquebrainz/frontend/templates/review/delete.html:5
+#: critiquebrainz/frontend/templates/review/edit.html:5
+#: critiquebrainz/frontend/templates/review/report.html:4
+#: critiquebrainz/frontend/templates/review/modify/release_group.html:9
+#: critiquebrainz/frontend/templates/user/reviews.html:45
+msgid "[Unknown release group]"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/entity_review.html:5
+#: critiquebrainz/frontend/templates/reports/reports_results.html:11
+#: critiquebrainz/frontend/templates/review/modify/release_group.html:6
+#: critiquebrainz/frontend/templates/user/reviews.html:55
+msgid "[Unknown artist]"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/entity_review.html:7
+#: critiquebrainz/frontend/templates/review/entity/event.html:23
+#, python-format
+msgid "%(event)s"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/entity_review.html:7
+#: critiquebrainz/frontend/templates/review/delete.html:7
+#: critiquebrainz/frontend/templates/review/edit.html:7
+#: critiquebrainz/frontend/templates/review/entity/event.html:11
+#: critiquebrainz/frontend/templates/review/entity/event.html:20
+#: critiquebrainz/frontend/templates/review/modify/event.html:8
+#: critiquebrainz/frontend/templates/user/reviews.html:50
+msgid "[Unknown event]"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/event.html:19
+#: critiquebrainz/frontend/templates/navbar.html:37
+msgid "Write a review"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/event.html:24
+msgid "Edit my review"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/event.html:51
+#: critiquebrainz/frontend/templates/review/entity/event.html:54
+msgid "Held At"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/event.html:62
+#: critiquebrainz/frontend/templates/macros.html:27
+#: critiquebrainz/frontend/templates/review/browse.html:3
+#: critiquebrainz/frontend/templates/review/browse.html:6
+#: critiquebrainz/frontend/templates/user/base.html:24
+#: critiquebrainz/frontend/templates/user/info.html:36
+#: critiquebrainz/frontend/templates/user/reviews.html:3
+msgid "Reviews"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/event.html:64
+#: critiquebrainz/frontend/templates/index.html:31
+#: critiquebrainz/frontend/templates/index.html:59
+#: critiquebrainz/frontend/templates/user/reviews.html:7
+msgid "No reviews found"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/event.html:70
+msgid "Published on"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/event.html:71
+#: critiquebrainz/frontend/templates/review/edit.html:21
+#: critiquebrainz/frontend/templates/review/revisions.html:26
+#: critiquebrainz/frontend/templates/user/reviews.html:19
+msgid "Votes (+/-)"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/event.html:79
+#, python-format
+msgid "by %(reviewer)s"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/event.html:106
+msgid "Event information"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/index.html:8
@@ -586,7 +677,7 @@ msgid ""
 "CritiqueBrainz is a repository for Creative Commons licensed music "
 "reviews.\n"
 "        Here you can read what other people have written about an album "
-"or write your own review!"
+"or event and write your own review!"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/index.html:14
@@ -615,55 +706,19 @@ msgstr ""
 msgid "Popular reviews"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/index.html:31
-#: critiquebrainz/frontend/templates/index.html:65
-#: critiquebrainz/frontend/templates/user/reviews.html:7
-msgid "No reviews found"
-msgstr ""
-
 #: critiquebrainz/frontend/templates/index.html:47
-#: critiquebrainz/frontend/templates/index.html:81
-#: critiquebrainz/frontend/templates/mapping/confirm.html:13
-#: critiquebrainz/frontend/templates/mapping/report.html:13
-#: critiquebrainz/frontend/templates/review/browse.html:23
-#, python-format
-msgid "%(album)s by %(artist)s"
-msgstr ""
-
-#: critiquebrainz/frontend/templates/index.html:48
-#: critiquebrainz/frontend/templates/index.html:82
-#: critiquebrainz/frontend/templates/log/action.html:5
-#: critiquebrainz/frontend/templates/reports/reports_results.html:8
+#: critiquebrainz/frontend/templates/index.html:75
 #: critiquebrainz/frontend/templates/review/browse.html:24
-#: critiquebrainz/frontend/templates/review/delete.html:4
-#: critiquebrainz/frontend/templates/review/edit.html:6
-#: critiquebrainz/frontend/templates/review/modify.html:19
-#: critiquebrainz/frontend/templates/review/report.html:4
-#: critiquebrainz/frontend/templates/user/reviews.html:35
-msgid "[Unknown release group]"
-msgstr ""
-
-#: critiquebrainz/frontend/templates/index.html:49
-#: critiquebrainz/frontend/templates/index.html:83
-#: critiquebrainz/frontend/templates/reports/reports_results.html:10
-#: critiquebrainz/frontend/templates/review/browse.html:25
-#: critiquebrainz/frontend/templates/review/modify.html:16
-#: critiquebrainz/frontend/templates/user/reviews.html:33
-msgid "[Unknown artist]"
-msgstr ""
-
-#: critiquebrainz/frontend/templates/index.html:53
-#: critiquebrainz/frontend/templates/index.html:87
-#: critiquebrainz/frontend/templates/review/browse.html:30
+#: critiquebrainz/frontend/templates/review/entity/base.html:11
 #, python-format
 msgid "Review by %(user)s"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/index.html:63
+#: critiquebrainz/frontend/templates/index.html:57
 msgid "Recent reviews"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/index.html:93
+#: critiquebrainz/frontend/templates/index.html:81
 msgid "View all reviews..."
 msgstr ""
 
@@ -693,15 +748,6 @@ msgstr ""
 
 #: critiquebrainz/frontend/templates/macros.html:27
 msgid "Create and modify your reviews."
-msgstr ""
-
-#: critiquebrainz/frontend/templates/macros.html:27
-#: critiquebrainz/frontend/templates/review/browse.html:3
-#: critiquebrainz/frontend/templates/review/browse.html:6
-#: critiquebrainz/frontend/templates/user/base.html:24
-#: critiquebrainz/frontend/templates/user/info.html:36
-#: critiquebrainz/frontend/templates/user/reviews.html:3
-msgid "Reviews"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/macros.html:29
@@ -755,36 +801,41 @@ msgstr ""
 msgid "Browse reviews"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/navbar.html:37
-msgid "Write a review"
-msgstr ""
-
 #: critiquebrainz/frontend/templates/navbar.html:42
 #: critiquebrainz/frontend/templates/search/index.html:7
 #: critiquebrainz/frontend/templates/search/index.html:13
-#: critiquebrainz/frontend/templates/search/index.html:33
-#: critiquebrainz/frontend/templates/search/selector.html:25
+#: critiquebrainz/frontend/templates/search/index.html:34
+#: critiquebrainz/frontend/templates/search/selector.html:37
+#: critiquebrainz/frontend/templates/search/selector.html:57
 msgid "Search"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/navbar.html:46
-#: critiquebrainz/frontend/templates/review/modify.html:16
+#: critiquebrainz/frontend/templates/review/modify/release_group.html:6
 #: critiquebrainz/frontend/templates/search/index.html:26
-#: critiquebrainz/frontend/templates/search/index.html:56
-#: critiquebrainz/frontend/templates/search/selector.html:10
-#: critiquebrainz/frontend/templates/search/selector.html:40
-#: critiquebrainz/frontend/templates/user/reviews.html:13
+#: critiquebrainz/frontend/templates/search/index.html:57
+#: critiquebrainz/frontend/templates/search/index.html:63
+#: critiquebrainz/frontend/templates/search/selector.html:22
+#: critiquebrainz/frontend/templates/search/selector.html:82
+#: critiquebrainz/frontend/templates/search/selector.html:90
+#: critiquebrainz/frontend/templates/user/reviews.html:17
 msgid "Artist"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/navbar.html:47
-#: critiquebrainz/frontend/templates/review/modify.html:17
+#: critiquebrainz/frontend/templates/review/modify/release_group.html:7
 #: critiquebrainz/frontend/templates/search/index.html:27
-#: critiquebrainz/frontend/templates/search/index.html:55
-#: critiquebrainz/frontend/templates/search/selector.html:17
-#: critiquebrainz/frontend/templates/search/selector.html:41
-#: critiquebrainz/frontend/templates/user/reviews.html:14
+#: critiquebrainz/frontend/templates/search/index.html:62
+#: critiquebrainz/frontend/templates/search/selector.html:29
+#: critiquebrainz/frontend/templates/search/selector.html:83
 msgid "Release group"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/navbar.html:48
+#: critiquebrainz/frontend/templates/review/modify/event.html:6
+#: critiquebrainz/frontend/templates/search/index.html:28
+#: critiquebrainz/frontend/templates/search/selector.html:49
+msgid "Event"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/errors/400.html:2
@@ -832,7 +883,7 @@ msgstr ""
 #: critiquebrainz/frontend/templates/log/action.html:36
 #: critiquebrainz/frontend/templates/mapping/confirm.html:31
 #: critiquebrainz/frontend/templates/mapping/report.html:31
-#: critiquebrainz/frontend/templates/review/delete.html:18
+#: critiquebrainz/frontend/templates/review/delete.html:24
 #: critiquebrainz/frontend/templates/review/report.html:27
 msgid "Cancel"
 msgstr ""
@@ -974,7 +1025,9 @@ msgstr ""
 #: critiquebrainz/frontend/templates/oauth/prompt.html:15
 #: critiquebrainz/frontend/templates/profile/applications/index.html:20
 #: critiquebrainz/frontend/templates/profile/applications/index.html:54
-#: critiquebrainz/frontend/templates/search/index.html:48
+#: critiquebrainz/frontend/templates/search/index.html:49
+#: critiquebrainz/frontend/templates/search/index.html:56
+#: critiquebrainz/frontend/templates/search/selector.html:89
 msgid "Name"
 msgstr ""
 
@@ -1027,6 +1080,7 @@ msgid "Yes, I want to delete my account"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/profile/delete.html:15
+#: critiquebrainz/frontend/templates/review/entity/base.html:55
 msgid "No"
 msgstr ""
 
@@ -1088,7 +1142,7 @@ msgid "Modify"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/profile/applications/index.html:36
-#: critiquebrainz/frontend/templates/user/reviews.html:46
+#: critiquebrainz/frontend/templates/user/reviews.html:74
 msgid "Delete"
 msgstr ""
 
@@ -1143,7 +1197,7 @@ msgid "Author"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/reports/reports.html:30
-msgid "Quick actions"
+msgid "Actions"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/reports/reports.html:38
@@ -1158,7 +1212,7 @@ msgstr ""
 msgid "Failed to load older reports!"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/reports/reports_results.html:32
+#: critiquebrainz/frontend/templates/reports/reports_results.html:34
 msgid "Read latest revision"
 msgstr ""
 
@@ -1180,117 +1234,74 @@ msgstr ""
 msgid "as of"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/delete.html:6
+#: critiquebrainz/frontend/templates/review/delete.html:11
+#: critiquebrainz/frontend/templates/review/edit.html:11
 #, python-format
-msgid "Delete review of %(release_group)s"
+msgid "Edit review of \"%(entity)s\""
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/delete.html:9
+#: critiquebrainz/frontend/templates/review/delete.html:15
 msgid "Deleting review"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/delete.html:13
+#: critiquebrainz/frontend/templates/review/delete.html:19
 #, python-format
-msgid "Are you sure you want to delete your review of %(release_group)s?"
+msgid "Are you sure you want to delete your review of \"%(entity)s\"?"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/delete.html:14
+#: critiquebrainz/frontend/templates/review/delete.html:20
 msgid "There is no way to undo this action!"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/delete.html:17
+#: critiquebrainz/frontend/templates/review/delete.html:23
 msgid "Delete review"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/edit.html:7
-#, python-format
-msgid "Edit review of \"%(rg)s\""
-msgstr ""
-
-#: critiquebrainz/frontend/templates/review/edit.html:11
+#: critiquebrainz/frontend/templates/review/edit.html:15
 msgid "Editing review"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/edit.html:15
-#: critiquebrainz/frontend/templates/user/reviews.html:15
+#: critiquebrainz/frontend/templates/review/edit.html:19
+#: critiquebrainz/frontend/templates/review/revisions.html:25
+#: critiquebrainz/frontend/templates/user/reviews.html:18
 msgid "Created on"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/edit.html:17
-#: critiquebrainz/frontend/templates/user/reviews.html:16
-msgid "Votes (+/-)"
-msgstr ""
-
-#: critiquebrainz/frontend/templates/review/edit.html:19
+#: critiquebrainz/frontend/templates/review/edit.html:23
 msgid "Status"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/edit.html:22
-#: critiquebrainz/frontend/templates/user/reviews.html:27
+#: critiquebrainz/frontend/templates/review/edit.html:26
+#: critiquebrainz/frontend/templates/user/reviews.html:29
 msgid "Draft"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/edit.html:24
-#: critiquebrainz/frontend/templates/user/reviews.html:29
+#: critiquebrainz/frontend/templates/review/edit.html:28
+#: critiquebrainz/frontend/templates/user/reviews.html:31
 msgid "Published"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/edit.html:31
-#: critiquebrainz/frontend/templates/review/write.html:29
+#: critiquebrainz/frontend/templates/review/edit.html:35
+#: critiquebrainz/frontend/templates/review/write.html:37
 msgid "Publish"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/edit.html:32
-#: critiquebrainz/frontend/templates/review/write.html:30
+#: critiquebrainz/frontend/templates/review/edit.html:36
+#: critiquebrainz/frontend/templates/review/write.html:38
 msgid "Save draft"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/edit.html:34
+#: critiquebrainz/frontend/templates/review/edit.html:38
 msgid "Update"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/edit.html:36
+#: critiquebrainz/frontend/templates/review/edit.html:40
 msgid "Discard changes"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/edit.html:37
+#: critiquebrainz/frontend/templates/review/edit.html:41
+#: critiquebrainz/frontend/templates/review/entity/base.html:77
 msgid "Delete this review"
-msgstr ""
-
-#: critiquebrainz/frontend/templates/review/modify.html:41
-msgid "Write"
-msgstr ""
-
-#: critiquebrainz/frontend/templates/review/modify.html:42
-msgid "Preview"
-msgstr ""
-
-#: critiquebrainz/frontend/templates/review/modify.html:44
-#, python-format
-msgid ""
-"You can use <a href=\"%(url)s\" target=\"_blank\">Markdown</a> syntax to "
-"apply custom formatting."
-msgstr ""
-
-#: critiquebrainz/frontend/templates/review/modify.html:57
-#: critiquebrainz/frontend/templates/review/modify.html:130
-msgid "Loading preview..."
-msgstr ""
-
-#: critiquebrainz/frontend/templates/review/modify.html:62
-msgid "Please, specify language of this review:"
-msgstr ""
-
-#: critiquebrainz/frontend/templates/review/modify.html:74
-msgid "You cannot change the license after the review is published."
-msgstr ""
-
-#: critiquebrainz/frontend/templates/review/modify.html:119
-msgid "Review is empty."
-msgstr ""
-
-#: critiquebrainz/frontend/templates/review/modify.html:126
-msgid "Failed to load preview."
 msgstr ""
 
 #: critiquebrainz/frontend/templates/review/report.html:6
@@ -1307,16 +1318,46 @@ msgstr ""
 msgid "Report review"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/write.html:3
+#: critiquebrainz/frontend/templates/review/revisions.html:12
 #, python-format
-msgid "Write review of \"%(rg)s\""
+msgid "Revisions of Review of \"%(entity)s\" by %(user)s"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/write.html:6
+#: critiquebrainz/frontend/templates/review/revisions.html:16
+#, python-format
+msgid "Revisions of Review by %(user)s"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/revisions.html:28
+msgid "Compare"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/revisions.html:35
+msgid "Load older revisions"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/revisions.html:36
+msgid "Loading older revisions..."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/revisions.html:53
+msgid "Select two different revisions."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/revisions.html:77
+msgid "Failed to load older revisions!"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/write.html:10
+#, python-format
+msgid "Write review of \"%(entity)s\""
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/write.html:14
 msgid "Write review"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/review/write.html:15
+#: critiquebrainz/frontend/templates/review/write.html:23
 msgid ""
 "You acknowledge and agree that your contributed reviews to CritiqueBrainz"
 " are licensed under a\n"
@@ -1334,6 +1375,116 @@ msgid ""
 "licenses in order to support the operations of the organization."
 msgstr ""
 
+#: critiquebrainz/frontend/templates/review/entity/base.html:14
+msgid "<b>This review has not been published yet!</b> Only you can see it."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:16
+#, python-format
+msgid "Published on %(date)s"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:22
+msgid "This review has not yet been rated"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:38
+#, python-format
+msgid "This review is licensed under a %(name)s license."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:40
+#, python-format
+msgid "It was imported from %(source)s."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:53
+msgid "Did you find this review useful?"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:54
+msgid "Yes"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:58
+msgid "You found this review useful."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:60
+msgid "You didn't find this review useful."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:62
+msgid "Delete your vote"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:67
+msgid "Report abuse"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:73
+msgid "Edit this review"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:82
+#: critiquebrainz/frontend/templates/review/entity/base.html:89
+msgid "View older revisions"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/base.html:86
+#, python-format
+msgid "<a href=\"%(link)s\">Sign in</a> to rate this review"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/entity/event.html:12
+#, python-format
+msgid "Review of \"%(event)s\" by %(user)s"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/modify/base.html:19
+msgid "Write"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/modify/base.html:20
+msgid "Preview"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/modify/base.html:22
+#, python-format
+msgid ""
+"You can use <a href=\"%(url)s\" target=\"_blank\">Markdown</a> syntax to "
+"apply custom formatting."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/modify/base.html:35
+#: critiquebrainz/frontend/templates/review/modify/base.html:109
+msgid "Loading preview..."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/modify/base.html:40
+msgid "Please, specify language of this review:"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/modify/base.html:52
+msgid "You cannot change the license after the review is published."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/modify/base.html:59
+msgid "Note: Drafts are not private!"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/modify/base.html:98
+msgid "Review is empty."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/modify/base.html:105
+msgid "Failed to load preview."
+msgstr ""
+
+#: critiquebrainz/frontend/templates/review/modify/event.html:13
+msgid "Place"
+msgstr ""
+
 #: critiquebrainz/frontend/templates/search/index.html:5
 msgid "Search results"
 msgstr ""
@@ -1343,46 +1494,65 @@ msgid "Query"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/search/index.html:23
-#: critiquebrainz/frontend/templates/search/index.html:50
-#: critiquebrainz/frontend/templates/search/index.html:57
-#: critiquebrainz/frontend/templates/search/selector.html:42
+#: critiquebrainz/frontend/templates/search/index.html:51
+#: critiquebrainz/frontend/templates/search/index.html:64
+#: critiquebrainz/frontend/templates/search/selector.html:84
+#: critiquebrainz/frontend/templates/user/reviews.html:15
 msgid "Type"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/search/index.html:41
-#: critiquebrainz/frontend/templates/search/selector.html:34
+#: critiquebrainz/frontend/templates/search/index.html:42
+#: critiquebrainz/frontend/templates/search/selector.html:75
 msgid "No results found"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/search/index.html:49
+#: critiquebrainz/frontend/templates/search/index.html:50
 msgid "Sort name"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/search/index.html:51
+#: critiquebrainz/frontend/templates/search/index.html:52
 msgid "Country"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/search/index.html:66
-#: critiquebrainz/frontend/templates/search/selector.html:52
+#: critiquebrainz/frontend/templates/search/index.html:58
+#: critiquebrainz/frontend/templates/search/selector.html:91
+msgid "Location"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/search/index.html:73
+#: critiquebrainz/frontend/templates/search/selector.html:102
 msgid "Load more results"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/search/index.html:67
-#: critiquebrainz/frontend/templates/search/selector.html:53
+#: critiquebrainz/frontend/templates/search/index.html:74
+#: critiquebrainz/frontend/templates/search/selector.html:103
 msgid "Loading more results..."
 msgstr ""
 
-#: critiquebrainz/frontend/templates/search/index.html:95
-#: critiquebrainz/frontend/templates/search/selector.html:85
+#: critiquebrainz/frontend/templates/search/index.html:102
+#: critiquebrainz/frontend/templates/search/selector.html:141
 msgid "Failed to load more search results!"
 msgstr ""
 
+#: critiquebrainz/frontend/templates/search/results.html:35
+#: critiquebrainz/frontend/templates/search/selector_results.html:29
+#: critiquebrainz/frontend/templates/user/reviews.html:61
+msgid "more"
+msgstr ""
+
 #: critiquebrainz/frontend/templates/search/selector.html:3
-#: critiquebrainz/frontend/templates/search/selector.html:6
+msgid "Entity selection"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/search/selector.html:19
 msgid "Release group selection"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/search/selector.html:57
+#: critiquebrainz/frontend/templates/search/selector.html:46
+msgid "Event selection"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/search/selector.html:107
 msgid "Continue"
 msgstr ""
 
@@ -1438,19 +1608,27 @@ msgstr ""
 msgid "Votes"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/user/reviews.html:43
+#: critiquebrainz/frontend/templates/user/reviews.html:16
+msgid "Entity"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/user/reviews.html:37
+msgid "Hidden"
+msgstr ""
+
+#: critiquebrainz/frontend/templates/user/reviews.html:71
 msgid "Read"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/user/reviews.html:45
+#: critiquebrainz/frontend/templates/user/reviews.html:73
 msgid "Edit"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/user/reviews.html:57
+#: critiquebrainz/frontend/templates/user/reviews.html:85
 msgid "Newer"
 msgstr ""
 
-#: critiquebrainz/frontend/templates/user/reviews.html:60
+#: critiquebrainz/frontend/templates/user/reviews.html:88
 msgid "Older"
 msgstr ""
 

--- a/critiquebrainz/frontend/templates/review/modify/base.html
+++ b/critiquebrainz/frontend/templates/review/modify/base.html
@@ -56,6 +56,7 @@
     {% block license_agreement_input %} {% endblock %}
   </form>
   {% block buttons %} {% endblock %}
+  <br /><small class="text-warning"><em>{{ _('Note: Drafts are not private!') }}</em></small>
 {% endblock %}
 
 {% block scripts %}

--- a/critiquebrainz/frontend/templates/review/modify/event.html
+++ b/critiquebrainz/frontend/templates/review/modify/event.html
@@ -11,7 +11,11 @@
       {% endif %}
     </dd>
     <dt>{{ _('Place') }}</dt>
-    <dd>{{ entity['place-relation-list'][0]['place']['name'] or '-' }}</dd>
+    {% if entity['place-relation-list'] is not defined %}
+      <dd>{{ _('Unknown place') }}</dd>
+    {% else %}
+      <dd>{{ entity['place-relation-list'][0]['place']['name']}}</dd>
+    {% endif %}
     {% block more_info %}
     {# Information like creation date, votes etc. #}
     {% endblock %}

--- a/critiquebrainz/frontend/templates/review/modify/event.html
+++ b/critiquebrainz/frontend/templates/review/modify/event.html
@@ -12,7 +12,7 @@
     </dd>
     <dt>{{ _('Place') }}</dt>
     {% if entity['place-relation-list'] is not defined %}
-      <dd>{{ _('Unknown place') }}</dd>
+      <dd class="text-muted">{{ _('Unknown place') }}</dd>
     {% else %}
       <dd>{{ entity['place-relation-list'][0]['place']['name']}}</dd>
     {% endif %}


### PR DESCRIPTION
Added the note and used "fab extract_strings" to create the portable object template file(messages.pot)
Also fixed bug reported at http://tickets.musicbrainz.org/browse/CB-194