### PR TITLE
CB-230: Migrate user code off the ORM

### DIFF
--- a/critiquebrainz/data/model/mixins.py
+++ b/critiquebrainz/data/model/mixins.py
@@ -15,7 +15,7 @@ class DeleteMixin(object):
 class AdminMixin(UserMixin):
     """Allows a method to check if the current user is admin."""
     def is_admin(self):
-        return self.musicbrainz_id in current_app.config['ADMINS']
+        return self.musicbrainz_username in current_app.config['ADMINS']
 
 
 class AnonymousUser(AnonymousUserMixin):

--- a/critiquebrainz/data/model/moderation_log_test.py
+++ b/critiquebrainz/data/model/moderation_log_test.py
@@ -27,7 +27,7 @@ class ModerationLogCase(DataTestCase):
         db.session.add(self.license)
         db.session.flush()
 
-        self.review = Review.create(user=self.user, release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+        self.review = Review.create(user_id=self.user.id, release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                     text=u"It's... beautiful!", is_draft=False, license_id=self.license.id,
                                     language='en')
 

--- a/critiquebrainz/data/model/oauth_client.py
+++ b/critiquebrainz/data/model/oauth_client.py
@@ -38,7 +38,7 @@ class OAuthClient(db.Model, DeleteMixin):
         client_id = generate_string(20)
         client_secret = generate_string(40)
         client = cls(client_id=client_id, client_secret=client_secret,
-                     user=user, name=name, desc=desc, website=website,
+                     user_id=user.id, name=name, desc=desc, website=website,
                      redirect_uri=redirect_uri)
         db.session.add(client)
         db.session.commit()

--- a/critiquebrainz/data/model/review.py
+++ b/critiquebrainz/data/model/review.py
@@ -261,7 +261,7 @@ class Review(db.Model, DeleteMixin):
         review = Review(
             entity_id=entity_id,
             entity_type=entity_type,
-            user=kwargs.pop('user'),
+            user_id=kwargs.pop('user_id'),
             language=kwargs.pop('language', None),
             is_draft=kwargs.pop('is_draft', False),
             license_id=kwargs.pop('license_id', DEFAULT_LICENSE_ID),

--- a/critiquebrainz/data/model/review_test.py
+++ b/critiquebrainz/data/model/review_test.py
@@ -24,7 +24,7 @@ class ReviewTestCase(DataTestCase):
     def test_review_creation(self):
         self.assertEqual(Review.query.count(), 0)
 
-        review = Review.create(user=self.user,
+        review = Review.create(user_id=self.user.id,
                                release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                text=u"Testing!",
                                is_draft=False,
@@ -37,7 +37,7 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(reviews[0].license_id, review.license_id)
 
     def test_created_property(self):
-        review = Review.create(user=self.user,
+        review = Review.create(user_id=self.user.id,
                                release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                text=u"Testing!",
                                is_draft=False,
@@ -45,7 +45,7 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(review.created, review.revisions[0].timestamp)
 
     def test_review_deletion(self):
-        review = Review.create(user=self.user,
+        review = Review.create(user_id=self.user.id,
                                release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                text=u"Testing!",
                                is_draft=False,
@@ -56,13 +56,13 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(Review.query.count(), 0)
 
     def test_languages(self):
-        review_en = Review.create(user=self.user,
+        review_en = Review.create(user_id=self.user.id,
                                   release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                   text=u"Testing!",
                                   is_draft=False,
                                   license_id=self.license.id,
                                   language='en')
-        review_de = Review.create(user=self.user,
+        review_de = Review.create(user_id=self.user.id,
                                   release_group='e7aad618-fa86-3983-9e77-405e21796ece',
                                   text=u"Testing!",
                                   is_draft=False,
@@ -78,7 +78,7 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(count, 0)
 
     def test_update(self):
-        review = Review.create(user=self.user,
+        review = Review.create(user_id=self.user.id,
                                release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                text=u"Awesome!",
                                is_draft=True,
@@ -108,7 +108,7 @@ class ReviewTestCase(DataTestCase):
             review.update(text=u"Sucks!", is_draft=True)
 
     def test_revisions(self):
-        review = Review.create(user=self.user,
+        review = Review.create(user_id=self.user.id,
                                release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                text=u"Awesome!",
                                is_draft=False,
@@ -127,7 +127,7 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(len(reviews), 0)
 
         review = Review.create(
-            user=self.user,
+            user_id=self.user.id,
             release_group='e7aad618-fa86-3983-9e77-405e21796eca',
             text=u"Awesome!",
             is_draft=False,
@@ -159,7 +159,7 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(len(reviews), 0)
 
         new_review = Review.create(
-            user=self.user,
+            user_id=self.user.id,
             release_group='e7aad618-fa86-3983-9e77-405e21796eca',
             text=u"Testing!",
             is_draft=False,

--- a/critiquebrainz/data/model/revision_test.py
+++ b/critiquebrainz/data/model/revision_test.py
@@ -19,7 +19,7 @@ class RevisionTestCase(DataTestCase):
         db.session.add(self.license)
         db.session.commit()
 
-        self.review = Review.create(user=self.user,
+        self.review = Review.create(user_id=self.user.id,
                                     release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                     text=u"Testing!",
                                     is_draft=False,

--- a/critiquebrainz/data/model/spam_report.py
+++ b/critiquebrainz/data/model/spam_report.py
@@ -29,8 +29,8 @@ class SpamReport(db.Model, DeleteMixin):
         return Review.get(id=self.revision.review_id)
 
     @classmethod
-    def create(cls, revision_id, user, reason):
-        report = cls(user=user, revision_id=revision_id, reason=reason)
+    def create(cls, revision_id, user_id, reason):
+        report = cls(user_id=user_id, revision_id=revision_id, reason=reason)
         db.session.add(report)
         db.session.commit()
         return report

--- a/critiquebrainz/data/model/spam_report_test.py
+++ b/critiquebrainz/data/model/spam_report_test.py
@@ -21,7 +21,7 @@ class SpamReportTestCase(DataTestCase):
         db.session.add(self.license)
         db.session.flush()
 
-        self.review = Review.create(user=self.author, release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+        self.review = Review.create(user_id=self.author.id, release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                     text=u"It's... beautiful!", is_draft=False, license_id=self.license.id,
                                     language='en')
 
@@ -29,7 +29,7 @@ class SpamReportTestCase(DataTestCase):
         # There should be no spam reports initially.
         self.assertEqual(SpamReport.query.count(), 0)
 
-        report = SpamReport.create(self.review.last_revision.id, self.reporter, "Testing Reason")
+        report = SpamReport.create(self.review.last_revision.id, self.reporter.id, "Testing Reason")
 
         all_reports = SpamReport.query.all()
         self.assertEqual(len(all_reports), 1)
@@ -37,11 +37,11 @@ class SpamReportTestCase(DataTestCase):
         self.assertEqual(all_reports[0].revision_id, report.revision_id)
 
         # Let's try to add spam report using the author. This shouldn't be allowed.
-        SpamReport.create(self.review.last_revision.id, self.author, "Testing Reason")
+        SpamReport.create(self.review.last_revision.id, self.author.id, "Testing Reason")
         self.assertEqual(len(all_reports), 1)  # hence count is the same as before
 
     def test_spam_report_deletion(self):
-        report = SpamReport.create(self.review.last_revision.id, self.reporter, "Testing Reason")
+        report = SpamReport.create(self.review.last_revision.id, self.reporter.id, "Testing Reason")
         self.assertEqual(SpamReport.query.count(), 1)
 
         report.delete()

--- a/critiquebrainz/data/model/user_test.py
+++ b/critiquebrainz/data/model/user_test.py
@@ -123,7 +123,7 @@ class UserTestCase(DataTestCase):
         db.session.commit()
 
         self.assertFalse(user_2.has_voted(review))
-        Vote.create(user_2, review, True)
+        Vote.create(user_2.id, review, True)
         self.assertTrue(user_2.has_voted(review))
 
     def test_reviews_property(self):

--- a/critiquebrainz/data/model/user_test.py
+++ b/critiquebrainz/data/model/user_test.py
@@ -110,7 +110,7 @@ class UserTestCase(DataTestCase):
         db.session.add(license)
         db.session.commit()
 
-        review = Review.create(user=user_1,
+        review = Review.create(user_id=user_1.id,
                                release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                text=u"Testing!",
                                is_draft=False,
@@ -136,7 +136,7 @@ class UserTestCase(DataTestCase):
         license = License(id=u"Test", full_name=u'Test License')
         db.session.add(license)
         db.session.flush()
-        review = Review.create(user=user,
+        review = Review.create(user_id=user.id,
                                release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                text=u"Testing!",
                                is_draft=False,

--- a/critiquebrainz/data/model/vote.py
+++ b/critiquebrainz/data/model/vote.py
@@ -16,12 +16,12 @@ class Vote(db.Model, DeleteMixin):
     rated_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
     @classmethod
-    def create(cls, user, review, vote):
+    def create(cls, user_id, review, vote):
         """Create new vote for the latest revision of a specified review."""
         # Deleting the vote from the last revision if it exists
-        user.display_name, cls.query.filter_by(user=user, revision=review.last_revision).delete()
+        cls.query.filter_by(user_id=user_id, revision=review.last_revision).delete()
         # Creating a new vote for the last revision
-        vote_obj = cls(user=user, revision=review.last_revision, vote=vote)
+        vote_obj = cls(user_id=user_id, revision=review.last_revision, vote=vote)
         db.session.add(vote_obj)
         db.session.commit()
         return vote_obj

--- a/critiquebrainz/data/model/vote_test.py
+++ b/critiquebrainz/data/model/vote_test.py
@@ -22,13 +22,13 @@ class VoteTestCase(DataTestCase):
                                is_draft=False,
                                license_id=license.id)
 
-        vote_u1_positive = Vote.create(user_1, review, True)
+        vote_u1_positive = Vote.create(user_1.id, review, True)
 
         votes = db.session.query(Vote).all()
         self.assertEqual(len(votes), 1)
         self.assertIn(vote_u1_positive, votes)
 
-        vote_u2_negative = Vote.create(user_2, review, False)
+        vote_u2_negative = Vote.create(user_2.id, review, False)
 
         votes = db.session.query(Vote).all()
         self.assertEqual(len(votes), 2)

--- a/critiquebrainz/data/model/vote_test.py
+++ b/critiquebrainz/data/model/vote_test.py
@@ -18,7 +18,7 @@ class VoteTestCase(DataTestCase):
         db.session.commit()
         review = Review.create(release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                text=u"Testing!",
-                               user=author,
+                               user_id=author.id,
                                is_draft=False,
                                license_id=license.id)
 

--- a/critiquebrainz/db/revision_test.py
+++ b/critiquebrainz/db/revision_test.py
@@ -19,7 +19,7 @@ class RevisionTestCase(DataTestCase):
         db.session.add(self.license)
         db.session.commit()
 
-        self.review = Review.create(user=author,
+        self.review = Review.create(user_id=author.id,
                                     release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                     text=u"Testing!",
                                     is_draft=False,

--- a/critiquebrainz/db/user.py
+++ b/critiquebrainz/db/user.py
@@ -20,9 +20,9 @@ class User(AdminMixin, DeleteMixin):
     def avatar(self):
         """Link to user's avatar image."""
         if self.show_gravatar and self.email:
-            return "https://gravatar.com/avatar/" + hashlib.md5(self.mail.encode("utf-8")).hexdigest() + "?d=identicon&r=pg"
+            return db_users.gravatar_url(self.email)
         else:
-            return "https://gravatar.com/avatar/" + hashlib.md5(self.id.encode("utf-8")).hexdigest() + "?d=identicon"
+            return db_users.gravatar_url(self.id)
 
     @property
     def is_vote_limit_exceeded(self):
@@ -50,25 +50,25 @@ class User(AdminMixin, DeleteMixin):
 
     @property
     def votes(self):
-        return db_users.get_votes_since(self.id)
+        return db_users.get_votes(self.id)
 
     def votes_since(self, date):
-        return db_users.get_votes_since(self.id, date=date)
+        return db_users.get_votes(self.id, from_date=date)
 
     def votes_since_count(self, date):
-        return len(db_users.get_votes_since(self.id, date=date))
+        return len(db_users.get_votes(self.id, from_date=date))
 
     def votes_today(self):
-        return db_users.get_votes_since(self.id, date.today())
+        return self.votes_since(date.today())
 
     def votes_today_count(self):
-        return len(db_users.get_votes_since(self.id, date.today()))
+        return self.votes_since_count(date.today())
 
     def reviews_since(self, date):
-        return db_users.get_reviews_since(self.id, date=date)
+        return db_users.get_reviews(self.id, from_date=date)
 
     def reviews_since_count(self, date):
-        return len(db_users.get_reviews_since(self.id, date=date))
+        return len(db_users.get_reviews(self.id, from_date=date))
 
     def reviews_today(self):
         return self.reviews_since(date.today())

--- a/critiquebrainz/db/user.py
+++ b/critiquebrainz/db/user.py
@@ -1,0 +1,132 @@
+from critiquebrainz.data.model.mixins import DeleteMixin, AdminMixin
+import critiquebrainz.db.users as db_users
+import hashlib
+from critiquebrainz.data.constants import user_types
+from datetime import date, datetime, timedelta
+
+
+class User(AdminMixin, DeleteMixin):
+
+    def __init__(self, user):
+        self.id = str(user.get('id'))
+        self.display_name = user.get('display_name')
+        self.email = user.get('email')
+        self.created = user.get('created')
+        self.musicbrainz_id = user.get('musicbrainz_id')
+        self.show_gravatar = user.get('show_gravatar', False)
+        self.is_blocked = user.get('is_blocked', False)
+        allowed_includes = ('user_type', 'stats')
+
+    @property
+    def avatar(self):
+        """Link to user's avatar image."""
+        if self.show_gravatar and self.email:
+            return "https://gravatar.com/avatar/" + hashlib.md5(self.mail.encode("utf-8")).hexdigest() + "?d=identicon&r=pg"
+        else:
+            return "https://gravatar.com/avatar/" + hashlib.md5(self.id.encode("utf-8")).hexdigest() + "?d=identicon"
+
+    @property
+    def is_vote_limit_exceeded(self):
+        if self.votes_today_count() >= self.user_type.votes_per_day:
+            return True
+        else:
+            return False
+
+    @property
+    def is_review_limit_exceeded(self):
+        if self.reviews_today_count() >= self.user_type.reviews_per_day:
+            return True
+        else:
+            return False
+
+    @property
+    def karma(self):
+        if hasattr(self, '_karma') is False:
+            self._karma = db_users.karma(self.id)
+        return self._karma
+
+    @property
+    def reviews(self):
+        return db_users.reviews(self.id)
+
+    @property
+    def votes(self):
+        return db_users.get_votes(self.id)
+
+    def votes_since(self, date):
+        return db_users.get_votes(self.id, date=date)
+
+    def votes_since_count(self, date):
+        return len(db_users.get_votes(self.id, date=date))
+
+    def votes_today(self):
+        return db_users.get_votes(self.id, date.today())
+
+    def votes_today_count(self):
+        return len(db_users.get_votes(self.id, date.today()))
+
+    def reviews_since(self, date):
+        return db_users.get_reviews(self.id)
+
+    def reviews_since_count(self, date):
+        return len(db_users.get_reviews(self.id))
+
+    def reviews_today(self):
+        return self.reviews_since(date.today())
+
+    def reviews_today_count(self):
+        return self.reviews_since_count(date.today())
+
+    @property
+    def user_type(self):
+        def get_user_type(user):
+            for user_type in user_types:
+                if user_type.is_instance(user):
+                    return user_type
+        if hasattr(self, '_user_type') is False:
+            self._user_type = get_user_type(self)
+        return self._user_type
+
+    @property
+    def stats(self):
+        today = date.today()
+        return dict(
+            reviews_today=self.reviews_today_count(),
+            reviews_last_7_days=self.reviews_since_count(today - timedelta(days=7)),
+            reviews_this_month=self.reviews_since_count(date(today.year, today.month, 1)),
+            votes_today=self.votes_today_count(),
+            votes_last_7_days=self.votes_since_count(today-timedelta(days=7)),
+            votes_this_month=self.votes_since_count(date(today.year, today.month, 1)))
+
+    def to_dict(self, includes=None, confidential=False):
+        if includes is None:
+            includes = []
+        response = dict(id=self.id,
+                        display_name=self.display_name,
+                        created=self.created,
+                        karma=self.karma,
+                        user_type=self.user_type.label)
+
+        if confidential is True:
+            response.update(dict(email=self.email,
+                                 avatar=self.avatar,
+                                 show_gravatar=self.show_gravatar,
+                                 musicbrainz_id=self.musicbrainz_id))
+
+        if 'user_type' in includes:
+            response['user_type'] = dict(
+                label=self.user_type.label,
+                reviews_per_day=self.user_type.reviews_per_day,
+                votes_per_day=self.user_type.votes_per_day)
+
+        if 'stats' in includes:
+            today = date.today()
+            response['stats'] = dict(
+                reviews_today=self.reviews_today_count(),
+                reviews_last_7_days=self.reviews_since_count(today - timedelta(days=7)),
+                reviews_this_month=self.reviews_since_count(date(today.year, today.month, 1)),
+                votes_today=self.votes_today_count(),
+                votes_last_7_days=self.votes_since_count(today - timedelta(days=7)),
+                votes_this_month=self.votes_since_count(date(today.year, today.month, 1)))
+
+        return response

--- a/critiquebrainz/db/users.py
+++ b/critiquebrainz/db/users.py
@@ -1,6 +1,9 @@
 from hashlib import md5
+import critiquebrainz.db.revision as db_revision
 import sqlalchemy
 from critiquebrainz import db
+from datetime import datetime
+import uuid
 
 
 def gravatar_url(source, default="identicon", rating="pg"):
@@ -70,3 +73,543 @@ def get_many_by_mb_username(usernames):
             else:
                 user["avatar_url"] = gravatar_url(default_gravatar_src)
         return users
+
+
+def get_by_id(user_id):
+    """Get user from user_id
+
+    Args:
+        user_id(uuid): ID of the user
+
+    Returns:
+        Dictionary with the following structure:
+        {
+            "id": (uuid)
+            "display_name": (str)
+            "email": (str)
+            "created": (datetime)
+            "musicbrainz_id": (str)
+            "show_gravatar": (bool)
+            "is_blocked": (bool)
+        }
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT id, display_name, email, created,
+                   musicbrainz_id, show_gravatar, is_blocked
+              FROM "user"
+             WHERE id = :user_id
+        """), {
+            "user_id": user_id
+        })
+        row = result.fetchone()
+    return dict(row) if row else None
+
+
+def create(display_name, **kwargs):
+    """Create user using the given details
+
+    Args:
+        display_name(str): display_name of the user,
+        musicbrainz_id(str, optional): musicbrainz_id of user,
+        email(str, optional): email of the user,
+        show_gravatar(bool, optional): whether to show gravatar(default: false)
+        is_blocked(bool, optional): whether user is blocked(default: false)
+
+    Returns:
+        Dictionary with the following structure:
+        {
+            "id": (uuid)
+            "display_name": (str)
+            "email": (str)
+            "created": (datetime)
+            "musicbrainz_id": (str)
+            "show_gravatar": (bool)
+            "is_blocked": (bool)
+        }
+    """
+    id = str(uuid.uuid4())
+    musicbrainz_id = kwargs.pop('musicbrainz_id', None)
+    email = kwargs.pop('email', None)
+    show_gravatar = kwargs.pop('show_gravatar', False)
+    is_blocked = kwargs.pop('is_blocked', False)
+    if(kwargs):
+        raise TypeError('Unexpected **kwargs: %r' % kwargs)
+
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            INSERT INTO "user"
+                 VALUES (:id, :display_name, :email, :created, :musicbrainz_id, :show_gravatar, :is_blocked)
+              RETURNING id
+            """), {
+                "id": id,
+                "display_name": display_name,
+                "email": email,
+                "created": datetime.now(),
+                "musicbrainz_id": musicbrainz_id,
+                "show_gravatar": show_gravatar,
+                "is_blocked": is_blocked
+            })
+        new_id = result.fetchone()[0]
+        user = get_by_id(new_id)
+    return user
+
+
+def get_by_mbid(musicbrainz_id):
+    """Get user by musicbrainz_id
+
+    Args:
+        musicbrainz_id(str): Musicbrainz ID of the User
+
+    Returns:
+        Dictionary with the following structure:
+        {
+            "id": (uuid)
+            "display_name": (str)
+            "email": (str)
+            "created": (datetime)
+            "musicbrainz_id": (str)
+            "show_gravatar": (bool)
+            "is_blocked": (bool)
+        }
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT id, display_name, email, created,
+                   musicbrainz_id, show_gravatar, is_blocked
+            FROM "user"
+            WHERE musicbrainz_id = :musicbrainz_id
+        """), {
+            "musicbrainz_id": musicbrainz_id
+        })
+        row = result.fetchone()
+    return dict(row) if row else None
+
+
+def get_or_create(display_name, musicbrainz_id, **kwargs):
+    """Get user from display_name and musicbrainz_id
+
+    Args:
+        display_name(str): display_name of the user
+        musicbrainz_id(str): Musicbrainz ID of the user
+        email(str, optional): email of the user,
+        show_gravatar(bool, optional): whether to show gravatar(default: false)
+        is_blocked(bool, optional): whether user is blocked(default: false)
+
+    Returns:
+        Dictionary with the following structure:
+        {
+            "id": (uuid)
+            "display_name": (str)
+            "email": (str)
+            "created": (datetime)
+            "musicbrainz_id": (str)
+            "show_gravatar": (bool)
+            "is_blocked": (bool)
+        }
+    """
+    user = get_by_mbid(musicbrainz_id)
+    if not user:
+        user = create(display_name, musicbrainz_id=musicbrainz_id, **kwargs)
+    return user
+
+
+def get_count():
+    """Returns the total number of users
+
+    Returns:
+        count: (int)
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT count(*)
+              FROM "user"
+        """))
+        count = result.fetchone()[0]
+    return count
+
+
+def list(limit=None, offset=0):
+    """Returns the list of users of critiquebrainz
+
+    Args:
+        limit(int, optional): Number of users to be returned
+        offset(int, optional): Number of initial users to skip
+
+    Returns:
+        List of dictionaries of users with the following structure:
+        {
+            "id": (uuid)
+            "display_name": (str)
+            "email": (str)
+            "created": (datetime)
+            "musicbrainz_id": (str)
+            "show_gravatar": (bool)
+            "is_blocked": (bool)
+        }
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT id, display_name, email, created,
+                   musicbrainz_id, show_gravatar, is_blocked
+              FROM "user"
+             LIMIT :limit
+            OFFSET :offset
+        """), {
+            "limit": limit,
+            "offset": offset
+        })
+        rows = result.fetchall()
+        rows = [dict(row) for row in rows]
+    return rows
+
+
+def unblock(user_id):
+    """Unblock user (admin only)
+
+    Args:
+        user_id(uuid): ID of user to be unblocked
+    """
+    with db.engine.connect() as connection:
+        connection.execute(sqlalchemy.text("""
+            UPDATE "user"
+               SET is_blocked = 'false'
+             WHERE id = :user_id
+        """), {
+            "user_id": user_id
+        })
+
+
+def block(user_id):
+    """Block user (admin only)
+
+    Args:
+        user_id(uuid): ID of user to be blocked
+    """
+    with db.engine.connect() as connection:
+        connection.execute(sqlalchemy.text("""
+            UPDATE "user"
+               SET is_blocked = 'true'
+            WHERE id = :user_id
+        """), {
+            "user_id": user_id
+        })
+
+
+def has_voted(user_id, review_id):
+    """Check if a user has already voted a review
+
+    Args:
+        user_id(uuid): ID of the user
+        review_id(uuid): ID of the review
+
+    Returns:
+        (bool): True if has voted else False
+    """
+    last_revision = db_revision.get(review_id, limit=1)[0]
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT count(*)
+              FROM vote
+             WHERE revision_id = :revision_id
+               AND user_id = :user_id
+            """), {
+                "revision_id": last_revision['id'],
+                "user_id": user_id
+            })
+        count = result.fetchone()[0]
+    return count > 0
+
+
+def karma(user_id):
+    """Get the karma of a user
+
+    Args:
+        user_id(uuid): ID of the user
+
+    Returns:
+        karma(int): the karma of the user
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT review.user_id, vote
+              FROM ((vote
+         LEFT JOIN revision
+                ON revision.id = revision_id)
+         LEFT JOIN review
+                ON review.id = review_id)
+         LEFT JOIN "user"
+                ON "user".id = review.user_id
+             WHERE "user".id = :user_id
+        """), {
+            "user_id": user_id
+        })
+
+        rows = result.fetchall()
+        _karma = 0
+        for row in rows:
+            if row.vote == True:
+                _karma += 1
+            else:
+                _karma -= 1
+    return _karma
+
+
+def reviews(user_id):
+    """Get list of reviews written by a user
+
+    Args:
+        user_id(uuid): ID of the user
+
+    Returns:
+        List of reviews written by the user with the structure:
+        {
+            "id": (uuid)
+            "entity_id": (uuid),
+            "entity_type": event or place or release_group,
+            "user_id": (uuid),
+            "edits": (int),
+            "is_draft": (bool),
+            "license_id": (str),
+            "language": (str),
+            "source": (str),
+            "source_url" (str)
+        }
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT id, entity_id, entity_type, user_id, edits,
+                   is_draft, license_id, language, source, source_url
+              FROM review
+             WHERE user_id = :user_id
+        """), {
+            "user_id": user_id
+        })
+
+        rows = result.fetchall()
+        rows = [dict(row) for row in rows]
+
+    return rows
+
+
+def get_votes(user_id, date='1-1-1970'):
+    """Get votes by a user from a specified time
+
+    Args:
+        user_id(uuid): ID of the user
+        date(datetime): Date from which votes submitted(default: UTC)
+
+    Returns:
+        List of votes submitted by the user from the time specified
+        {
+            "vote": (bool),
+            "rated_at": (datetime)
+        }
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT vote, rated_at
+              FROM vote
+             WHERE user_id = :user_id
+               AND rated_at >= :date
+        """), {
+            "user_id": user_id,
+            "date": date
+        })
+
+        rows = result.fetchall()
+        rows = [dict(row) for row in rows]
+
+    return rows
+
+
+def get_reviews(user_id, date='1-1-1970'):
+    """Get reviews by a user from a specified time
+
+    Args:
+        user_id(uuid): ID of the user,
+        date(datetime): Date from which reviews submitted(default: UTC)
+
+    Returns:
+        List of reviews by the user from the time specified
+        {
+            "id": (uuid)
+            "entity_id": (uuid),
+            "entity_type": event or place or release_group,
+            "user_id": (uuid),
+            "edits": (int),
+            "is_draft": (bool),
+            "license_id": (str),
+            "language": (str),
+            "source": (str),
+            "source_url" (str)
+        }
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+           SELECT *
+           FROM review
+      LEFT JOIN
+        (SELECT review_id
+              , min(timestamp)
+             AS creation_time
+           FROM revision
+       GROUP BY review_id)
+             AS review_create
+             ON review.id = review_id
+          WHERE user_id = :user_id
+            AND creation_time > :date
+        """), {
+            "user_id": user_id,
+            "date": date
+        })
+
+        rows = result.fetchall()
+        rows = [dict(row) for row in rows]
+
+    return rows
+
+
+def update(user, display_name=None, email=None, show_gravatar=None):
+    """Update info of a user
+
+    Args:
+        user: User object whose info is to be updated,
+        display_name(str): Display name of user,
+        email(str): Email of the user,
+        show_gravatar(bool): whether to show gravatar
+    """
+    if display_name is None:
+        display_name = user.display_name
+    if show_gravatar is None:
+        show_gravatar = user.show_gravatar
+    if email is None:
+        email = user.email
+
+    with db.engine.connect() as connection:
+        connection.execute(sqlalchemy.text("""
+            UPDATE "user"
+               SET display_name = :display_name,
+                  show_gravatar = :show_gravatar,
+                          email = :email
+             WHERE id = :user_id
+        """), {
+            "user_id": user.id,
+            "display_name": display_name,
+            "show_gravatar": show_gravatar,
+            "email": email
+        })
+
+
+def delete(user_id):
+    """Delete a user
+    Deletes user, votes, reviews, revisions and spam reports
+    by it
+
+    Args:
+        user_id(uuid): ID of the user to be deleted
+    """
+    with db.engine.connect() as connection:
+        connection.execute(sqlalchemy.text("""
+            DELETE
+              FROM "user"
+             WHERE id = :user_id
+        """), {
+            "user_id": user_id
+        })
+        connection.execute(sqlalchemy.text("""
+            DELETE
+              FROM "vote"
+             WHERE user_id = :user_id
+        """), {
+            "user_id": user_id
+        })
+        connection.execute(sqlalchemy.text("""
+            DELETE
+              FROM "spam_report"
+             WHERE user_id = :user_id
+        """), {
+            "user_id": user_id
+        })
+    user_reviews = reviews(user_id)
+    with db.engine.connect() as connection:
+        for review in user_reviews:
+            connection.execute(sqlalchemy.text("""
+                DELETE
+                  FROM review
+                 WHERE id = :review_id
+            """), {
+                "review_id": review['id']
+            })
+            connection.execute(sqlalchemy.text("""
+                DELETE
+                  FROM revision
+                 WHERE review_id = :review_id
+            """), {
+                "review_id": review['id']
+            })
+
+
+def clients(user_id):
+    """Get list of oauth clients registered by user
+
+    Args:
+        user_id(uuid): ID of the user,
+
+    Returns:
+        List of dictionaries of oauth clients of the user
+        {
+            "client_id": (unicode),
+            "client_secret": (unicode),
+            "redirect_uri": (unicode),
+            "user_id": (uuid),
+            "name": (unicode),
+            "desc": (unicode),
+            "website": (unicode)
+        }
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT client_id, client_secret, redirect_uri,
+                   user_id, name, oauth_client.desc, website
+              FROM oauth_client
+             WHERE user_id = :user_id
+        """), {
+            "user_id": user_id
+        })
+
+        rows = result.fetchall()
+        rows = [dict(row) for row in rows]
+    return rows
+
+
+def tokens(user_id):
+    """Get the oauth_tokens from a user_id
+
+    Args:
+        user_id(uuid): ID of the user
+
+    Returns:
+        List of dictionaries of client tokens of the user
+        {
+            "id": (int),
+            "client_id": (Unicode),
+            "access_token": (Unicode),
+            "refresh_token": (Unicode),
+            "expires": (datetime),
+            "scopes": (Unicode)
+        }
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT id, client_id, access_token,
+                   refresh_token, expires, scopes
+              FROM oauth_token
+             WHERE user_id = :user_id
+        """), {
+            "user_id": user_id
+        })
+
+        rows = result.fetchall()
+        rows = [dict(row) for row in rows]
+    return rows

--- a/critiquebrainz/db/users.py
+++ b/critiquebrainz/db/users.py
@@ -109,13 +109,14 @@ def get_by_id(user_id):
             "user_id": user_id
         })
         row = result.fetchone()
-        if row:
-            row = dict(row)
-            row['musicbrainz_username'] = row.pop('musicbrainz_id')
-    return row if row else None
+        if not row:
+            return None
+        row = dict(row)
+        row['musicbrainz_username'] = row.pop('musicbrainz_id')
+    return row
 
 
-def create(display_name, **kwargs):
+def create(**user_data):
     """Create user using the given details.
 
     Args:
@@ -137,12 +138,13 @@ def create(display_name, **kwargs):
             "is_blocked": (bool)
         }
     """
-    musicbrainz_username = kwargs.pop('musicbrainz_username', None)
-    email = kwargs.pop('email', None)
-    show_gravatar = kwargs.pop('show_gravatar', False)
-    is_blocked = kwargs.pop('is_blocked', False)
-    if kwargs:
-        raise TypeError('Unexpected **kwargs: %r' % kwargs)
+    display_name = user_data.pop('display_name')
+    musicbrainz_username = user_data.pop('musicbrainz_username', None)
+    email = user_data.pop('email', None)
+    show_gravatar = user_data.pop('show_gravatar', False)
+    is_blocked = user_data.pop('is_blocked', False)
+    if user_data:
+        raise TypeError('Unexpected **user_data: %r' % user_data)
 
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
@@ -159,8 +161,7 @@ def create(display_name, **kwargs):
                 "is_blocked": is_blocked,
             })
         new_id = result.fetchone()[0]
-        user = get_by_id(new_id)
-    return user
+    return get_by_id(new_id)
 
 
 def get_by_mbid(musicbrainz_username):
@@ -196,10 +197,11 @@ def get_by_mbid(musicbrainz_username):
             "musicbrainz_username": musicbrainz_username
         })
         row = result.fetchone()
-        if row:
-            row = dict(row)
-            row['musicbrainz_username'] = row.pop('musicbrainz_id')
-    return row if row else None
+        if not row:
+            return None
+        row = dict(row)
+        row['musicbrainz_username'] = row.pop('musicbrainz_id')
+    return row
 
 
 def get_or_create(musicbrainz_username, new_user_data):
@@ -231,7 +233,7 @@ def get_or_create(musicbrainz_username, new_user_data):
     user = get_by_mbid(musicbrainz_username)
     if not user:
         display_name = new_user_data.pop("display_name")
-        user = create(display_name, musicbrainz_username=musicbrainz_username, **new_user_data)
+        user = create(display_name=display_name, musicbrainz_username=musicbrainz_username, **new_user_data)
     return user
 
 
@@ -246,8 +248,8 @@ def total_count():
             SELECT count(*)
               FROM "user"
         """))
-        count = result.fetchone()[0]
-    return count
+
+        return result.fetchone()[0]
 
 
 def list_users(limit=None, offset=0):
@@ -325,7 +327,7 @@ def block(user_id):
 
 
 def has_voted(user_id, review_id):
-    """Check if a user has already voted a review.
+    """Check if a user has already voted on the last revision of a review.
 
     Args:
         user_id(uuid): ID of the user.
@@ -356,7 +358,7 @@ def karma(user_id):
         user_id(uuid): ID of the user.
 
     Returns:
-        karma(int): the karma of the user.
+        karma_value(int): the karma of the user.
     """
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
@@ -374,13 +376,13 @@ def karma(user_id):
         })
 
         rows = result.fetchall()
-        _karma = 0
+        karma_value = 0
         for row in rows:
             if row.vote == True:
-                _karma += 1
+                karma_value += 1
             else:
-                _karma -= 1
-    return _karma
+                karma_value -= 1
+    return karma_value
 
 
 def reviews(user_id):
@@ -423,17 +425,15 @@ def reviews(user_id):
         })
 
         rows = result.fetchall()
-        rows = [dict(row) for row in rows]
-
-    return rows
+    return [dict(row) for row in rows]
 
 
-def get_votes_since(user_id, date='1-1-1970'):
+def get_votes(user_id, from_date='1-1-1970'):
     """Get votes by a user from a specified time.
 
     Args:
         user_id(uuid): ID of the user.
-        date(datetime): Date from which votes submitted(default: UTC).
+        from_date(datetime): Date from which votes submitted by user are to be returned.
 
     Returns:
         List of votes submitted by the user from the time specified
@@ -448,24 +448,22 @@ def get_votes_since(user_id, date='1-1-1970'):
                    rated_at
               FROM vote
              WHERE user_id = :user_id
-               AND rated_at >= :date
+               AND rated_at >= :from_date
         """), {
             "user_id": user_id,
-            "date": date
+            "from_date": from_date
         })
 
         rows = result.fetchall()
-        rows = [dict(row) for row in rows]
-
-    return rows
+    return [dict(row) for row in rows]
 
 
-def get_reviews_since(user_id, date='1-1-1970'):
+def get_reviews(user_id, from_date='1-1-1970'):
     """Get reviews by a user from a specified time.
 
     Args:
         user_id(uuid): ID of the user.
-        date(datetime): Date from which reviews submitted(default: UTC).
+        from_date(datetime): Date from which reviews submitted by user are to be returned.
 
     Returns:
         List of reviews by the user from the time specified
@@ -503,47 +501,45 @@ def get_reviews_since(user_id, date='1-1-1970'):
                   GROUP BY review_id) AS review_create
                 ON review.id = review_id
              WHERE user_id = :user_id
-               AND creation_time > :date
+               AND creation_time > :from_date
         """), {
             "user_id": user_id,
-            "date": date
+            "from_date": from_date
         })
 
         rows = result.fetchall()
-        rows = [dict(row) for row in rows]
-
-    return rows
+    return [dict(row) for row in rows]
 
 
-def update(user, display_name=None, email=None, show_gravatar=None):
+def update(user_id, user_new_info):
     """Update info of a user.
 
     Args:
-        user: User object whose info is to be updated.
-        display_name(str): Display name of user.
-        email(str): Email of the user.
-        show_gravatar(bool): whether to show gravatar.
+        user_id: ID of user whose info is to be updated.
+        user_new_info: Dictionary containing the new information for the user
+        {
+            "display_name": (str),
+            "show_gravatar": (bool),
+            "email": (str)
+        }
     """
-    if display_name is None:
-        display_name = user.display_name
-    if show_gravatar is None:
-        show_gravatar = user.show_gravatar
-    if email is None:
-        email = user.email
+    updates = []
+    if "display_name" in user_new_info:
+        updates.append("display_name = :display_name")
+    if "show_gravatar" in user_new_info:
+        updates.append("show_gravatar = :show_gravatar")
+    if "email" in user_new_info:
+        updates.append("email = :email")
 
-    with db.engine.connect() as connection:
-        connection.execute(sqlalchemy.text("""
-            UPDATE "user"
-               SET display_name = :display_name,
-                  show_gravatar = :show_gravatar,
-                          email = :email
-             WHERE id = :user_id
-        """), {
-            "user_id": user.id,
-            "display_name": display_name,
-            "show_gravatar": show_gravatar,
-            "email": email
-        })
+    setstr = ", ".join(updates)
+    query = sqlalchemy.text("""UPDATE "user"
+                                  SET {}
+                                WHERE id = :user_id
+            """.format(setstr))
+    if user_new_info:
+        user_new_info["user_id"] = user_id
+        with db.engine.connect() as connection:
+            connection.execute(query, user_new_info)
 
 
 def delete(user_id):
@@ -597,8 +593,7 @@ def clients(user_id):
         })
 
         rows = result.fetchall()
-        rows = [dict(row) for row in rows]
-    return rows
+    return [dict(row) for row in rows]
 
 
 def tokens(user_id):
@@ -611,11 +606,11 @@ def tokens(user_id):
         List of dictionaries of client tokens of the user
         {
             "id": (int),
-            "client_id": (Unicode),
-            "access_token": (Unicode),
-            "refresh_token": (Unicode),
+            "client_id": (str),
+            "access_token": (str),
+            "refresh_token": (str),
             "expires": (datetime),
-            "scopes": (Unicode)
+            "scopes": (str)
         }
     """
     with db.engine.connect() as connection:
@@ -633,5 +628,4 @@ def tokens(user_id):
         })
 
         rows = result.fetchall()
-        rows = [dict(row) for row in rows]
-    return rows
+    return [dict(row) for row in rows]

--- a/critiquebrainz/db/users_test.py
+++ b/critiquebrainz/db/users_test.py
@@ -1,13 +1,34 @@
 from critiquebrainz.data.testing import DataTestCase
-from critiquebrainz.data.model.user import User
+from critiquebrainz.db.user import User
+from critiquebrainz.data import db
+import critiquebrainz.db.users as db_users
 from critiquebrainz.db.users import gravatar_url, get_many_by_mb_username
-
+from critiquebrainz.data.model.review import Review
+from critiquebrainz.data.model.spam_report import SpamReport
+from critiquebrainz.data.model.license import License
+import critiquebrainz.db.vote as db_vote
+from datetime import datetime, date, timedelta
+from uuid import UUID
 
 class UserTestCase(DataTestCase):
     def setUp(self):
         super(UserTestCase, self).setUp()
-        self.user1 = User.get_or_create("test", musicbrainz_id='tester_1')
-        self.user2 = User.get_or_create("test1", musicbrainz_id="тестер")
+        self.user1 = User(db_users.get_or_create("test", musicbrainz_id='tester_1'))
+        self.user2 = User(db_users.get_or_create("test1", musicbrainz_id="тестер"))
+        self.author = User(db_users.get_or_create("Author1", musicbrainz_id="author1"))
+        license = License(id='Test', full_name='Test License')
+        db.session.add(license)
+        db.session.commit()
+        self.review = Review.create(release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+                               text="Testing!",
+                               user_id=self.author.id,
+                               is_draft=False,
+                               license_id=license.id)
+        vote = db_vote.submit(self.user1.id, self.review.last_revision.id, True)
+        self.review_created = self.review.last_revision.timestamp
+        self.review_id = self.review.id
+        self.revision_id = self.review.last_revision.id
+        self.report = SpamReport.create(self.revision_id, self.user1.id, "Testing Reason Report")
 
     def test_get_many_by_mb_username(self):
         users = [self.user1.musicbrainz_id, self.user2.musicbrainz_id]
@@ -21,3 +42,95 @@ class UserTestCase(DataTestCase):
             gravatar_url("test2"),
             "https://gravatar.com/avatar/ad0234829205b9033196ba818f7a872b?d=identicon&r=pg"
         )
+
+    def test_get_by_id(self):
+        user = db_users.get_by_id(self.user1.id)
+        self.assertEqual(user['display_name'], "test")
+        self.assertEqual(user['musicbrainz_id'], "tester_1")
+
+    def test_users_list(self):
+        users = db_users.list()
+        self.assertEqual(len(users), 3)
+
+        users = db_users.list(0, 10)
+        self.assertEqual(len(users), 0)
+
+        user3 = db_users.get_or_create("test2", "user_1")
+        users = db_users.list(1, 1)
+        self.assertEqual(len(users), 1)
+        self.assertEqual(users[0]['display_name'], "test1")
+
+    def test_get_count(self):
+        count = db_users.get_count()
+        self.assertEqual(count, 3)
+
+        user3 = db_users.get_or_create("test2", "user_1")
+        count = db_users.get_count()
+        self.assertEqual(count, 4)
+
+    def test_get_by_mbid(self):
+        user = db_users.get_by_mbid("tester_1")
+        self.assertEqual(user['display_name'], "test")
+
+    def test_create(self):
+        user = db_users.create("test_user", email="foo@foo.com", musicbrainz_id="tester2")
+        self.assertEqual(user['email'], "foo@foo.com")
+        self.assertEqual(type(user['id']), UUID)
+        self.assertEqual(user['is_blocked'], False)
+
+    def test_vote(self):
+        voted = db_users.has_voted(self.user1.id, self.review.id)
+        self.assertEqual(voted, True)
+        voted = db_users.has_voted(self.user2.id, self.review.id)
+        self.assertEqual(voted, False)
+
+    def test_karma(self):
+        karma = db_users.karma(self.author.id)
+        self.assertEqual(karma, 1)
+        karma = db_users.karma(self.user2.id)
+        self.assertEqual(karma, 0)
+
+    def test_reviews(self):
+        review = db_users.reviews(self.author.id)[0]
+        self.assertEqual(review['license_id'], 'Test')
+        self.assertEqual(type(review['user_id']), UUID)
+        self.assertEqual(str(review['user_id']), self.author.id)
+
+    def test_votes_since(self):
+        votes = db_users.get_votes(self.user1.id)
+        self.assertEqual(len(votes), 1)
+        two_days_from_now = date.today() + timedelta(days=2)
+        votes = db_users.get_votes(self.user1.id, two_days_from_now)
+        self.assertEqual(len(votes), 0)
+
+    def test_review_since(self):
+        reviews = db_users.get_reviews(self.author.id)
+        self.assertEqual(len(reviews), 1)
+        self.review.update(text="Testing Again")
+        reviews = db_users.get_reviews(self.author.id)
+        self.assertEqual(len(reviews), 1)
+        self.assertEqual(reviews[0]['creation_time'], self.review_created)
+        two_days_from_now = date.today() + timedelta(days=2)
+        reviews = db_users.get_reviews(self.author.id, two_days_from_now)
+        self.assertEqual(len(reviews), 0)
+
+    def test_update(self):
+        db_users.update(self.user1, email='foo@foo.com')
+        user1 = db_users.get_by_id(self.user1.id)
+        self.assertEqual(user1['email'], 'foo@foo.com')
+
+    def test_delete(self):
+
+        user1_id = self.user1.id
+        db_users.delete(self.user1.id)
+        # Votes should be deleted as well
+        votes = db_users.get_votes(self.user1.id)
+        self.assertEqual(len(votes), 0)
+        # Spam Reports to be deleted as well
+        spam_report_count = SpamReport.query.filter_by(user_id=user1_id, revision_id=self.revision_id).count()
+        self.assertEqual(spam_report_count, 0)
+
+        db_users.delete(self.author.id)
+        # Review should not exist
+        reviews = db_users.get_reviews(self.author.id)
+        self.assertEqual(len(reviews), 0)

--- a/critiquebrainz/db/users_test.py
+++ b/critiquebrainz/db/users_test.py
@@ -25,11 +25,13 @@ class UserTestCase(DataTestCase):
         license = License(id='Test', full_name='Test License')
         db.session.add(license)
         db.session.commit()
-        self.review = Review.create(release_group='e7aad618-fa86-3983-9e77-405e21796eca',
-                               text="Testing!",
-                               user_id=self.author.id,
-                               is_draft=False,
-                               license_id=license.id)
+        self.review = Review.create(
+                release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+                text="Testing!",
+                user_id=self.author.id,
+                is_draft=False,
+                license_id=license.id,
+        )
         vote = db_vote.submit(self.user1.id, self.review.last_revision.id, True)
         self.review_created = self.review.last_revision.timestamp
         self.review_id = self.review.id
@@ -83,7 +85,7 @@ class UserTestCase(DataTestCase):
         self.assertEqual(user['display_name'], "test")
 
     def test_create(self):
-        user = db_users.create("test_user", email="foo@foo.com", musicbrainz_username="tester2")
+        user = db_users.create(display_name="test_user", email="foo@foo.com", musicbrainz_username="tester2")
         self.assertEqual(user['email'], "foo@foo.com")
         self.assertEqual(type(user['id']), UUID)
         self.assertEqual(user['is_blocked'], False)
@@ -106,26 +108,28 @@ class UserTestCase(DataTestCase):
         self.assertEqual(type(review['user_id']), UUID)
         self.assertEqual(str(review['user_id']), self.author.id)
 
-    def test_votes_since(self):
-        votes = db_users.get_votes_since(self.user1.id)
+    def test_get_votes(self):
+        votes = db_users.get_votes(self.user1.id)
         self.assertEqual(len(votes), 1)
         two_days_from_now = date.today() + timedelta(days=2)
-        votes = db_users.get_votes_since(self.user1.id, two_days_from_now)
+        votes = db_users.get_votes(self.user1.id, from_date=two_days_from_now)
         self.assertEqual(len(votes), 0)
 
-    def test_review_since(self):
-        reviews = db_users.get_reviews_since(self.author.id)
+    def test_get_reviews(self):
+        reviews = db_users.get_reviews(self.author.id)
         self.assertEqual(len(reviews), 1)
         self.review.update(text="Testing Again")
-        reviews = db_users.get_reviews_since(self.author.id)
+        reviews = db_users.get_reviews(self.author.id)
         self.assertEqual(len(reviews), 1)
         self.assertEqual(reviews[0]['creation_time'], self.review_created)
         two_days_from_now = date.today() + timedelta(days=2)
-        reviews = db_users.get_reviews_since(self.author.id, two_days_from_now)
+        reviews = db_users.get_reviews(self.author.id, from_date=two_days_from_now)
         self.assertEqual(len(reviews), 0)
 
     def test_update(self):
-        db_users.update(self.user1, email='foo@foo.com')
+        db_users.update(self.user1.id, user_new_info={
+            "email": 'foo@foo.com',
+        })
         user1 = db_users.get_by_id(self.user1.id)
         self.assertEqual(user1['email'], 'foo@foo.com')
 
@@ -134,7 +138,7 @@ class UserTestCase(DataTestCase):
         user1_id = self.user1.id
         db_users.delete(self.user1.id)
         # Votes should be deleted as well
-        votes = db_users.get_votes_since(self.user1.id)
+        votes = db_users.get_votes(self.user1.id)
         self.assertEqual(len(votes), 0)
         # Spam Reports to be deleted as well
         spam_report_count = SpamReport.query.filter_by(user_id=user1_id, revision_id=self.revision_id).count()
@@ -142,5 +146,5 @@ class UserTestCase(DataTestCase):
 
         db_users.delete(self.author.id)
         # Review should not exist
-        reviews = db_users.get_reviews_since(self.author.id)
+        reviews = db_users.get_reviews(self.author.id)
         self.assertEqual(len(reviews), 0)

--- a/critiquebrainz/db/vote_test.py
+++ b/critiquebrainz/db/vote_test.py
@@ -1,7 +1,8 @@
 from critiquebrainz.data.testing import DataTestCase
 from critiquebrainz.data import db
 from critiquebrainz.data.model.vote import Vote
-from critiquebrainz.data.model.user import User
+from critiquebrainz.db.user import User
+import critiquebrainz.db.users as db_users
 from critiquebrainz.data.model.review import Review
 from critiquebrainz.data.model.license import License
 from critiquebrainz.db import exceptions
@@ -14,9 +15,15 @@ class VoteTestCase(DataTestCase):
 
     def setUp(self):
         super(VoteTestCase, self).setUp()
-        author = User.get_or_create('Author', musicbrainz_id='0')
-        self.user_1 = User.get_or_create('Tester #1', musicbrainz_id='1')
-        self.user_2 = User.get_or_create('Tester #2', musicbrainz_id='2')
+        author = User(db_users.get_or_create('0', new_user_data={
+            "display_name": "Author",
+        }))
+        self.user_1 = User(db_users.get_or_create('1', new_user_data={
+            "display_name": "Tester #1",
+        }))
+        self.user_2 = User(db_users.get_or_create('2', new_user_data={
+            "display_name": "Tester #2",
+        }))
         license = License(id='Test', full_name='Test License')
         db.session.add(license)
         db.session.commit()
@@ -31,7 +38,7 @@ class VoteTestCase(DataTestCase):
             vote.get(self.user_1.id, self.review.last_revision.id)
 
     def test_get(self):
-        vote_1 = Vote.create(self.user_1, self.review, True)
+        vote_1 = Vote.create(self.user_1.id, self.review, True)
         vote_1_data = vote.get(self.user_1.id, self.review.last_revision.id)
         self.assertDictEqual(vote_1_data, {
                 "user_id": UUID(vote_1.user_id),
@@ -43,7 +50,7 @@ class VoteTestCase(DataTestCase):
         self.assertEqual(type(vote_1_data["revision_id"]), int)
         self.assertEqual(type(vote_1_data["rated_at"]), datetime)
 
-        vote_2 = Vote.create(self.user_2, self.review, False)
+        vote_2 = Vote.create(self.user_2.id, self.review, False)
         vote_2_data = vote.get(self.user_2.id, self.review.last_revision.id)
         self.assertDictEqual(vote_2_data, {
             "user_id": UUID(vote_2.user_id),

--- a/critiquebrainz/db/vote_test.py
+++ b/critiquebrainz/db/vote_test.py
@@ -22,7 +22,7 @@ class VoteTestCase(DataTestCase):
         db.session.commit()
         self.review = Review.create(release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                text="Testing!",
-                               user=author,
+                               user_id=author.id,
                                is_draft=False,
                                license_id=license.id)
 

--- a/critiquebrainz/frontend/login/__init__.py
+++ b/critiquebrainz/frontend/login/__init__.py
@@ -6,10 +6,11 @@ It is based on OAuth2 protocol. MusicBrainz is the only supported provider.
 from flask import redirect, url_for
 from flask_login import LoginManager, current_user
 from flask_babel import lazy_gettext, gettext
-from critiquebrainz.data.model.user import User
 from critiquebrainz.data.model.mixins import AnonymousUser
 from werkzeug.exceptions import Unauthorized
 from functools import wraps
+from critiquebrainz.db.user import User
+import critiquebrainz.db.users as db_users
 
 mb_auth = None
 
@@ -22,7 +23,11 @@ login_manager.anonymous_user = AnonymousUser
 
 @login_manager.user_loader
 def load_user(user_id):
-    return User.get(id=user_id)
+    user = db_users.get_by_id(user_id)
+    if user:
+        return User(user)
+    else:
+        return None
 
 
 def login_forbidden(f):

--- a/critiquebrainz/frontend/login/provider.py
+++ b/critiquebrainz/frontend/login/provider.py
@@ -66,7 +66,9 @@ class MusicBrainzAuthentication(BaseAuthentication):
             decoder=lambda content: json.loads(content.decode("utf-8")),
         )
         data = s.get('oauth2/userinfo').json()
-        return User(db_users.get_or_create(data.get('sub'), musicbrainz_id=data.get('sub')))
+        return User(db_users.get_or_create(data.get('sub'), new_user_data={
+            "display_name": data.get('sub'),
+        }))
 
     def validate_post_login(self):
         if request.args.get('error'):

--- a/critiquebrainz/frontend/login/provider.py
+++ b/critiquebrainz/frontend/login/provider.py
@@ -2,7 +2,8 @@ import json
 from rauth import OAuth2Service
 from flask import request, session, url_for
 
-from critiquebrainz.data.model.user import User
+from critiquebrainz.db.user import User
+import critiquebrainz.db.users as db_users
 from critiquebrainz.utils import generate_string
 
 
@@ -46,7 +47,7 @@ class BaseAuthentication(object):
 
 
 class MusicBrainzAuthentication(BaseAuthentication):
-  
+
     def get_authentication_uri(self, **kwargs):
         csrf = generate_string(20)
         self.persist_data(csrf=csrf)
@@ -65,7 +66,7 @@ class MusicBrainzAuthentication(BaseAuthentication):
             decoder=lambda content: json.loads(content.decode("utf-8")),
         )
         data = s.get('oauth2/userinfo').json()
-        return User.get_or_create(data.get('sub'), musicbrainz_id=data.get('sub'))
+        return User(db_users.get_or_create(data.get('sub'), musicbrainz_id=data.get('sub')))
 
     def validate_post_login(self):
         if request.args.get('error'):

--- a/critiquebrainz/frontend/templates/user/info.html
+++ b/critiquebrainz/frontend/templates/user/info.html
@@ -3,10 +3,10 @@
 {% block title %}{{ user.display_name }} - {{ _('Info') }} - CritiqueBrainz{% endblock %}
 
 {% block profile_content %}
-  {% if user.musicbrainz_id %}
+  {% if user.musicbrainz_username %}
     <div>
       <img src="{{ get_static_path('favicons/musicbrainz-16.svg') }}" />
-      <b><a href="https://musicbrainz.org/user/{{ user.musicbrainz_id }}">See profile on MusicBrainz</a></b>
+      <b><a href="https://musicbrainz.org/user/{{ user.musicbrainz_username }}">See profile on MusicBrainz</a></b>
     </div>
   {% endif %}
 

--- a/critiquebrainz/frontend/views/index.py
+++ b/critiquebrainz/frontend/views/index.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template
 from flask_babel import format_number
-from critiquebrainz.data.model.user import User
+import critiquebrainz.db.users as db_users
 from critiquebrainz.data.model.review import Review
 from bs4 import BeautifulSoup
 from markdown import markdown
@@ -24,7 +24,7 @@ def index():
 
     # Statistics
     review_count = format_number(Review.get_count(is_draft = False))
-    user_count = format_number(User.get_count())
+    user_count = format_number(db_users.get_count())
 
     return render_template('index/index.html', popular_reviews=popular_reviews, recent_reviews=recent_reviews,
                            reviews_total=review_count, users_total=user_count)

--- a/critiquebrainz/frontend/views/index.py
+++ b/critiquebrainz/frontend/views/index.py
@@ -24,7 +24,7 @@ def index():
 
     # Statistics
     review_count = format_number(Review.get_count(is_draft = False))
-    user_count = format_number(db_users.get_count())
+    user_count = format_number(db_users.total_count())
 
     return render_template('index/index.html', popular_reviews=popular_reviews, recent_reviews=recent_reviews,
                            reviews_total=review_count, users_total=user_count)

--- a/critiquebrainz/frontend/views/moderators.py
+++ b/critiquebrainz/frontend/views/moderators.py
@@ -13,12 +13,12 @@ def mods_list():
     mods = []
     for mod_data in mods_data:
         # Removing from `mod_usernames` to figure out which mods don't have a CB account afterwards
-        if mod_data["musicbrainz_id"].lower() in mod_usernames:
-            mod_usernames.remove(mod_data["musicbrainz_id"].lower())
+        if mod_data["musicbrainz_username"].lower() in mod_usernames:
+            mod_usernames.remove(mod_data["musicbrainz_username"].lower())
         mods.append({
             'critiquebrainz_id': mod_data["id"],
-            'musicbrainz_username': mod_data["musicbrainz_id"],
-            'avatar_url': gravatar_url(mod_data["musicbrainz_id"]),
+            'musicbrainz_username': mod_data["musicbrainz_username"],
+            'avatar_url': gravatar_url(mod_data["musicbrainz_username"]),
         })
     for mod_username in mod_usernames:  # The rest
         mods.append({

--- a/critiquebrainz/frontend/views/profile.py
+++ b/critiquebrainz/frontend/views/profile.py
@@ -14,9 +14,11 @@ profile_bp = Blueprint('profile_details', __name__)
 def edit():
     form = ProfileEditForm()
     if form.validate_on_submit():
-        db_users.update(current_user, display_name=form.display_name.data,
-                            email=form.email.data,
-                            show_gravatar=form.show_gravatar.data)
+        db_users.update(current_user.id, user_new_info={
+            "display_name":form.display_name.data,
+            "email":form.email.data,
+            "show_gravatar":form.show_gravatar.data,
+        })
         flash.success(gettext("Profile updated."))
         return redirect(url_for('user.reviews', user_id=current_user.id))
     else:

--- a/critiquebrainz/frontend/views/profile.py
+++ b/critiquebrainz/frontend/views/profile.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, render_template, request, redirect, url_for
 from flask_babel import gettext
 from flask_login import login_required, current_user
+import critiquebrainz.db.users as db_users
 
 from critiquebrainz.frontend import flash
 from critiquebrainz.frontend.forms.profile import ProfileEditForm
@@ -13,7 +14,7 @@ profile_bp = Blueprint('profile_details', __name__)
 def edit():
     form = ProfileEditForm()
     if form.validate_on_submit():
-        current_user.update(display_name=form.display_name.data,
+        db_users.update(current_user, display_name=form.display_name.data,
                             email=form.email.data,
                             show_gravatar=form.show_gravatar.data)
         flash.success(gettext("Profile updated."))
@@ -29,7 +30,7 @@ def edit():
 @login_required
 def delete():
     if request.method == 'POST':
-        current_user.delete()
+        db_users.delete(current_user.id)
         return redirect(url_for('frontend.index'))
     return render_template('profile/delete.html')
 

--- a/critiquebrainz/frontend/views/profile_apps.py
+++ b/critiquebrainz/frontend/views/profile_apps.py
@@ -7,6 +7,7 @@ from critiquebrainz.data.model.oauth_client import OAuthClient
 from critiquebrainz.data.model.oauth_token import OAuthToken
 from critiquebrainz.frontend.forms.profile_apps import ApplicationForm
 from critiquebrainz.frontend import flash
+import critiquebrainz.db.users as db_users
 
 profile_apps_bp = Blueprint('profile_applications', __name__)
 
@@ -15,8 +16,8 @@ profile_apps_bp = Blueprint('profile_applications', __name__)
 @login_required
 def index():
     return render_template('profile/applications/index.html',
-                           applications=[c.to_dict() for c in current_user.clients],
-                           tokens=[t.to_dict() for t in current_user.tokens])
+                           applications=db_users.clients(current_user.id),
+                           tokens=db_users.tokens(current_user.id))
 
 
 @profile_apps_bp.route('/create', methods=['GET', 'POST'])

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -172,7 +172,7 @@ def create():
         return redirect(url_for('user.reviews', user_id=current_user.id))
 
     # Checking if the user already wrote a review for this entity
-    review = Review.query.filter_by(user=current_user, entity_id=entity_id).first()
+    review = Review.query.filter_by(user_id=current_user.id, entity_id=entity_id).first()
     if review:
         flash.error(gettext("You have already published a review for this entity!"))
         return redirect(url_for('review.entity', id=review.id))
@@ -185,7 +185,7 @@ def create():
             return redirect(url_for('user.reviews', user_id=current_user.id))
 
         is_draft = form.state.data == 'draft'
-        review = Review.create(user=current_user, entity_id=entity_id, entity_type=entity_type,
+        review = Review.create(user_id=current_user.id, entity_id=entity_id, entity_type=entity_type,
                                text=form.text.data, license_id=form.license_choice.data,
                                language=form.language.data, is_draft=is_draft)
         if is_draft:
@@ -326,14 +326,14 @@ def report(id):
         return redirect(url_for('.entity', id=id))
 
     last_revision_id = review.last_revision.id
-    count = SpamReport.query.filter_by(user=current_user, revision_id=last_revision_id).count()
+    count = SpamReport.query.filter_by(user_id=current_user.id, revision_id=last_revision_id).count()
     if count > 0:
         flash.error(gettext("You have already reported this review."))
         return redirect(url_for('.entity', id=id))
 
     form = ReviewReportForm()
     if form.validate_on_submit():
-        SpamReport.create(last_revision_id, current_user, form.reason.data)
+        SpamReport.create(last_revision_id, current_user.id, form.reason.data)
         flash.success(gettext("Review has been reported."))
         return redirect(url_for('.entity', id=id))
 

--- a/critiquebrainz/frontend/views/test/profile_apps.py
+++ b/critiquebrainz/frontend/views/test/profile_apps.py
@@ -1,14 +1,15 @@
 from critiquebrainz.frontend.testing import FrontendTestCase
-from critiquebrainz.data.model.user import User
+from critiquebrainz.db.user import User
 from critiquebrainz.data.model.oauth_client import OAuthClient
+import critiquebrainz.db.users as db_users
 
 
 class ProfileApplicationsViewsTestCase(FrontendTestCase):
 
     def setUp(self):
         super(ProfileApplicationsViewsTestCase, self).setUp()
-        self.user = User.get_or_create(u"Tester", u"aef06569-098f-4218-a577-b413944d9493")
-        self.hacker = User.get_or_create(u"Hacker!", u"9371e5c7-5995-4471-a5a9-33481f897f9c")
+        self.user = User(db_users.get_or_create(u"Tester", u"aef06569-098f-4218-a577-b413944d9493"))
+        self.hacker = User(db_users.get_or_create(u"Hacker!", u"9371e5c7-5995-4471-a5a9-33481f897f9c"))
         self.application = dict(
             name="Some Application",
             desc="Created for some purpose",

--- a/critiquebrainz/frontend/views/test/profile_apps.py
+++ b/critiquebrainz/frontend/views/test/profile_apps.py
@@ -8,8 +8,12 @@ class ProfileApplicationsViewsTestCase(FrontendTestCase):
 
     def setUp(self):
         super(ProfileApplicationsViewsTestCase, self).setUp()
-        self.user = User(db_users.get_or_create(u"Tester", u"aef06569-098f-4218-a577-b413944d9493"))
-        self.hacker = User(db_users.get_or_create(u"Hacker!", u"9371e5c7-5995-4471-a5a9-33481f897f9c"))
+        self.user = User(db_users.get_or_create(u"aef06569-098f-4218-a577-b413944d9493", new_user_data={
+            "display_name": u"Tester",
+        }))
+        self.hacker = User(db_users.get_or_create(u"9371e5c7-5995-4471-a5a9-33481f897f9c", new_user_data={
+            "display_name": u"Hacker!",
+        }))
         self.application = dict(
             name="Some Application",
             desc="Created for some purpose",

--- a/critiquebrainz/frontend/views/test/test_profile.py
+++ b/critiquebrainz/frontend/views/test/test_profile.py
@@ -7,7 +7,9 @@ class ProfileViewsTestCase(FrontendTestCase):
 
     def setUp(self):
         super(ProfileViewsTestCase, self).setUp()
-        self.user = User(db_users.get_or_create("Tester", "aef06569-098f-4218-a577-b413944d9493"))
+        self.user = User(db_users.get_or_create("aef06569-098f-4218-a577-b413944d9493", new_user_data={
+            "display_name": "Tester",
+        }))
 
     def test_edit(self):
         data = dict(

--- a/critiquebrainz/frontend/views/test/test_profile.py
+++ b/critiquebrainz/frontend/views/test/test_profile.py
@@ -1,12 +1,13 @@
 from critiquebrainz.frontend.testing import FrontendTestCase
-from critiquebrainz.data.model.user import User
+from critiquebrainz.db.user import User
+import critiquebrainz.db.users as db_users
 
 
 class ProfileViewsTestCase(FrontendTestCase):
 
     def setUp(self):
         super(ProfileViewsTestCase, self).setUp()
-        self.user = User.get_or_create("Tester", "aef06569-098f-4218-a577-b413944d9493")
+        self.user = User(db_users.get_or_create("Tester", "aef06569-098f-4218-a577-b413944d9493"))
 
     def test_edit(self):
         data = dict(

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -9,8 +9,12 @@ class ReviewViewsTestCase(FrontendTestCase):
 
     def setUp(self):
         super(ReviewViewsTestCase, self).setUp()
-        self.user = User(db_users.get_or_create(u"Tester", u"aef06569-098f-4218-a577-b413944d9493"))
-        self.hacker = User(db_users.get_or_create(u"Hacker!", u"9371e5c7-5995-4471-a5a9-33481f897f9c"))
+        self.user = User(db_users.get_or_create(u"aef06569-098f-4218-a577-b413944d9493", new_user_data={
+            "display_name": u"Tester",
+        }))
+        self.hacker = User(db_users.get_or_create(u"9371e5c7-5995-4471-a5a9-33481f897f9c", new_user_data={
+            "display_name": u"Hacker!",
+        }))
         self.license = License.create(u"CC BY-SA 3.0", u"Created so we can fill the form correctly.")
         self.review_text = "Testing! This text should be on the page."
 

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -1,22 +1,23 @@
 from critiquebrainz.frontend.testing import FrontendTestCase
 from critiquebrainz.data.model.review import Review
-from critiquebrainz.data.model.user import User
+from critiquebrainz.db.user import User
 from critiquebrainz.data.model.license import License
+import critiquebrainz.db.users as db_users
 
 
 class ReviewViewsTestCase(FrontendTestCase):
 
     def setUp(self):
         super(ReviewViewsTestCase, self).setUp()
-        self.user = User.get_or_create(u"Tester", u"aef06569-098f-4218-a577-b413944d9493")
-        self.hacker = User.get_or_create(u"Hacker!", u"9371e5c7-5995-4471-a5a9-33481f897f9c")
+        self.user = User(db_users.get_or_create(u"Tester", u"aef06569-098f-4218-a577-b413944d9493"))
+        self.hacker = User(db_users.get_or_create(u"Hacker!", u"9371e5c7-5995-4471-a5a9-33481f897f9c"))
         self.license = License.create(u"CC BY-SA 3.0", u"Created so we can fill the form correctly.")
         self.review_text = "Testing! This text should be on the page."
 
     def create_dummy_review(self, is_draft=False):
         review = Review.create(
             release_group="6b3cd75d-7453-39f3-86c4-1441f360e121",
-            user=self.user,
+            user_id=self.user.id,
             text=self.review_text,
             is_draft=is_draft,
             license_id=self.license.id,

--- a/critiquebrainz/frontend/views/test/test_user.py
+++ b/critiquebrainz/frontend/views/test/test_user.py
@@ -1,17 +1,18 @@
 from critiquebrainz.frontend.testing import FrontendTestCase
-from critiquebrainz.data.model.user import User
+from critiquebrainz.db.user import User
+import critiquebrainz.db.users as db_users
 
 
 class UserViewsTestCase(FrontendTestCase):
 
     def test_reviews(self):
-        user = User.get_or_create("Tester", "aef06569-098f-4218-a577-b413944d9493")
+        user = User(db_users.get_or_create("Tester", "aef06569-098f-4218-a577-b413944d9493"))
         response = self.client.get("/user/%s" % user.id)
         self.assert200(response)
         self.assertIn("Tester", str(response.data))
 
     def test_info(self):
-        user = User.get_or_create("Tester", "aef06569-098f-4218-a577-b413944d9493")
+        user = User(db_users.get_or_create("Tester", "aef06569-098f-4218-a577-b413944d9493"))
         response = self.client.get("/user/%s/info" % user.id)
         self.assert200(response)
         self.assertIn("Tester", str(response.data))

--- a/critiquebrainz/frontend/views/test/test_user.py
+++ b/critiquebrainz/frontend/views/test/test_user.py
@@ -6,13 +6,17 @@ import critiquebrainz.db.users as db_users
 class UserViewsTestCase(FrontendTestCase):
 
     def test_reviews(self):
-        user = User(db_users.get_or_create("Tester", "aef06569-098f-4218-a577-b413944d9493"))
+        user = User(db_users.get_or_create("aef06569-098f-4218-a577-b413944d9493", new_user_data={
+            "display_name": "Tester",
+        }))
         response = self.client.get("/user/%s" % user.id)
         self.assert200(response)
         self.assertIn("Tester", str(response.data))
 
     def test_info(self):
-        user = User(db_users.get_or_create("Tester", "aef06569-098f-4218-a577-b413944d9493"))
+        user = User(db_users.get_or_create("aef06569-098f-4218-a577-b413944d9493", new_user_data={
+            "display_name": "Tester",
+        }))
         response = self.client.get("/user/%s/info" % user.id)
         self.assert200(response)
         self.assertIn("Tester", str(response.data))

--- a/critiquebrainz/frontend/views/user.py
+++ b/critiquebrainz/frontend/views/user.py
@@ -1,13 +1,14 @@
-from flask import Blueprint, render_template, request, redirect, url_for
+from flask import Blueprint, render_template, request, redirect, url_for, abort
 from flask_babel import gettext
 from flask_login import login_required, current_user
 
 from critiquebrainz.data.model.moderation_log import ModerationLog, ACTION_BLOCK_USER
 from critiquebrainz.data.model.review import Review
-from critiquebrainz.data.model.user import User
+from critiquebrainz.db.user import User
 from critiquebrainz.frontend.forms.log import AdminActionForm
 from critiquebrainz.frontend.login import admin_view
 from critiquebrainz.frontend import flash
+import critiquebrainz.db.users as db_users
 
 user_bp = Blueprint('user', __name__)
 
@@ -18,7 +19,10 @@ def reviews(user_id):
     if current_user.is_authenticated and current_user.id == user_id:
         user = current_user
     else:
-        user = User.query.get_or_404(user_id)
+        user = db_users.get_by_id(user_id)
+        if not user:
+            abort(404)
+        user = User(user)
     page = int(request.args.get('page', default=1))
     if page < 1:
         return redirect(url_for('.reviews'))
@@ -33,26 +37,32 @@ def reviews(user_id):
 
 @user_bp.route('/<uuid:user_id>/info')
 def info(user_id):
-    return render_template('user/info.html', section='info', user=User.query.get_or_404(str(user_id)))
+    user = db_users.get_by_id(user_id)
+    if not user:
+        abort(404)
+    user = User(user)
+    return render_template('user/info.html', section='info', user=user)
 
 
 @user_bp.route('/<uuid:user_id>/block', methods=['GET', 'POST'])
 @login_required
 @admin_view
 def block(user_id):
-    user = User.query.get_or_404(str(user_id))
+    user = db_users.get_by_id(user_id)
+    if not user:
+        abort(404)
 
-    if user.is_blocked:
+    if user['is_blocked']:
         flash.info(gettext("This account is already blocked."))
-        return redirect(url_for('user.reviews', user_id=user.id))
+        return redirect(url_for('user.reviews', user_id=user['id']))
 
     form = AdminActionForm()
     if form.validate_on_submit():
-        user.block()
+        db_users.block(user['id'])
         ModerationLog.create(admin_id=current_user.id, action=ACTION_BLOCK_USER,
-                             reason=form.reason.data, user_id=user.id)
+                             reason=form.reason.data, user_id=user['id'])
         flash.success(gettext("This user account has been blocked."))
-        return redirect(url_for('user.reviews', user_id=user.id))
+        return redirect(url_for('user.reviews', user_id=user['id']))
 
     return render_template('log/action.html', user=user, form=form, action=ACTION_BLOCK_USER)
 
@@ -61,7 +71,9 @@ def block(user_id):
 @login_required
 @admin_view
 def unblock(user_id):
-    user = User.query.get_or_404(str(user_id))
-    user.unblock()
+    user = db_users.get_by_id(user_id)
+    if not user:
+        abort(404)
+    db_users.unblock(user['id'])
     flash.success(gettext("This user account has been unblocked."))
-    return redirect(url_for('user.reviews', user_id=user.id))
+    return redirect(url_for('user.reviews', user_id=user['id']))

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -297,7 +297,7 @@ def review_list_handler():
     if release_group:
         entity_id = release_group
         entity_type = 'release_group'
-    else:        
+    else:
         entity_id = Parser.uuid('uri', 'entity_id', optional=True)
         entity_type = Parser.string('uri', 'entity_type', valid_values=ENTITY_TYPES, optional=True)
 
@@ -374,7 +374,7 @@ def review_post_handler(user):
     if user.is_review_limit_exceeded:
         raise LimitExceeded('You have exceeded your limit of reviews per day.')
     entity_id, entity_type, text, license_choice, language, is_draft = fetch_params()
-    review = Review.create(user=user, entity_id=entity_id, entity_type=entity_type, text=text,
+    review = Review.create(user_id=user.id, entity_id=entity_id, entity_type=entity_type, text=text,
                            license_id=license_choice, language=language, is_draft=is_draft)
     return jsonify(message='Request processed successfully', id=review.id)
 

--- a/critiquebrainz/ws/review/views_test.py
+++ b/critiquebrainz/ws/review/views_test.py
@@ -16,7 +16,7 @@ class ReviewViewsTestCase(WebServiceTestCase):
         self.review = dict(
             entity_id="6b3cd75d-7453-39f3-86c4-1441f360e121",
             entity_type='release_group',
-            user=self.user,
+            user_id=self.user.id,
             text="Testing! This text should be on the page.",
             is_draft=False,
             license_id=self.license.id,

--- a/critiquebrainz/ws/user/views.py
+++ b/critiquebrainz/ws/user/views.py
@@ -33,7 +33,7 @@ def user_me_handler(user):
             "user_type": "Noob",
             "email": "your_email_id",
             "karma": 0,
-            "musicbrainz_id": "username/id associated with musicbrainz",
+            "musicbrainz_username": "username/id associated with musicbrainz",
             "id": "your-unique-user-id",
             "avatar": "https:\/\/gravatar.com\/your-gravatar-link"
           }


### PR DESCRIPTION
Migrated users code off the ORM and created a seperate class for `User` in `db/user.py` using the SQLAlchemy core code for `user`. Made changes accordingly in the `frontend` for using the migrated code. However, changes in `webservice` is yet to be made. I've added the following functions in `users.py` and corresponding tests:
+ `get_by_id` for fetching user by id
+ `get_by_mbid` for fetching user by mbid
+ `get or create` and `create` for creating new user
+ `get_count` for counting number of users
+ `list` for listing users with `offset` and `limit`
+ `block` and `unblock` for blocking and unblocking users
+ `karma` for user karma
+ `has_voted`, `get_votes` for user has voted and user votes since a date
+ `reviews`, `get_reviews` for user reviews and user reviews since a date
+ `update` and `delete` for updating and deleting user info
+ `clients` and `tokens` for user registered clients and tokens

I've made changes in `Review.create`, `SpamReport.create` and `Vote.create` to use `user_id` rather that `data/User` object in order to use the migrated code.
