### PR TITLE
Fix a couple language issues in the MusicBrainz release group links

### DIFF
--- a/critiquebrainz/frontend/templates/release_group/entity.html
+++ b/critiquebrainz/frontend/templates/release_group/entity.html
@@ -126,7 +126,7 @@
       </table>
       {% if release_group['release-list']|length > 1 %}
         <em class="text-muted small">
-          {{ _('This is a tracklist from one of releases.') }}
+          {{ _('This is a tracklist from one of the releases.') }}
           <a href="https://musicbrainz.org/release-group/{{ release_group.id }}">{{ _('See all on MusicBrainz') }}</a>.
         </em>
       {% endif %}

--- a/critiquebrainz/frontend/templates/release_group/entity.html
+++ b/critiquebrainz/frontend/templates/release_group/entity.html
@@ -127,7 +127,7 @@
       {% if release_group['release-list']|length > 1 %}
         <em class="text-muted small">
           {{ _('This is a tracklist from one of the releases.') }}
-          <a href="https://musicbrainz.org/release-group/{{ release_group.id }}">{{ _('See all on MusicBrainz') }}</a>.
+          <a href="https://musicbrainz.org/release-group/{{ release_group.id }}">{{ _('See all releases on MusicBrainz') }}</a>.
         </em>
       {% endif %}
     {% endif %}


### PR DESCRIPTION
* Fixes a grammatical error due to a missing article.
* Adds more context to the "See all on MusicBrainz" string, which seems too ambiguous for translators on its own (see all what?). I think it reads better with "releases," anyway.