### PR TITLE
Make language selector more visible

### DIFF
--- a/critiquebrainz/frontend/templates/footer.html
+++ b/critiquebrainz/frontend/templates/footer.html
@@ -33,6 +33,19 @@
         <li><a href="{{ url_for('log.browse') }}">{{ _('Moderation log') }}</a></li>
       </ul>
     </div>
+    {# Last block should fill up the rest of this row. #}
+    <div class="col-sm-6">
+      <div id="language-selector" class="btn-group dropup pull-right hidden-lg">
+        <button type="button" class="btn btn-xs dropdown-toggle" data-toggle="dropdown">
+          <span class="glyphicon glyphicon-globe"></span> {{ _('Language') }} <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu">
+          {% for language in config.LANGUAGES|dictsort(false, 'value') %}
+            <li><a href="?l={{ language[0] }}">{{ language[1]|capitalize }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
   </div>
   <div class="meb-credit">
     {{ _('Project of the %(metabrainz_fdn)s',

--- a/critiquebrainz/frontend/templates/footer.html
+++ b/critiquebrainz/frontend/templates/footer.html
@@ -35,7 +35,7 @@
     </div>
     {# Last block should fill up the rest of this row. #}
     <div class="col-sm-6">
-      <div id="language-selector" class="btn-group dropup pull-right hidden-lg">
+      <div id="language-selector" class="btn-group dropup pull-right">
         <button type="button" class="btn btn-xs dropdown-toggle" data-toggle="dropdown">
           <span class="glyphicon glyphicon-globe"></span> {{ _('Language') }} <span class="caret"></span>
         </button>

--- a/critiquebrainz/frontend/templates/footer.html
+++ b/critiquebrainz/frontend/templates/footer.html
@@ -33,19 +33,6 @@
         <li><a href="{{ url_for('log.browse') }}">{{ _('Moderation log') }}</a></li>
       </ul>
     </div>
-    {# Last block should fill up the rest of this row. #}
-    <div class="col-sm-6">
-      <div id="language-selector" class="btn-group dropup pull-right">
-        <button type="button" class="btn btn-xs dropdown-toggle" data-toggle="dropdown">
-          <span class="glyphicon glyphicon-globe"></span> {{ _('Language') }} <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu" role="menu">
-          {% for language in config.LANGUAGES|dictsort(false, 'value') %}
-            <li><a href="?l={{ language[0] }}">{{ language[1]|capitalize }}</a></li>
-          {% endfor %}
-        </ul>
-      </div>
-    </div>
   </div>
   <div class="meb-credit">
     {{ _('Project of the %(metabrainz_fdn)s',

--- a/critiquebrainz/frontend/templates/navbar.html
+++ b/critiquebrainz/frontend/templates/navbar.html
@@ -35,7 +35,7 @@
         {% endif %}
         <li><a href="{{ url_for('review.browse') }}">{{ _('Browse reviews') }}</a></li>
         <li><a href="{{ url_for('review.create') }}">{{ _('Write a review') }}</a></li>
-        <li id="language-selector" class="dropdown hidden-md">
+        <li class="language-selector dropdown hidden-md">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#">
             <span class="glyphicon glyphicon-globe"></span> {{ _('Language') }} <span class="caret"></span>
           </a>

--- a/critiquebrainz/frontend/templates/navbar.html
+++ b/critiquebrainz/frontend/templates/navbar.html
@@ -35,7 +35,16 @@
         {% endif %}
         <li><a href="{{ url_for('review.browse') }}">{{ _('Browse reviews') }}</a></li>
         <li><a href="{{ url_for('review.create') }}">{{ _('Write a review') }}</a></li>
-        <li class="hidden-md"><a href="{{ url_for('frontend.about') }}">{{ _('About') }}</a></li>
+        <li id="language-selector" class="dropdown hidden-md">
+          <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+            <span class="glyphicon glyphicon-globe"></span> {{ _('Language') }} <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu" role="menu">
+            {% for language in config.LANGUAGES|dictsort(false, 'value') %}
+              <li><a href="?l={{ language[0] }}">{{ language[1]|capitalize }}</a></li>
+            {% endfor %}
+          </ul>
+        </li>
       </ul>
       <form class="navbar-form navbar-right" role="search" method="GET" action="{{ url_for('search.index') }}">
         <div class="form-group">


### PR DESCRIPTION
This PR resolved [CB-111](http://tickets.musicbrainz.org/browse/CB-111). 505c3d3b58c69 moves the language selector to replace the “About” navbar link, and 152c94d9865c2 adds a second language selector back to the footer but makes it only visible when the navbar language selector is hidden or collapsed.