### PR TITLE
CB-213: Fix display of entity type labels

### DIFF
--- a/critiquebrainz/frontend/static/css/main.less
+++ b/critiquebrainz/frontend/static/css/main.less
@@ -91,6 +91,7 @@ ul.sharing {
   span.entity-type {
     position: absolute;
     top: 0;
+    left: 0;
     padding-left: 4px;
     padding-right: 4px;
 


### PR DESCRIPTION
Tested on Firefox 43.0 on Ubuntu 14.04.