### PR TITLE
CB-195 Redirect /release/ to proper /release-group/

### DIFF
--- a/critiquebrainz/frontend/__init__.py
+++ b/critiquebrainz/frontend/__init__.py
@@ -77,6 +77,7 @@ def create_app(debug=None):
     from critiquebrainz.frontend.search.views import search_bp
     from critiquebrainz.frontend.artist.views import artist_bp
     from critiquebrainz.frontend.release_group.views import release_group_bp
+    from critiquebrainz.frontend.release.views import release_bp
     from critiquebrainz.frontend.event.views import event_bp
     from critiquebrainz.frontend.mapping.views import mapping_bp
     from critiquebrainz.frontend.user.views import user_bp
@@ -92,6 +93,7 @@ def create_app(debug=None):
     app.register_blueprint(search_bp, url_prefix='/search')
     app.register_blueprint(artist_bp, url_prefix='/artist')
     app.register_blueprint(release_group_bp, url_prefix='/release-group')
+    app.register_blueprint(release_bp, url_prefix='/release')
     app.register_blueprint(event_bp, url_prefix='/event')
     app.register_blueprint(mapping_bp, url_prefix='/mapping')
     app.register_blueprint(user_bp, url_prefix='/user')

--- a/critiquebrainz/frontend/apis/musicbrainz.py
+++ b/critiquebrainz/frontend/apis/musicbrainz.py
@@ -131,7 +131,7 @@ def get_release_by_id(id):
     release = cache.get(key)
     if not release:
         try:
-            release = musicbrainzngs.get_release_by_id(id, ['recordings', 'media']).get('release')
+            release = musicbrainzngs.get_release_by_id(id, ['recordings', 'media', 'release-groups']).get('release')
         except ResponseError as e:
             if e.cause.code == 404:
                 return None

--- a/critiquebrainz/frontend/release/views.py
+++ b/critiquebrainz/frontend/release/views.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, redirect
+from critiquebrainz.frontend.apis import musicbrainz
+from werkzeug.exceptions import NotFound
+
+release_bp = Blueprint('release', __name__)
+
+
+@release_bp.route('/<uuid:id>')
+def entity(id):
+    id = str(id)
+    if musicbrainz.get_release_by_id(id):
+        release_data = musicbrainz.get_release_by_id(id)
+        group_id = release_data['release-group']['id']
+        url = '/release-group/' + str(group_id)
+        return redirect(url, 301)
+    else:
+        raise NotFound(gettext("Sorry, we couldn't find a release with that MusicBrainz ID."))

--- a/critiquebrainz/frontend/release/views.py
+++ b/critiquebrainz/frontend/release/views.py
@@ -8,8 +8,8 @@ release_bp = Blueprint('release', __name__)
 @release_bp.route('/<uuid:id>')
 def entity(id):
     id = str(id)
-    if musicbrainz.get_release_by_id(id):
-        release_data = musicbrainz.get_release_by_id(id)
+    release_data = musicbrainz.get_release_by_id(id)
+    if release_data:
         group_id = release_data['release-group']['id']
         url = '/release-group/' + str(group_id)
         return redirect(url, 301)

--- a/critiquebrainz/frontend/release/views_test.py
+++ b/critiquebrainz/frontend/release/views_test.py
@@ -5,5 +5,4 @@ class ReleaseViewsTestCase(FrontendTestCase):
 
     def test_release_page(self):
         response = self.client.get("/release/4a3541a7-db1d-4da2-a36b-172c5f8b2cc4")
-        self.assertEqual(response.status_code, 301)
         self.assertRedirects(response, "/release-group/4d1e6020-324d-4e8c-af1d-c7a2525a15ee")

--- a/critiquebrainz/frontend/release/views_test.py
+++ b/critiquebrainz/frontend/release/views_test.py
@@ -1,0 +1,8 @@
+from critiquebrainz.frontend.testing import FrontendTestCase
+
+
+class ReleaseViewsTestCase(FrontendTestCase):
+
+    def test_release_page(self):
+        response = self.client.get("/release/4a3541a7-db1d-4da2-a36b-172c5f8b2cc4")
+        self.assertEqual(response.status_code, 301)

--- a/critiquebrainz/frontend/release/views_test.py
+++ b/critiquebrainz/frontend/release/views_test.py
@@ -6,3 +6,4 @@ class ReleaseViewsTestCase(FrontendTestCase):
     def test_release_page(self):
         response = self.client.get("/release/4a3541a7-db1d-4da2-a36b-172c5f8b2cc4")
         self.assertEqual(response.status_code, 301)
+        self.assertRedirects(response, "/release-group/4d1e6020-324d-4e8c-af1d-c7a2525a15ee")


### PR DESCRIPTION
[CB-195: Redirect cb.o/release/$R_MBID to parent cb.o/release-group/$RG_MBID](http://tickets.musicbrainz.org/browse/CB-195)