### PR TITLE
Changed documentation link from .org to .io

### DIFF
--- a/critiquebrainz/frontend/templates/footer.html
+++ b/critiquebrainz/frontend/templates/footer.html
@@ -19,7 +19,7 @@
       </ul>
     </div>
     <div class="col-sm-2">
-      <div class="title"><a href="https://critiquebrainz.readthedocs.org">{{ _('Developers') }}</a></div>
+      <div class="title"><a href="https://critiquebrainz.readthedocs.io">{{ _('Developers') }}</a></div>
       <ul>
         <li><a href="https://critiquebrainz.readthedocs.io/api.html">{{ _('Web API') }}</a></li>
         <li><a href="https://github.com/metabrainz/critiquebrainz">{{ _('Source code') }}</a></li>


### PR DESCRIPTION
Changed documentation link TLD due to http://blog.readthedocs.com/securing-subdomains/