### PR TITLE
Exclude drafts from public dumps

### DIFF
--- a/critiquebrainz/data/export_manager.py
+++ b/critiquebrainz/data/export_manager.py
@@ -171,7 +171,8 @@ def public(location=os.path.join(os.getcwd(), 'export', 'public'), rotate=False)
         reviews_combined_tables_dir = os.path.join(temp_dir, 'cbdump-reviews-all')
         create_path(reviews_combined_tables_dir)
         with open(os.path.join(reviews_combined_tables_dir, 'review'), 'w') as f:
-            cursor.copy_to(f, 'review', columns=get_columns(model.Review))
+            cursor.copy_to(f, "(SELECT %s FROM review WHERE is_draft = false)" %
+                           (', '.join(get_columns(model.Review))))
         with open(os.path.join(reviews_combined_tables_dir, 'revision'), 'w') as f:
             cursor.copy_to(f, '(%s)' % revision_query_object)
         tar.add(reviews_combined_tables_dir, arcname='cbdump')
@@ -193,7 +194,7 @@ def public(location=os.path.join(os.getcwd(), 'export', 'public'), rotate=False)
             tables_dir = os.path.join(temp_dir, safe_name)
             create_path(tables_dir)
             with open(os.path.join(tables_dir, 'review'), 'w') as f:
-                cursor.copy_to(f, "(SELECT (%s) FROM review WHERE license_id = '%s')" %
+                cursor.copy_to(f, "(SELECT %s FROM review WHERE is_draft = false AND license_id = '%s')" %
                                (', '.join(get_columns(model.Review)), license.id))
             with open(os.path.join(tables_dir, 'revision'), 'w') as f:
                 cursor.copy_to(f, '(%s)' % (revision_query_object.filter("review.license_id = '%s'" % (license.id))))

--- a/critiquebrainz/frontend/templates/review/modify/base.html
+++ b/critiquebrainz/frontend/templates/review/modify/base.html
@@ -56,7 +56,6 @@
     {% block license_agreement_input %} {% endblock %}
   </form>
   {% block buttons %} {% endblock %}
-  <br /><small class="text-warning"><em>{{ _('Note: Drafts are not private!') }}</em></small>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
Drafts reviews and revisions are included in the public data dumps. This should not be the case if users did not know that their drafts were not private.  #14 resolved [jira:CB-160](http://tickets.musicbrainz.org/browse/CB-160) by adding a note to warn users that drafts weren't private.

This PR resolves [jira:CB-208](http://tickets.musicbrainz.org/browse/CB-208), which attemps to solve the problem better by excluding draft reviews and revisions from the public data dumps: 

The commit messages contain detailed information about the implementation.