### PR TITLE
CB-134 More information about Spotify albums on mapping page is shown now.

### DIFF
--- a/critiquebrainz/frontend/templates/mapping/spotify.html
+++ b/critiquebrainz/frontend/templates/mapping/spotify.html
@@ -29,9 +29,15 @@
           </a>
         </div>
         <div class="caption">
-          <div class="title">{{ item.name }}</div>
-          <span class="text-muted">{{ item.album_type }}</span><br />
-          <em><a href="{{ item.external_urls.spotify }}">{{ _('Listen on Spotify') }}</a></em><br />
+            <div class="title">
+                {{ item.name }}
+                <br>
+                <span style="font-weight:normal">by </span>
+                {{ artists(item) }}
+                {{ release_date_string(item) }}
+            </div>
+            <span class="text-muted">{{ item.album_type }}</span><br />
+            <em><a href="{{ item.external_urls.spotify }}">{{ _('Listen on Spotify') }}</a></em><br />
         </div>
       </div>
     </div>
@@ -45,7 +51,7 @@
             <li class="previous"><a href="{{ url_for('mapping.spotify', release_group_id=release_group.id, page=page-1) }}">&larr; {{ _('Previous') }}</a></li>
           {% endif %}
           {% if page-1 < count//limit %}
-            <li class="next"><a href="{{ url_for('mapping.spotify', release_group_id=release_group.id, page=page+1) }}">{{ _('Next') }} &rarr;</a></li>
+            <li class="next"><a href="{{ url_for('mapping.spotify', release_group_id=release_group.id, page=page + 1) }}">{{ _('Next') }} &rarr;</a></li>
           {% endif %}
         </ul>
       </div>
@@ -86,3 +92,29 @@
     {{ super() }}
     <script>$('.match-link').tooltip()</script>
 {% endblock %}
+
+{% macro artists(album) -%}
+    {% if album.artists|length == 0 or album.artists[0].name != 'Various Artists' %}
+        {%- for artist in album.artists[:3] %}
+            {{  artist.name }}
+            {% if not loop.last %}
+                {{ ', ' }}
+            {% endif %}
+        {%- endfor %}
+    {% else %}
+        {% set first_track = album.tracks['items'][0] %}
+        {% if first_track.artists|length > 0 and first_track.artists[0].name != 'Various Artists' %}
+            {{ first_track.artists[0].name + ' and others'}}
+        {% else %}
+            {{ 'Various Artists' }}
+        {% endif %}
+
+    {% endif %}
+{%- endmacro %}
+
+{% macro release_date_string(album) -%}
+    {% if album.release_date %}
+        ({{ album.release_date.split('-')[0] }})
+    {% endif %}
+
+{%- endmacro %}

--- a/critiquebrainz/frontend/templates/mapping/spotify.html
+++ b/critiquebrainz/frontend/templates/mapping/spotify.html
@@ -29,16 +29,16 @@
           </a>
         </div>
         <div class="caption">
-            <div class="title">
-                {{ item.name }}
-                <br>
-                <span style="font-weight:normal">by </span>
-                {{ artists(item) }}
-                <br>
-            </div>
-            <b> {{ release_date_string(item) }} </b>
-            <span class="text-muted">{{ item.album_type }}</span><br />
-            <em><a href="{{ item.external_urls.spotify }}">{{ _('Listen on Spotify') }}</a></em><br />
+          <div class="title">
+            {{ item.name }}
+            <br />
+            <span style="font-weight:normal">by </span>
+            {{ artists(item) }}
+            <br />
+          </div>
+          <b>{{ release_date_string(item) }}</b>
+          <span class="text-muted">{{ item.album_type }}</span><br />
+          <em><a href="{{ item.external_urls.spotify }}">{{ _('Listen on Spotify') }}</a></em><br />
         </div>
       </div>
     </div>
@@ -95,34 +95,34 @@
 {% endblock %}
 
 {% macro artists(album) -%}
-    {% if album.artists|length == 0 or album.artists[0].name != 'Various Artists' %}
-        {%- for artist in album.artists %}
-            {{  artist.name }}
-            {% if not loop.last %}
-                {{ ', ' }}
-            {% endif %}
-        {%- endfor %}
-    {% else %}
-        {% set added_artists=[] %}
-        {% for track in album.tracks['items'] %}
-            {% for artist in track.artists %}
-                {% if artist.name not in added_artists and artist.name != 'Various Artists'%}
-                    {% do added_artists.append(artist.name)%}
-                {% endif %}
-            {% endfor %}
-        {% endfor %}
-        {% for artist_name in added_artists %}
-            {{ artist_name }}
-            {% if not loop.last %}
-                {{ ', ' }}
-            {% endif %}
-        {% endfor %}
-    {% endif %}
+  {% if album.artists|length == 0 or album.artists[0].name != 'Various Artists' %}
+    {%- for artist in album.artists %}
+      {{  artist.name }}
+      {% if not loop.last %}
+        {{ ', ' }}
+      {% endif %}
+    {%- endfor %}
+  {% else %}
+    {% set added_artists=[] %}
+    {% for track in album.tracks['items'] %}
+      {% for artist in track.artists %}
+        {% if artist.name not in added_artists and artist.name != 'Various Artists'%}
+          {% do added_artists.append(artist.name)%}
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+    {% for artist_name in added_artists %}
+      {{ artist_name }}
+      {% if not loop.last %}
+        {{ ', ' }}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
 {%- endmacro %}
 
 {% macro release_date_string(album) -%}
-    {% if album.release_date %}
-        {{ album.release_date.split('-')[0] }}
-    {% endif %}
+  {% if album.release_date %}
+    {{ album.release_date.split('-')[0] }}
+  {% endif %}
 
 {%- endmacro %}

--- a/critiquebrainz/frontend/templates/mapping/spotify.html
+++ b/critiquebrainz/frontend/templates/mapping/spotify.html
@@ -34,8 +34,9 @@
                 <br>
                 <span style="font-weight:normal">by </span>
                 {{ artists(item) }}
-                {{ release_date_string(item) }}
+                <br>
             </div>
+            <b> {{ release_date_string(item) }} </b>
             <span class="text-muted">{{ item.album_type }}</span><br />
             <em><a href="{{ item.external_urls.spotify }}">{{ _('Listen on Spotify') }}</a></em><br />
         </div>
@@ -95,26 +96,33 @@
 
 {% macro artists(album) -%}
     {% if album.artists|length == 0 or album.artists[0].name != 'Various Artists' %}
-        {%- for artist in album.artists[:3] %}
+        {%- for artist in album.artists %}
             {{  artist.name }}
             {% if not loop.last %}
                 {{ ', ' }}
             {% endif %}
         {%- endfor %}
     {% else %}
-        {% set first_track = album.tracks['items'][0] %}
-        {% if first_track.artists|length > 0 and first_track.artists[0].name != 'Various Artists' %}
-            {{ first_track.artists[0].name + ' and others'}}
-        {% else %}
-            {{ 'Various Artists' }}
-        {% endif %}
-
+        {% set added_artists=[] %}
+        {% for track in album.tracks['items'] %}
+            {% for artist in track.artists %}
+                {% if artist.name not in added_artists and artist.name != 'Various Artists'%}
+                    {% do added_artists.append(artist.name)%}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+        {% for artist_name in added_artists %}
+            {{ artist_name }}
+            {% if not loop.last %}
+                {{ ', ' }}
+            {% endif %}
+        {% endfor %}
     {% endif %}
 {%- endmacro %}
 
 {% macro release_date_string(album) -%}
     {% if album.release_date %}
-        ({{ album.release_date.split('-')[0] }})
+        {{ album.release_date.split('-')[0] }}
     {% endif %}
 
 {%- endmacro %}

--- a/critiquebrainz/frontend/views/mapping.py
+++ b/critiquebrainz/frontend/views/mapping.py
@@ -62,8 +62,13 @@ def spotify():
     query = unicode(release_group['title']).translate(punctuation_map)
     # Searching...
     response = spotify_api.search(query, 'album', limit, offset).get('albums')
-    return render_template('mapping/spotify.html', release_group=release_group, search_results=response.get('items'),
-                           page=page, limit=limit, count=response.get('total'))
+
+    albums_ids = [x['id'] for x in response['items']]
+    full_response = spotify_api.get_multiple_albums(albums_ids)
+
+    return render_template('mapping/spotify.html', release_group=release_group,
+                           search_results=full_response.itervalues(), page=page,
+                           limit=limit, count=response.get('total'))
 
 
 @mapping_bp.route('/spotify/confirm', methods=['GET', 'POST'])


### PR DESCRIPTION
CritiqueBrainz provides an embedded Spotify player on pages that are mapped to it in mbspotify. Mappings are created by users on CritiqueBrainz using a search interface that we have. Search gets data from Spotify using their Web API, but the only parts we use are cover art and name of the album. Now users can also see the artists that made some particular album and the release year.

[Related ticket] (http://tickets.musicbrainz.org/browse/CB-134)

Prototypes: 

1. **Artists from tracks if unavailable, date in the same line as artists and in brackets.**
![data_w_nawiasie_przy_artystach_artysci_ze_sciezek_male](https://cloud.githubusercontent.com/assets/7630347/12398001/27b77130-be11-11e5-81f3-aa42b4973932.png)


2. **Artists from default artists, date in the same line as artists and in brackets.**
![data_w_nawiasie_przy_artystach_male](https://cloud.githubusercontent.com/assets/7630347/12397989/0f429c6a-be11-11e5-8b0a-062ac30fde07.png)


3. **Artists from tracks if unavailable, date in the same line as type and in brackets.**
![data_w_nawiasie_przy_typie_artysci_ze_sciezek](https://cloud.githubusercontent.com/assets/7630347/12397974/fd3d02bc-be10-11e5-802c-d85ce3eaa4c1.png)



4. **Artists from default artists, date in the same line as type and in brackets.**
![data_w_nawiasie_przy_typie](https://cloud.githubusercontent.com/assets/7630347/12397965/f455c7d8-be10-11e5-958e-afe5561750be.png)



5. **Artists from default artists, date in the next line.**
![data_na_dole_various](https://cloud.githubusercontent.com/assets/7630347/12397880/4b8460f6-be10-11e5-8175-db12639589da.png)


6. **Artists from tracks if unavailable, date in the next line.**
![data_na_dole_sciezki](https://cloud.githubusercontent.com/assets/7630347/12397864/30f0470a-be10-11e5-8486-f16d06cdb3a5.png)


7. **All artists from tracks if unavailable, date in the next line**
![all_artists_from_tracks](https://cloud.githubusercontent.com/assets/7630347/12397796/b7635b8e-be0f-11e5-8a94-1752ca6158cf.png)

8. **Freso's idea**
![freso](https://cloud.githubusercontent.com/assets/7630347/12400301/79e2d248-be1f-11e5-84d4-dbdddff39e4f.png)

