### PR TITLE
CB-235: Tags on release-group page

### DIFF
--- a/critiquebrainz/frontend/external/musicbrainz.py
+++ b/critiquebrainz/frontend/external/musicbrainz.py
@@ -126,7 +126,7 @@ def get_release_group_by_id(id):
     if not release_group:
         try:
             release_group = musicbrainzngs.get_release_group_by_id(
-                id, ['artists', 'releases', 'release-group-rels', 'url-rels', 'work-rels']
+                id, ['artists', 'releases', 'release-group-rels', 'url-rels', 'work-rels', 'tags']
             ).get('release-group')
         except ResponseError as e:
             if e.cause.code == 404:

--- a/critiquebrainz/frontend/static/styles/main.less
+++ b/critiquebrainz/frontend/static/styles/main.less
@@ -21,6 +21,11 @@ body {
   > thead > tr > th { border-bottom-width: 1px; }
 }
 
+.tags {
+  margin-bottom: 10px;
+  font-size: @font-size-small;
+}
+
 .nav {
   > li {
     > a { color: @mb-purple; }

--- a/critiquebrainz/frontend/templates/macros.html
+++ b/critiquebrainz/frontend/templates/macros.html
@@ -93,6 +93,19 @@
   </div>
 {%- endmacro %}
 
+{% macro show_tags(tags) %}
+  {% if tags %}
+    {% for tag in tags %}
+      <span><a href="{{"https://musicbrainz.org/tag/%s"|format(tag['name'])}}">{{tag['name']}}</a></span>
+      {%- if not loop.last -%}
+        ,
+      {% endif %}
+    {% endfor %}
+  {% else %}
+    <p>{{ _('(none)') }}</p>
+  {% endif %}
+{% endmacro %}
+
 {% macro soundcloud_player(soundcloud_url) %}
   <div class=soundcloud-player">
     {% if soundcloud_url %}

--- a/critiquebrainz/frontend/templates/macros.html
+++ b/critiquebrainz/frontend/templates/macros.html
@@ -96,7 +96,7 @@
 {% macro show_tags(tags) %}
   {% if tags %}
     {% for tag in tags %}
-      <span><a href="{{"https://musicbrainz.org/tag/%s"|format(tag['name'])}}">{{tag['name']}}</a></span>
+      <a href="{{"https://musicbrainz.org/tag/%s"|format(tag['name'])}}">{{tag['name']}}</a>
       {%- if not loop.last -%}
         ,
       {% endif %}

--- a/critiquebrainz/frontend/templates/macros.html
+++ b/critiquebrainz/frontend/templates/macros.html
@@ -96,13 +96,13 @@
 {% macro show_tags(tags) %}
   {% if tags %}
     {% for tag in tags %}
-      <a href="{{"https://musicbrainz.org/tag/%s"|format(tag['name'])}}">{{tag['name']}}</a>
+      <a href="{{ 'https://musicbrainz.org/tag/%s'|format(tag['name']) }}">{{ tag['name'] }}</a>
       {%- if not loop.last -%}
         ,
       {% endif %}
     {% endfor %}
   {% else %}
-    <p>{{ _('(none)') }}</p>
+    <p class="text-muted">{{ _('(none)') }}</p>
   {% endif %}
 {% endmacro %}
 

--- a/critiquebrainz/frontend/templates/release_group/entity.html
+++ b/critiquebrainz/frontend/templates/release_group/entity.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from 'macros.html' import cover_art, show_embedded_player with context %}
+{% from 'macros.html' import cover_art, show_embedded_player, show_tags with context %}
 
 {% block title %}
   {{ _('Release group "%(title)s" by %(artist)s', title=release_group.title, artist=release_group['artist-credit-phrase']) }}
@@ -156,6 +156,11 @@
         {% endfor %}
       </ul>
     {% endif %}
+
+    <b>{{ _('Tags') }}</b>
+    <div class="tags">
+      {{ show_tags(tags) }}
+    </div>
 
     <div class="external-links">
       <div class="favicon-container"><img src="{{ get_static_path('favicons/musicbrainz-16.svg') }}" /></div>

--- a/critiquebrainz/frontend/views/release_group.py
+++ b/critiquebrainz/frontend/views/release_group.py
@@ -15,6 +15,9 @@ def entity(id):
     release_group = musicbrainz.get_release_group_by_id(id)
     if not release_group:
         raise NotFound(gettext("Sorry, we couldn't find a release group with that MusicBrainz ID."))
+    tags = None
+    if release_group.get('tag-list'):
+        tags = release_group['tag-list']
     if len(release_group['release-list']) > 0:
         release = musicbrainz.get_release_by_id(release_group['release-list'][0]['id'])
     else:
@@ -36,5 +39,5 @@ def entity(id):
         my_review = None
     reviews, count = Review.list(entity_id=id, entity_type='release_group', sort='rating', limit=limit, offset=offset)
     return render_template('release_group/entity.html', id=id, release_group=release_group, reviews=reviews,
-                           release=release, my_review=my_review, spotify_mappings=spotify_mappings,
+                           release=release, my_review=my_review, spotify_mappings=spotify_mappings, tags=tags,
                            soundcloud_url=soundcloud_url, limit=limit, offset=offset, count=count)

--- a/critiquebrainz/frontend/views/release_group.py
+++ b/critiquebrainz/frontend/views/release_group.py
@@ -15,9 +15,10 @@ def entity(id):
     release_group = musicbrainz.get_release_group_by_id(id)
     if not release_group:
         raise NotFound(gettext("Sorry, we couldn't find a release group with that MusicBrainz ID."))
-    tags = None
-    if release_group.get('tag-list'):
+    if 'tag-list' in release_group:
         tags = release_group['tag-list']
+    else:
+        tags = None
     if len(release_group['release-list']) > 0:
         release = musicbrainz.get_release_by_id(release_group['release-list'][0]['id'])
     else:


### PR DESCRIPTION
For ticket CB-235
Presently, tags are not shown on the release group page. Tags can be shown on the release group page under the release group information.

All tags are shown similar to (with their links pointing to musicbrainz.org/tag/tagname):
![1](https://cloud.githubusercontent.com/assets/12391372/21962078/145a0b3a-db42-11e6-8af2-512cd84c26cd.png)
and:
![2](https://cloud.githubusercontent.com/assets/12391372/21962081/315c4144-db42-11e6-8890-7749c289dcf3.png)

Please suggest improvements :)
