### PR TITLE
CB-192: Added <a> to release_group.html in External Links column

### DIFF
--- a/critiquebrainz/frontend/templates/release_group.html
+++ b/critiquebrainz/frontend/templates/release_group.html
@@ -182,6 +182,7 @@
     <div class="external-links">
       <div class="favicon-container"><img src="{{ url_for('static', filename='favicons/musicbrainz-16.svg') }}" /></div>
       <a href="//musicbrainz.org/release-group/{{ release_group.id }}"><em>{{ _('Edit on MusicBrainz') }}</em></a>
+      <div class="text-muted">Cover art provided by <a href="https://coverartarchive.org/">Cover Art Archive</a></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
I added the link to the CAA in the external links of /release-group/. As the ticket stated, there was supposedly the same addition required for /artist/, but it seemed to already have been added.

http://tickets.musicbrainz.org/browse/CB-192