### PR TITLE
CB-230: Migrate review related code off the ORM

### DIFF
--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -293,7 +293,7 @@ def create(**kwargs):
     return get_by_id(review_id)
 
 
-def list(**kwargs):
+def list_reviews(**kwargs):
     """Get a list of reviews.
 
     This method provides several filters that can be used to select

--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -1,0 +1,608 @@
+import sqlalchemy
+from critiquebrainz import db
+from critiquebrainz.db import exceptions as db_exceptions
+from brainzutils import cache
+from werkzeug.exceptions import BadRequest
+from random import shuffle
+from flask_babel import lazy_gettext
+import critiquebrainz.db.revision as db_revision
+from critiquebrainz.db.user import User
+import critiquebrainz.db.users as db_users
+from critiquebrainz.db.user import User
+import uuid
+
+REVIEW_CACHE_NAMESPACE = "Review"
+DEFAULT_LICENSE_ID = "CC BY-SA 3.0"
+DEFAULT_LANG = "en"
+ENTITY_TYPES = [
+    'event',
+    'place',
+    'release_group',
+]
+
+
+def to_dict(review, confidential=False):
+    review["user"] = User(db_users.get_by_id(review.pop("user_id")))
+    review["user"] = review["user"].to_dict(confidential=True)
+    review["id"] = str(review["id"])
+    review["entity_id"] = str(review["entity_id"])
+    review["last_updated"] = review["last_revision"]["timestamp"]
+    review['last_revision']['review_id'] = str(review['last_revision']['review_id'])
+    return review
+
+
+def get_by_id(review_id):
+    """Get review from review ID.
+
+    Args:
+        review_id(uuid): ID of the review.
+    Returns:
+        Dictionary with the following structure
+        {
+            "id": uuid,
+            "entity_id": uuid,
+            "entity_type": 'release_group', 'event', 'place',
+            "user_id": uuid,
+            "user": dict,
+            "edits": int,
+            "is_draft": bool,
+            "is_hidden": bool,
+            "language": str,
+            "license_id": str,
+            "source": str,
+            "source_url": str,
+            "last_revision: dict,
+            "votes": dict,
+            "rating": int,
+            "text": str, "created": datetime,
+            "license": dict,
+        }
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT review.id AS id,
+                   entity_id,
+                   entity_type,
+                   user_id,
+                   edits,
+                   is_draft,
+                   is_hidden,
+                   license_id,
+                   language,
+                   source,
+                   source_url,
+                   revision.id AS last_revision_id,
+                   timestamp,
+                   text,
+                   email,
+                   "user".created as user_created,
+                   display_name,
+                   show_gravatar,
+                   musicbrainz_id,
+                   is_blocked,
+                   created_time.created,
+                   license.full_name,
+                   license.info_url
+              FROM review
+              JOIN revision
+                ON revision.review_id = review.id
+              JOIN "user"
+                ON "user".id = review.user_id
+              JOIN license
+                ON license.id = license_id
+              JOIN (
+                    SELECT review.id,
+                           timestamp AS created
+                      FROM review
+                      JOIN revision
+                        ON review.id = revision.review_id
+                     WHERE review.id = :review_id
+                  ORDER BY revision.timestamp ASC
+                     LIMIT 1
+                   ) AS created_time
+                ON created_time.id = review.id
+          ORDER BY timestamp DESC
+        """), {
+            "review_id": review_id,
+        })
+
+        review = result.fetchone()
+        if not review:
+            raise db_exceptions.NoDataFoundException("No review found with review ID: {}".format(review_id))
+
+        review = dict(review)
+        review["last_revision"] = {
+            "id": review.pop("last_revision_id"),
+            "timestamp": review.pop("timestamp"),
+            "text": review.get("text"),
+            "review_id": review.get("id"),
+        }
+        review["user"] = User({
+            "id": review["user_id"],
+            "display_name": review.pop("display_name", None),
+            "is_blocked": review.pop("is_blocked", False),
+            "show_gravatar": review.pop("show_gravatar", False),
+            "musicbrainz_username": review.pop("musicbrainz_id"),
+            "email": review.pop("email"),
+            "created": review.pop("user_created"),
+        })
+        review["license"] = {
+            "id": review["license_id"],
+            "info_url": review["info_url"],
+            "full_name": review["full_name"],
+        }
+        votes = db_revision.votes(review["last_revision"]["id"])
+        review["votes_positive_count"] = votes["positive"]
+        review["votes_negative_count"] = votes["negative"]
+        review["rating"] = review["votes_positive_count"] - review["votes_negative_count"]
+    return review
+
+
+def hide(review_id):
+    """Hide review given the review id.
+
+    Args:
+        review_id(uuid): ID of the review to hide.
+    """
+    with db.engine.connect() as connection:
+        connection.execute(sqlalchemy.text("""
+            UPDATE review
+               SET is_hidden='true'
+             WHERE id = :review_id
+        """), {
+            "review_id": review_id,
+        })
+
+
+def unhide(review_id):
+    """Unhide review given the review id.
+
+    Args:
+        review_id(uuid): ID of the review to unhide.
+    """
+    with db.engine.connect() as connection:
+        connection.execute(sqlalchemy.text("""
+            UPDATE review
+               SET is_hidden='fa'
+             WHERE id = :review_id
+        """), {
+            "review_id": review_id,
+        })
+
+
+def get_count(**kwargs):
+    """Get number of reviews in CritiqueBrainz.
+
+    Args:
+        is_draft (bool): True if drafted reviews are to be counted.
+        is_hidden (bool): True if hidden reviews are to be counted.
+    """
+    is_drafted = kwargs.pop('is_draft', False)
+    is_hidden = kwargs.pop('is_hidden', False)
+    if(kwargs):
+        raise TypeError('Unexpected **kwargs: %r' % kwargs)
+
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT count(*)
+              FROM review
+             WHERE is_draft = :is_drafted
+               AND is_hidden = :is_hidden
+        """), {
+            "is_drafted": is_drafted,
+            "is_hidden": is_hidden,
+        })
+        return result.fetchone()[0]
+
+
+def update(review_id, drafted, **kwargs):
+    """Update contents of this review.
+
+    Args:
+        review_id (uuid): ID of the review.
+        drafted (bool): Whether review is presently drafted.
+        license_id(optional, str): Updated license id of a review.
+        is_draft(optional, bool): Whether to publish review or keep it drafted.
+        text(optional, str): Updated text of a review.
+    """
+
+    updates = []
+    updated_info = {}
+
+    license_id = kwargs.pop("license_id", None)
+    if license_id is not None:
+        if not drafted: # If trying to convert published review into draft.
+            raise BadRequest(lazy_gettext("Changing licence of a published review is not allowed."))
+        updates.append("license_id = :license_id")
+        updated_info["license_id"] = license_id
+
+    language = kwargs.pop("language", None)
+    if language is not None:
+        updates.append("language = :language")
+        updated_info["language"] = language
+
+    is_draft = kwargs.pop("is_draft", None)
+    if is_draft is not None:
+        if not drafted and is_draft: # If trying to convert published review into draft
+            raise BadRequest(lazy_gettext("Converting published reviews back to drafts is not allowed."))
+        updates.append("is_draft = :is_draft")
+        updated_info["is_draft"] = is_draft
+
+    text = kwargs.pop("text")
+    if kwargs:
+        raise TypeError('Unexpected **kwargs: %r' %kwargs)
+
+    setstr = ", ".join(updates)
+    query = sqlalchemy.text("""
+        UPDATE review
+           SET {}
+         WHERE id = :review_id
+    """.format(setstr))
+
+    if setstr:
+        updated_info["review_id"] = review_id
+        with db.engine.connect() as connection:
+            connection.execute(query, updated_info)
+    # Create new revision
+    new_revision = db_revision.create(review_id, text)
+    review = get_by_id(review_id)
+    cache.invalidate_namespace(REVIEW_CACHE_NAMESPACE)
+    return review
+
+
+def create(**kwargs):
+    if 'release_group' in kwargs:
+       entity_id = kwargs.pop('release_group')
+       entity_type = 'release_group'
+    else:
+        entity_id = kwargs.pop('entity_id')
+        entity_type = kwargs.pop('entity_type')
+
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            BEGIN;
+            INSERT INTO review
+            VALUES (:id, :entity_id, :entity_type, :user_id, :edits, :is_draft,
+            :is_hidden, :license_id, :language, :source, :source_url)
+         RETURNING id;
+       """), {
+           "id": str(uuid.uuid4()),
+           "entity_id": entity_id,
+           "entity_type": entity_type,
+           "user_id": kwargs.pop("user_id"),
+           "edits": 0,
+           "is_draft": kwargs.pop("is_draft", False),
+           "is_hidden": False,
+           "language": kwargs.pop("language", DEFAULT_LANG),
+           "license_id": kwargs.pop("license_id", DEFAULT_LICENSE_ID),
+           "source": kwargs.pop("source", None),
+           "source_url": kwargs.pop("source_url", None),
+        })
+        text = kwargs.pop("text")
+        if kwargs:
+            connection.execute(sqlalchemy.text("""
+                ROLLBACK;
+            """))
+            raise TypeError("Unexpected **kwargs: %r" % kwargs)
+        connection.execute(sqlalchemy.text("""
+            COMMIT;
+        """))
+        review_id = result.fetchone()[0]
+        review_revision = db_revision.create(review_id, text)
+        cache.invalidate_namespace(REVIEW_CACHE_NAMESPACE)
+    return get_by_id(review_id)
+
+
+def list(**kwargs):
+    """Get a list of reviews.
+
+    This method provides several filters that can be used to select
+    specific review. See argument description below for more info.
+
+    Args:
+        entity_id: MBID of the entity that is associated with a review.
+        entity_type: One of the supported reviewable entities: 'release_group' or 'event', etc.
+        user_id: UUID of the author.
+        sort: Order of the returned reviews. Can be either "rating" (order by rating), or "created"
+            (order by creation time), or "random" (order randomly).
+        limit: Maximum number of reviews returned by this method.
+        offset: Offset that can be used in conjuction with the limit.
+        language: Language (code) of the returned reviews.
+        license_id: License of the returned reviews.
+        inc_drafts: True if reviews marked as drafts should be included.
+            False if not.
+        inc_hidden: True if reviews marked as hidden should be included.
+            False if not.
+        exclude: List of id of reviews to exclude.
+
+    Returns:
+        Pair of values: List of reviews that match applied filters
+        and total number of reviews.
+    """
+    filters = []
+    filter_data = {}
+    inc_drafts = kwargs.pop('inc_drafts', None)
+    if not inc_drafts:
+        filters.append("is_draft = :is_draft")
+        filter_data["is_draft"] = False
+
+    inc_hidden = kwargs.pop('inc_hidden', None)
+    if not inc_hidden:
+        filters.append("is_hidden = :is_hidden")
+        filter_data["is_hidden"] = False
+
+    # FILTERING
+    entity_id = kwargs.pop('entity_id', None)
+    if entity_id is not None:
+        filters.append("entity_id = :entity_id")
+        filter_data["entity_id"] = entity_id
+
+    entity_type = kwargs.pop('entity_type', None)
+    if entity_type is not None:
+        filters.append("entity_type = :entity_type")
+        filter_data["entity_type"] = entity_type
+
+    license_id = kwargs.pop('license_id', None)
+    if license_id is not None:
+        filters.append("license_id = :license_id")
+        filter_data["license_id"] = license_id
+
+    user_id = kwargs.pop('user_id', None)
+    if user_id is not None:
+        filters.append("review.user_id = :user_id")
+        filter_data["user_id"] = user_id
+
+    exclude = kwargs.pop('exclude', None)
+    if exclude is not None:
+        filters.append("review.id NOT IN :exclude")
+        filter_data["exclude"] = tuple(exclude)
+
+    language = kwargs.pop('language', None)
+    if language is not None:
+        filters.append("language = :language")
+        filter_data["language"] = language
+
+    filterstr = " AND ".join(filters)
+    if filterstr:
+        filterstr = " WHERE " + filterstr
+
+    query = sqlalchemy.text("""
+        SELECT COUNT(*)
+          FROM review
+            {}
+        """.format(filterstr))
+
+    with db.engine.connect() as connection:
+        result = connection.execute(query, filter_data)
+        count = result.fetchone()[0]
+    sort = kwargs.pop("sort", None)
+    order_by_clause = str()
+
+    if sort == 'rating':
+        order_by_clause = """
+            ORDER BY rating DESC
+        """
+    elif sort == 'created':
+        order_by_clause = """
+            ORDER BY created DESC
+        """
+    elif sort == 'random':
+        order_by_clause = """
+            ORDER BY RANDOM()
+        """
+    # Note that all revisions' votes are considered in these ratings
+    query = sqlalchemy.text("""
+        SELECT review.id,
+               entity_id,
+               entity_type,
+               edits,
+               is_draft,
+               is_hidden,
+               license_id,
+               language,
+               review.user_id,
+               display_name,
+               show_gravatar,
+               is_blocked,
+               email,
+               "user".created as user_created,
+               musicbrainz_id,
+               MIN(revision.timestamp) as created,
+               SUM(
+                CASE
+                 WHEN vote='t' THEN 1
+                 ELSE 0
+                END
+               ) AS votes_positive_count,
+               SUM(
+                CASE
+                 WHEN vote='f' THEN 1
+                 ELSE 0
+                END
+               ) AS votes_negative_count,
+               SUM(
+                CASE
+                 WHEN vote = 't' THEN 1
+                 WHEN vote = 'f' THEN -1
+                 WHEN vote IS NULL THEN 0
+                END
+               ) AS rating,
+               latest_revision.id as latest_revision_id,
+               latest_revision.timestamp as latest_revision_timestamp,
+               latest_revision.text as text,
+               source,
+               source_url,
+               license.full_name,
+               license.info_url
+          FROM review
+          JOIN revision
+            ON review.id = revision.review_id
+     LEFT JOIN vote
+            ON vote.revision_id = revision.id
+          JOIN "user"
+            ON review.user_id = "user".id
+          JOIN license
+            ON license.id = license_id
+          JOIN (
+                revision
+                JOIN (
+                  SELECT review.id AS review_uuid,
+                         MAX(timestamp) AS latest_timestamp
+                    FROM review
+                    JOIN revision
+                      ON review.id = review_id
+                GROUP BY review.id
+                     ) AS latest
+                  ON latest.review_uuid = revision.review_id
+                 AND latest.latest_timestamp = revision.timestamp
+               ) AS latest_revision
+            ON review.id = latest_revision.review_id
+            {}
+      GROUP BY review.id, latest_revision.id, "user".id, license.id
+            {}
+         LIMIT :limit
+        OFFSET :offset
+        """.format(filterstr, order_by_clause))
+
+    filter_data["limit"] = kwargs.pop("limit", None)
+    filter_data["offset"] = kwargs.pop("offset", None)
+
+    if kwargs:
+        raise TypeError('Unexpected **kwargs: %r' % kwargs)
+
+    with db.engine.connect() as connection:
+        results = connection.execute(query, filter_data)
+        rows = results.fetchall()
+        rows = [dict(row) for row in rows]
+        # Orgainze last revision info in reviews
+        if rows:
+            for row in rows:
+                row["last_revision"] = {
+                    "id": row.pop("latest_revision_id"),
+                    "timestamp": row.pop("latest_revision_timestamp"),
+                    "text": row["text"],
+                    "review_id": row["id"],
+                }
+                row["user"] = User({
+                    "id": row["user_id"],
+                    "display_name": row.pop("display_name"),
+                    "show_gravatar": row.pop("show_gravatar"),
+                    "is_blocked": row.pop("is_blocked"),
+                    "musicbrainz_username": row.pop("musicbrainz_id"),
+                    "email": row.pop("email"),
+                    "created": row.pop("user_created"),
+                })
+    return rows, count
+
+
+def get_popular(limit=None):
+    """Get list of popular reviews.
+
+    Popularity is determined by rating of a particular review. Rating is a difference between
+    positive votes and negative. In this case only votes from the last month are
+    used to calculate rating.
+
+    Results are cached for 1 hour.
+
+    Args:
+        limit: Maximum number of reviews to return.
+
+    Returns:
+        Randomized list of popular reviews which are converted into dictionaries using to_dict method.
+    """
+    cache_key = cache.gen_key('popular_reviews', limit)
+    reviews = cache.get(cache_key, REVIEW_CACHE_NAMESPACE)
+    reviews = None
+    defined_limit = 4 * limit if limit else None
+
+    if not reviews:
+        with db.engine.connect() as connection:
+            results = connection.execute(sqlalchemy.text("""
+                SELECT review.id,
+                       entity_id,
+                       entity_type,
+                       review.user_id,
+                       edits,
+                       is_draft,
+                       is_hidden,
+                       license_id,
+                       language,
+                       source,
+                       source_url,
+                       SUM(
+                        CASE
+                          WHEN vote = 't' THEN 1
+                          WHEN vote = 'f' THEN -1
+                          WHEN vote IS NULL THEN 0
+                        END
+                       ) AS rating,
+                       latest_revision.id AS latest_revision_id,
+                       latest_revision.timestamp AS latest_revision_timestamp,
+                       latest_revision.text AS text
+                      FROM review
+                  JOIN revision
+                    ON revision.review_id = review.id
+             LEFT JOIN vote
+                    ON vote.revision_id = revision.id
+                  JOIN (
+                        revision
+                        JOIN (
+                          SELECT review.id AS review_uuid,
+                                 MAX(timestamp) AS latest_timestamp
+                            FROM review
+                            JOIN revision
+                              ON review.id = review_id
+                        GROUP BY review.id
+                             ) AS latest
+                          ON latest.review_uuid = revision.review_id
+                         AND latest.latest_timestamp = revision.timestamp
+                       ) AS latest_revision
+                    ON review.id = latest_revision.review_id
+                 WHERE entity_id
+                    IN (
+                          SELECT
+                        DISTINCT entity_id
+                            FROM (
+                          SELECT entity_id
+                            FROM review
+                        ORDER BY RANDOM()
+                        ) AS randomized_entity_ids
+                       )
+              GROUP BY review.id, latest_revision.id
+              ORDER BY rating
+                 LIMIT :limit
+            """), {
+                "limit": defined_limit,
+            })
+            reviews = results.fetchall()
+
+        reviews = [dict(review) for review in reviews]
+        if reviews:
+            for review in reviews:
+                review["last_revision"] = {
+                    "id": review.pop("latest_revision_id"),
+                    "timestamp": review.pop("latest_revision_timestamp"),
+                    "text": review["text"],
+                    "review_id": review["id"],
+                }
+            reviews = [to_dict(review, confidential=True) for review in reviews]
+
+        cache.set(cache_key, reviews, 1 * 60 * 60, REVIEW_CACHE_NAMESPACE) # 1 hour
+    shuffle(reviews)
+    return reviews[:limit]
+
+
+def delete(review_id):
+    """Delete a review, given the review ID.
+
+    Args:
+        review_id: ID of the review to be deleted.
+    """
+    with db.engine.connect() as connection:
+        connection.execute(sqlalchemy.text("""
+            DELETE
+              FROM review
+             WHERE id = :review_id
+        """), {
+            "review_id": review_id,
+        })

--- a/critiquebrainz/db/review_test.py
+++ b/critiquebrainz/db/review_test.py
@@ -24,7 +24,8 @@ class ReviewTestCase(DataTestCase):
     def test_review_creation(self):
         review = db_review.create(
            user_id=self.user.id,
-           release_group="e7aad618-fa86-3983-9e77-405e21796eca",
+           entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+           entity_type="release_group",
            text="Testing",
            is_draft=False,
            license_id=self.license.id,
@@ -38,7 +39,8 @@ class ReviewTestCase(DataTestCase):
     def test_review_deletion(self):
         review = db_review.create(
             user_id=self.user.id,
-            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
             text="Testing",
             is_draft=False,
             license_id=self.license.id,
@@ -50,7 +52,8 @@ class ReviewTestCase(DataTestCase):
     def test_languages(self):
         review_en = db_review.create(
             user_id=self.user.id,
-            release_group="e7aad618-fa86-3983-9e77-405e21796ece",
+            entity_id="e7aad618-fa86-3983-9e77-405e21796ece",
+            entity_type="release_group",
             text="Testing",
             is_draft=False,
             license_id=self.license.id,
@@ -59,7 +62,8 @@ class ReviewTestCase(DataTestCase):
 
         review_de = db_review.create(
             user_id=self.user.id,
-            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
             text="Testing",
             is_draft=False,
             license_id=self.license.id,
@@ -75,7 +79,8 @@ class ReviewTestCase(DataTestCase):
     def test_update(self):
         review = db_review.create(
             user_id=self.user.id,
-            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
             text="Testing",
             is_draft=True,
             license_id=self.license.id,
@@ -83,7 +88,7 @@ class ReviewTestCase(DataTestCase):
         another_license = License(id="License-2", full_name="Another License")
         db.session.add(another_license)
         db.session.commit()
-        review = db_review.update(
+        db_review.update(
             review_id=review["id"],
             drafted=review["is_draft"],
             text="Bad update",
@@ -105,15 +110,15 @@ class ReviewTestCase(DataTestCase):
 
         # Checking things that shouldn't be allowed
         with self.assertRaises(BadRequest):
-            review = db_review.update(
-                review_id=review["id"],
-                drafted=review["is_draft"],
+            db_review.update(
+                review_id=retrieved_review["id"],
+                drafted=retrieved_review["is_draft"],
                 text="Sucks!",
                 license_id=self.license.id,
             )
-
+        review = db_review.get_by_id(review["id"])
         with self.assertRaises(BadRequest):
-            review = db_review.update(
+            db_review.update(
                 review_id=review["id"],
                 drafted=review["is_draft"],
                 text="Sucks!",
@@ -127,7 +132,8 @@ class ReviewTestCase(DataTestCase):
 
         review = db_review.create(
             user_id=self.user.id,
-            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
             text="Awesome",
             is_draft=False,
             license_id=self.license.id,
@@ -137,7 +143,7 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(len(reviews), 1)
         self.assertEqual(reviews[0]["text"], "Awesome")
 
-        review = db_review.update(
+        db_review.update(
             review_id=review["id"],
             drafted=review["is_draft"],
             text="Beautiful!",
@@ -164,8 +170,9 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(len(reviews), 0)
 
         new_review = db_review.create(
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
             user_id=self.user.id,
-            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
             text="Awesome",
             is_draft=False,
             license_id=self.license.id,
@@ -174,18 +181,19 @@ class ReviewTestCase(DataTestCase):
         reviews = db_review.get_popular()
         self.assertEqual(len(reviews), 1)
 
-    def test_hide_and_unhide(self):
+    def test_set_hidden_state(self):
         review = db_review.create(
             user_id=self.user.id,
-            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
             text="Awesome",
             is_draft=False,
             license_id=self.license.id,
         )
-        db_review.hide(review["id"])
+        db_review.set_hidden_state(review["id"], is_hidden="True")
         review = db_review.get_by_id(review["id"])
         self.assertEqual(review["is_hidden"], True)
-        db_review.unhide(review["id"])
+        db_review.set_hidden_state(review["id"], is_hidden="False")
         review = db_review.get_by_id(review["id"])
         self.assertEqual(review["is_hidden"], False)
 
@@ -194,7 +202,8 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(count, 0)
         review = db_review.create(
             user_id=self.user.id,
-            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
             text="Awesome",
             is_draft=False,
             license_id=self.license.id,

--- a/critiquebrainz/db/review_test.py
+++ b/critiquebrainz/db/review_test.py
@@ -1,0 +1,190 @@
+from critiquebrainz.data.testing import DataTestCase
+from critiquebrainz.data import db
+import critiquebrainz.db.users as db_users
+from critiquebrainz.db.user import User
+from werkzeug.exceptions import BadRequest
+from critiquebrainz.data.model.license import License
+import critiquebrainz.db.review as db_review
+import critiquebrainz.db.revision as db_revision
+
+class ReviewTestCase(DataTestCase):
+
+    def setUp(self):
+        super(ReviewTestCase, self).setUp()
+
+        # Review needs user
+        self.user = User(db_users.get_or_create("Tester", new_user_data={
+            "display_name": "test user",
+        }))
+        # And license
+        self.license = License(id=u"Test", full_name=u'Test License')
+        db.session.add(self.license)
+        db.session.commit()
+
+    def test_review_creation(self):
+        review = db_review.create(
+           user_id=self.user.id,
+           release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+           text="Testing",
+           is_draft=False,
+           license_id=self.license.id,
+        )
+        reviews, count = db_review.list()
+        self.assertEqual(count, 1)
+        self.assertEqual(reviews[0]["id"], review["id"])
+        self.assertEqual(reviews[0]["entity_id"], review["entity_id"])
+        self.assertEqual(reviews[0]["license_id"], review["license_id"])
+
+    def test_review_deletion(self):
+        review = db_review.create(
+            user_id=self.user.id,
+            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            text="Testing",
+            is_draft=False,
+            license_id=self.license.id,
+        )
+        self.assertEqual(db_review.list()[1], 1)
+        db_review.delete(review["id"])
+        self.assertEqual(db_review.list()[1], 0)
+
+    def test_languages(self):
+        review_en = db_review.create(
+            user_id=self.user.id,
+            release_group='e7aad618-fa86-3983-9e77-405e21796ece',
+            text="Testing",
+            is_draft=False,
+            license_id=self.license.id,
+            language='en',
+        )
+
+        review_de = db_review.create(
+            user_id=self.user.id,
+            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            text="Testing",
+            is_draft=False,
+            license_id=self.license.id,
+            language='de',
+        )
+        reviews, count = db_review.list(language='de')
+        self.assertEqual(len(reviews), 1)
+        self.assertEqual(count, 1)
+
+        reviews, count = db_review.list(language='ru')
+        self.assertEqual(count, 0)
+
+    def test_update(self):
+        review = db_review.create(
+            user_id=self.user.id,
+            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            text="Testing",
+            is_draft=True,
+            license_id=self.license.id,
+        )
+        another_license = License(id="License-2", full_name="Another License")
+        db.session.add(another_license)
+        db.session.commit()
+        review = db_review.update(
+            review["id"],
+            review["is_draft"],
+            text="Bad update",
+            is_draft=False,
+            license_id=another_license.id,
+            language='es',
+        )
+        # Checking if contents are updated
+        retrieved_review = db_review.list()[0][0]
+        self.assertEqual(retrieved_review["text"], "Bad update")
+        self.assertFalse(retrieved_review["is_draft"])
+        self.assertEqual(retrieved_review["license_id"], another_license.id)
+        self.assertEqual(retrieved_review["language"], 'es')
+
+        # Updating should create a new revision.
+        revisions = db_revision.get(retrieved_review["id"], limit=None)
+        self.assertEqual(len(revisions), 2)
+        self.assertEqual(revisions[0], retrieved_review["last_revision"])
+
+        # Checking things that shouldn't be allowed
+        with self.assertRaises(BadRequest):
+            review = db_review.update(
+                review["id"],
+                review["is_draft"],
+                text="Sucks!",
+                license_id=self.license.id,
+            )
+
+        with self.assertRaises(BadRequest):
+            review = db_review.update(
+                review["id"],
+                review["is_draft"],
+                text="Sucks!",
+                is_draft=True,
+            )
+
+    def test_list(self):
+        reviews, count = db_review.list()
+        self.assertEqual(count, 0)
+        self.assertEqual(len(reviews), 0)
+
+        review = db_review.create(
+            user_id=self.user.id,
+            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            text="Awesome",
+            is_draft=False,
+            license_id=self.license.id,
+        )
+        reviews, count = db_review.list()
+        self.assertEqual(count, 1)
+        self.assertEqual(len(reviews), 1)
+        self.assertEqual(reviews[0]["text"], "Awesome")
+
+        review = db_review.update(
+            review["id"],
+            review["is_draft"],
+            text="Beautiful!",
+        )
+        reviews, count = db_review.list()
+        self.assertEqual(count, 1)
+        self.assertEqual(len(reviews), 1)
+        self.assertEqual(reviews[0]["text"], "Beautiful!")
+
+        reviews, count = db_review.list(sort='rating')
+        self.assertEqual(count, 1)
+        self.assertEqual(len(reviews), 1)
+
+        reviews, count = db_review.list(sort='created')
+        self.assertEqual(count, 1)
+        self.assertEqual(len(reviews), 1)
+
+        reviews, count = db_review.list(sort='random')
+        self.assertEqual(count, 1)
+        self.assertEqual(len(reviews), 1)
+
+    def test_get_popular(self):
+        reviews = db_review.get_popular()
+        self.assertEqual(len(reviews), 0)
+
+        new_review = db_review.create(
+            user_id=self.user.id,
+            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            text="Awesome",
+            is_draft=False,
+            license_id=self.license.id,
+        )
+
+        reviews = db_review.get_popular()
+        self.assertEqual(len(reviews), 1)
+
+    def test_hide_and_unhide(self):
+        review = db_review.create(
+            user_id=self.user.id,
+            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            text="Awesome",
+            is_draft=False,
+            license_id=self.license.id,
+        )
+        db_review.hide(review["id"])
+        review = db_review.get_by_id(review["id"])
+        self.assertEqual(review["is_hidden"], True)
+        db_review.unhide(review["id"])
+        review = db_review.get_by_id(review["id"])
+        self.assertEqual(review["is_hidden"], False)

--- a/critiquebrainz/db/review_test.py
+++ b/critiquebrainz/db/review_test.py
@@ -2,10 +2,10 @@ from critiquebrainz.data.testing import DataTestCase
 from critiquebrainz.data import db
 import critiquebrainz.db.users as db_users
 from critiquebrainz.db.user import User
-from werkzeug.exceptions import BadRequest
 from critiquebrainz.data.model.license import License
 import critiquebrainz.db.review as db_review
 import critiquebrainz.db.revision as db_revision
+import critiquebrainz.db.exceptions as db_exceptions
 
 class ReviewTestCase(DataTestCase):
 
@@ -109,7 +109,7 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(revisions[0], retrieved_review["last_revision"])
 
         # Checking things that shouldn't be allowed
-        with self.assertRaises(BadRequest):
+        with self.assertRaises(db_exceptions.BadDataException):
             db_review.update(
                 review_id=retrieved_review["id"],
                 drafted=retrieved_review["is_draft"],
@@ -117,7 +117,7 @@ class ReviewTestCase(DataTestCase):
                 license_id=self.license.id,
             )
         review = db_review.get_by_id(review["id"])
-        with self.assertRaises(BadRequest):
+        with self.assertRaises(db_exceptions.BadDataException):
             db_review.update(
                 review_id=review["id"],
                 drafted=review["is_draft"],
@@ -190,10 +190,10 @@ class ReviewTestCase(DataTestCase):
             is_draft=False,
             license_id=self.license.id,
         )
-        db_review.set_hidden_state(review["id"], is_hidden="True")
+        db_review.set_hidden_state(review["id"], is_hidden=True)
         review = db_review.get_by_id(review["id"])
         self.assertEqual(review["is_hidden"], True)
-        db_review.set_hidden_state(review["id"], is_hidden="False")
+        db_review.set_hidden_state(review["id"], is_hidden=False)
         review = db_review.get_by_id(review["id"])
         self.assertEqual(review["is_hidden"], False)
 

--- a/critiquebrainz/db/review_test.py
+++ b/critiquebrainz/db/review_test.py
@@ -17,14 +17,14 @@ class ReviewTestCase(DataTestCase):
             "display_name": "test user",
         }))
         # And license
-        self.license = License(id=u"Test", full_name=u'Test License')
+        self.license = License(id=u"Test", full_name="Test License")
         db.session.add(self.license)
         db.session.commit()
 
     def test_review_creation(self):
         review = db_review.create(
            user_id=self.user.id,
-           release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+           release_group="e7aad618-fa86-3983-9e77-405e21796eca",
            text="Testing",
            is_draft=False,
            license_id=self.license.id,
@@ -38,7 +38,7 @@ class ReviewTestCase(DataTestCase):
     def test_review_deletion(self):
         review = db_review.create(
             user_id=self.user.id,
-            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
             text="Testing",
             is_draft=False,
             license_id=self.license.id,
@@ -50,32 +50,32 @@ class ReviewTestCase(DataTestCase):
     def test_languages(self):
         review_en = db_review.create(
             user_id=self.user.id,
-            release_group='e7aad618-fa86-3983-9e77-405e21796ece',
+            release_group="e7aad618-fa86-3983-9e77-405e21796ece",
             text="Testing",
             is_draft=False,
             license_id=self.license.id,
-            language='en',
+            language="en",
         )
 
         review_de = db_review.create(
             user_id=self.user.id,
-            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
             text="Testing",
             is_draft=False,
             license_id=self.license.id,
-            language='de',
+            language="de",
         )
-        reviews, count = db_review.list_reviews(language='de')
+        reviews, count = db_review.list_reviews(language="de")
         self.assertEqual(len(reviews), 1)
         self.assertEqual(count, 1)
 
-        reviews, count = db_review.list_reviews(language='ru')
+        reviews, count = db_review.list_reviews(language="ru")
         self.assertEqual(count, 0)
 
     def test_update(self):
         review = db_review.create(
             user_id=self.user.id,
-            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
             text="Testing",
             is_draft=True,
             license_id=self.license.id,
@@ -84,19 +84,19 @@ class ReviewTestCase(DataTestCase):
         db.session.add(another_license)
         db.session.commit()
         review = db_review.update(
-            review["id"],
-            review["is_draft"],
+            review_id=review["id"],
+            drafted=review["is_draft"],
             text="Bad update",
             is_draft=False,
             license_id=another_license.id,
-            language='es',
+            language="es",
         )
         # Checking if contents are updated
         retrieved_review = db_review.list_reviews()[0][0]
         self.assertEqual(retrieved_review["text"], "Bad update")
         self.assertFalse(retrieved_review["is_draft"])
         self.assertEqual(retrieved_review["license_id"], another_license.id)
-        self.assertEqual(retrieved_review["language"], 'es')
+        self.assertEqual(retrieved_review["language"], "es")
 
         # Updating should create a new revision.
         revisions = db_revision.get(retrieved_review["id"], limit=None)
@@ -106,16 +106,16 @@ class ReviewTestCase(DataTestCase):
         # Checking things that shouldn't be allowed
         with self.assertRaises(BadRequest):
             review = db_review.update(
-                review["id"],
-                review["is_draft"],
+                review_id=review["id"],
+                drafted=review["is_draft"],
                 text="Sucks!",
                 license_id=self.license.id,
             )
 
         with self.assertRaises(BadRequest):
             review = db_review.update(
-                review["id"],
-                review["is_draft"],
+                review_id=review["id"],
+                drafted=review["is_draft"],
                 text="Sucks!",
                 is_draft=True,
             )
@@ -127,7 +127,7 @@ class ReviewTestCase(DataTestCase):
 
         review = db_review.create(
             user_id=self.user.id,
-            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
             text="Awesome",
             is_draft=False,
             license_id=self.license.id,
@@ -138,8 +138,8 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(reviews[0]["text"], "Awesome")
 
         review = db_review.update(
-            review["id"],
-            review["is_draft"],
+            review_id=review["id"],
+            drafted=review["is_draft"],
             text="Beautiful!",
         )
         reviews, count = db_review.list_reviews()
@@ -147,15 +147,15 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(len(reviews), 1)
         self.assertEqual(reviews[0]["text"], "Beautiful!")
 
-        reviews, count = db_review.list_reviews(sort='rating')
+        reviews, count = db_review.list_reviews(sort="rating")
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
 
-        reviews, count = db_review.list_reviews(sort='created')
+        reviews, count = db_review.list_reviews(sort="created")
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
 
-        reviews, count = db_review.list_reviews(sort='random')
+        reviews, count = db_review.list_reviews(sort="random")
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
 
@@ -165,7 +165,7 @@ class ReviewTestCase(DataTestCase):
 
         new_review = db_review.create(
             user_id=self.user.id,
-            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
             text="Awesome",
             is_draft=False,
             license_id=self.license.id,
@@ -177,7 +177,7 @@ class ReviewTestCase(DataTestCase):
     def test_hide_and_unhide(self):
         review = db_review.create(
             user_id=self.user.id,
-            release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
             text="Awesome",
             is_draft=False,
             license_id=self.license.id,
@@ -188,3 +188,16 @@ class ReviewTestCase(DataTestCase):
         db_review.unhide(review["id"])
         review = db_review.get_by_id(review["id"])
         self.assertEqual(review["is_hidden"], False)
+
+    def test_get_count(self):
+        count = db_review.get_count()
+        self.assertEqual(count, 0)
+        review = db_review.create(
+            user_id=self.user.id,
+            release_group="e7aad618-fa86-3983-9e77-405e21796eca",
+            text="Awesome",
+            is_draft=False,
+            license_id=self.license.id,
+        )
+        count = db_review.get_count(is_draft=False, is_hidden=False)
+        self.assertEqual(count, 1)

--- a/critiquebrainz/db/review_test.py
+++ b/critiquebrainz/db/review_test.py
@@ -29,7 +29,7 @@ class ReviewTestCase(DataTestCase):
            is_draft=False,
            license_id=self.license.id,
         )
-        reviews, count = db_review.list()
+        reviews, count = db_review.list_reviews()
         self.assertEqual(count, 1)
         self.assertEqual(reviews[0]["id"], review["id"])
         self.assertEqual(reviews[0]["entity_id"], review["entity_id"])
@@ -43,9 +43,9 @@ class ReviewTestCase(DataTestCase):
             is_draft=False,
             license_id=self.license.id,
         )
-        self.assertEqual(db_review.list()[1], 1)
+        self.assertEqual(db_review.list_reviews()[1], 1)
         db_review.delete(review["id"])
-        self.assertEqual(db_review.list()[1], 0)
+        self.assertEqual(db_review.list_reviews()[1], 0)
 
     def test_languages(self):
         review_en = db_review.create(
@@ -65,11 +65,11 @@ class ReviewTestCase(DataTestCase):
             license_id=self.license.id,
             language='de',
         )
-        reviews, count = db_review.list(language='de')
+        reviews, count = db_review.list_reviews(language='de')
         self.assertEqual(len(reviews), 1)
         self.assertEqual(count, 1)
 
-        reviews, count = db_review.list(language='ru')
+        reviews, count = db_review.list_reviews(language='ru')
         self.assertEqual(count, 0)
 
     def test_update(self):
@@ -92,7 +92,7 @@ class ReviewTestCase(DataTestCase):
             language='es',
         )
         # Checking if contents are updated
-        retrieved_review = db_review.list()[0][0]
+        retrieved_review = db_review.list_reviews()[0][0]
         self.assertEqual(retrieved_review["text"], "Bad update")
         self.assertFalse(retrieved_review["is_draft"])
         self.assertEqual(retrieved_review["license_id"], another_license.id)
@@ -120,8 +120,8 @@ class ReviewTestCase(DataTestCase):
                 is_draft=True,
             )
 
-    def test_list(self):
-        reviews, count = db_review.list()
+    def test_list_reviews(self):
+        reviews, count = db_review.list_reviews()
         self.assertEqual(count, 0)
         self.assertEqual(len(reviews), 0)
 
@@ -132,7 +132,7 @@ class ReviewTestCase(DataTestCase):
             is_draft=False,
             license_id=self.license.id,
         )
-        reviews, count = db_review.list()
+        reviews, count = db_review.list_reviews()
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
         self.assertEqual(reviews[0]["text"], "Awesome")
@@ -142,20 +142,20 @@ class ReviewTestCase(DataTestCase):
             review["is_draft"],
             text="Beautiful!",
         )
-        reviews, count = db_review.list()
+        reviews, count = db_review.list_reviews()
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
         self.assertEqual(reviews[0]["text"], "Beautiful!")
 
-        reviews, count = db_review.list(sort='rating')
+        reviews, count = db_review.list_reviews(sort='rating')
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
 
-        reviews, count = db_review.list(sort='created')
+        reviews, count = db_review.list_reviews(sort='created')
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
 
-        reviews, count = db_review.list(sort='random')
+        reviews, count = db_review.list_reviews(sort='random')
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
 

--- a/critiquebrainz/db/revision_test.py
+++ b/critiquebrainz/db/revision_test.py
@@ -38,8 +38,8 @@ class RevisionTestCase(DataTestCase):
         self.assertEqual(type(first_revision['id']), int)
 
         self.review = db_review.update(
-            self.review["id"],
-            self.review["is_draft"],
+            review_id=self.review["id"],
+            drafted=self.review["is_draft"],
             text="Testing Again!",
         )
         second_revision = revision.get(review_id)[0]
@@ -50,8 +50,8 @@ class RevisionTestCase(DataTestCase):
         self.assertEqual(type(second_revision['id']), int)
 
         self.review = db_review.update(
-            self.review["id"],
-            self.review["is_draft"],
+            review_id=self.review["id"],
+            drafted=self.review["is_draft"],
             text="Testing Once Again!",
         )
         # Testing offset and limit
@@ -81,8 +81,8 @@ class RevisionTestCase(DataTestCase):
         rev_num = revision.get_revision_number(self.review["id"], self.review["last_revision"]["id"])
         self.assertEqual(rev_num, 1)
         self.review = db_review.update(
-            self.review["id"],
-            self.review["is_draft"],
+            review_id=self.review["id"],
+            drafted=self.review["is_draft"],
             text="Updated this review",
         )
         rev_num = revision.get_revision_number(self.review["id"], self.review["last_revision"]["id"])

--- a/critiquebrainz/db/revision_test.py
+++ b/critiquebrainz/db/revision_test.py
@@ -1,7 +1,6 @@
 from critiquebrainz.data.testing import DataTestCase
 from critiquebrainz.data import db
 import critiquebrainz.db.review as db_review
-
 from critiquebrainz.data.model.user import User
 from critiquebrainz.db import revision
 from critiquebrainz.db import vote
@@ -26,7 +25,7 @@ class RevisionTestCase(DataTestCase):
             entity_type="release_group",
             text=u"Testing!",
             is_draft=False,
-            license_id=self.license.id,
+            license_id=self.license["id"],
         )
 
     def test_get_and_count(self):

--- a/critiquebrainz/db/revision_test.py
+++ b/critiquebrainz/db/revision_test.py
@@ -19,11 +19,14 @@ class RevisionTestCase(DataTestCase):
         db.session.add(self.license)
         db.session.commit()
 
-        self.review = db_review.create(user_id=self.author.id,
-                                    release_group='e7aad618-fa86-3983-9e77-405e21796eca',
-                                    text=u"Testing!",
-                                    is_draft=False,
-                                    license_id=self.license.id)
+        self.review = db_review.create(
+            user_id=self.author.id,
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
+            text=u"Testing!",
+            is_draft=False,
+            license_id=self.license.id,
+        )
 
     def test_get_and_count(self):
         """Test the get function that gets revisions for the test review ordered by the timestamp
@@ -37,7 +40,7 @@ class RevisionTestCase(DataTestCase):
         self.assertEqual(type(first_revision['timestamp']), datetime)
         self.assertEqual(type(first_revision['id']), int)
 
-        self.review = db_review.update(
+        db_review.update(
             review_id=self.review["id"],
             drafted=self.review["is_draft"],
             text="Testing Again!",
@@ -49,7 +52,7 @@ class RevisionTestCase(DataTestCase):
         self.assertEqual(type(second_revision['timestamp']), datetime)
         self.assertEqual(type(second_revision['id']), int)
 
-        self.review = db_review.update(
+        db_review.update(
             review_id=self.review["id"],
             drafted=self.review["is_draft"],
             text="Testing Once Again!",
@@ -80,10 +83,11 @@ class RevisionTestCase(DataTestCase):
         """Test to get the revision number of a revision of a specified review."""
         rev_num = revision.get_revision_number(self.review["id"], self.review["last_revision"]["id"])
         self.assertEqual(rev_num, 1)
-        self.review = db_review.update(
+        db_review.update(
             review_id=self.review["id"],
             drafted=self.review["is_draft"],
             text="Updated this review",
         )
+        self.review = db_review.get_by_id(self.review["id"])
         rev_num = revision.get_revision_number(self.review["id"], self.review["last_revision"]["id"])
         self.assertEqual(rev_num, 2)

--- a/critiquebrainz/db/spam_report_test.py
+++ b/critiquebrainz/db/spam_report_test.py
@@ -3,7 +3,6 @@ from critiquebrainz.db.user import User
 import critiquebrainz.db.spam_report as db_spam_report
 import critiquebrainz.db.review as db_review
 import critiquebrainz.db.license as db_license
-
 import critiquebrainz.db.users as db_users
 
 
@@ -30,7 +29,7 @@ class SpamReportTestCase(DataTestCase):
             text="Testing!",
             user_id=author.id,
             is_draft=False,
-            license_id=license.id,
+            license_id=license["id"],
         )
         self.revision_id = self.review["last_revision"]["id"]
         self.report = db_spam_report.create(self.revision_id, self.user1.id, "To test is this report")

--- a/critiquebrainz/db/spam_report_test.py
+++ b/critiquebrainz/db/spam_report_test.py
@@ -24,11 +24,12 @@ class SpamReportTestCase(DataTestCase):
         db.session.add(license)
         db.session.commit()
         self.review = db_review.create(
-                release_group='e7aad618-fa86-3983-9e77-405e21796eca',
-                text="Testing!",
-                user_id=author.id,
-                is_draft=False,
-                license_id=license.id,
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
+            text="Testing!",
+            user_id=author.id,
+            is_draft=False,
+            license_id=license.id,
         )
         self.revision_id = self.review["last_revision"]["id"]
         self.report = db_spam_report.create(self.revision_id, self.user1.id, "To test is this report")
@@ -56,11 +57,12 @@ class SpamReportTestCase(DataTestCase):
 
     def test_list_reports(self):
         report1 = db_spam_report.create(self.revision_id, self.user2.id, "This is a report")
-        self.review = db_review.update(
+        db_review.update(
             review_id=self.review["id"],
             drafted=self.review["is_draft"],
             text="Updated Review",
         )
+        self.review = db_review.get_by_id(self.review["id"])
         report2 = db_spam_report.create(self.review["last_revision"]["id"], self.user1.id, "This is again a report on the updated review")
         # two reports on the old revision and one on the new revision.
         reports, count = db_spam_report.list_reports(review_id=self.review["id"])

--- a/critiquebrainz/db/spam_report_test.py
+++ b/critiquebrainz/db/spam_report_test.py
@@ -57,8 +57,8 @@ class SpamReportTestCase(DataTestCase):
     def test_list_reports(self):
         report1 = db_spam_report.create(self.revision_id, self.user2.id, "This is a report")
         self.review = db_review.update(
-            self.review["id"],
-            self.review["is_draft"],
+            review_id=self.review["id"],
+            drafted=self.review["is_draft"],
             text="Updated Review",
         )
         report2 = db_spam_report.create(self.review["last_revision"]["id"], self.user1.id, "This is again a report on the updated review")

--- a/critiquebrainz/db/spam_report_test.py
+++ b/critiquebrainz/db/spam_report_test.py
@@ -2,7 +2,7 @@ from critiquebrainz.data.testing import DataTestCase
 from critiquebrainz.data import db
 from critiquebrainz.db.user import User
 import critiquebrainz.db.spam_report as db_spam_report
-from critiquebrainz.data.model.review import Review
+import critiquebrainz.db.review as db_review
 from critiquebrainz.data.model.license import License
 import critiquebrainz.db.users as db_users
 
@@ -23,14 +23,14 @@ class SpamReportTestCase(DataTestCase):
         license = License(id='Test', full_name='Test License')
         db.session.add(license)
         db.session.commit()
-        self.review = Review.create(
+        self.review = db_review.create(
                 release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                 text="Testing!",
                 user_id=author.id,
                 is_draft=False,
                 license_id=license.id,
         )
-        self.revision_id = self.review.last_revision.id
+        self.revision_id = self.review["last_revision"]["id"]
         self.report = db_spam_report.create(self.revision_id, self.user1.id, "To test is this report")
         self.report_time = self.report["reported_at"]
 
@@ -56,17 +56,21 @@ class SpamReportTestCase(DataTestCase):
 
     def test_list_reports(self):
         report1 = db_spam_report.create(self.revision_id, self.user2.id, "This is a report")
-        self.review.update(text="Updated Review")
-        report2 = db_spam_report.create(self.review.last_revision.id, self.user1.id, "This is again a report on the updated review")
+        self.review = db_review.update(
+            self.review["id"],
+            self.review["is_draft"],
+            text="Updated Review",
+        )
+        report2 = db_spam_report.create(self.review["last_revision"]["id"], self.user1.id, "This is again a report on the updated review")
         # two reports on the old revision and one on the new revision.
-        reports, count = db_spam_report.list_reports(review_id=self.review.id)
+        reports, count = db_spam_report.list_reports(review_id=self.review["id"])
         self.assertEqual(count, 3)
         # get all reports by a user.
         reports, count = db_spam_report.list_reports(user_id=self.user2.id)
         self.assertEqual(count, 1)
         # archive and include all archived reports.
         # there must be two reports including the archived one.
-        db_spam_report.archive(self.user1.id, self.review.last_revision.id)
+        db_spam_report.archive(self.user1.id, self.review["last_revision"]["id"])
         reports, count = db_spam_report.list_reports(inc_archived=True)
         self.assertEqual(count, 3)
         # there must be one reports excluding the archived one.

--- a/critiquebrainz/db/users.py
+++ b/critiquebrainz/db/users.py
@@ -477,7 +477,7 @@ def get_reviews(user_id, from_date='1-1-1970'):
             "license_id": (str),
             "language": (str),
             "source": (str),
-            "source_url" (str)
+            "source_url":(str),
         }
     """
     with db.engine.connect() as connection:

--- a/critiquebrainz/db/users_test.py
+++ b/critiquebrainz/db/users_test.py
@@ -3,7 +3,7 @@ from critiquebrainz.db.user import User
 from critiquebrainz.data import db
 import critiquebrainz.db.users as db_users
 from critiquebrainz.db.users import gravatar_url, get_many_by_mb_username
-from critiquebrainz.data.model.review import Review
+import critiquebrainz.db.review as db_review
 from critiquebrainz.data.model.spam_report import SpamReport
 from critiquebrainz.data.model.license import License
 import critiquebrainz.db.vote as db_vote
@@ -25,17 +25,17 @@ class UserTestCase(DataTestCase):
         license = License(id='Test', full_name='Test License')
         db.session.add(license)
         db.session.commit()
-        self.review = Review.create(
+        self.review = db_review.create(
                 release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                 text="Testing!",
                 user_id=self.author.id,
                 is_draft=False,
                 license_id=license.id,
         )
-        vote = db_vote.submit(self.user1.id, self.review.last_revision.id, True)
-        self.review_created = self.review.last_revision.timestamp
-        self.review_id = self.review.id
-        self.revision_id = self.review.last_revision.id
+        vote = db_vote.submit(self.user1.id, self.review["last_revision"]["id"], True)
+        self.review_created = self.review["last_revision"]["timestamp"]
+        self.review_id = self.review["id"]
+        self.revision_id = self.review["last_revision"]["id"]
         self.report = SpamReport.create(self.revision_id, self.user1.id, "Testing Reason Report")
 
     def test_get_many_by_mb_username(self):
@@ -91,9 +91,9 @@ class UserTestCase(DataTestCase):
         self.assertEqual(user['is_blocked'], False)
 
     def test_vote(self):
-        voted = db_users.has_voted(self.user1.id, self.review.id)
+        voted = db_users.has_voted(self.user1.id, self.review["id"])
         self.assertEqual(voted, True)
-        voted = db_users.has_voted(self.user2.id, self.review.id)
+        voted = db_users.has_voted(self.user2.id, self.review["id"])
         self.assertEqual(voted, False)
 
     def test_karma(self):

--- a/critiquebrainz/db/users_test.py
+++ b/critiquebrainz/db/users_test.py
@@ -26,7 +26,8 @@ class UserTestCase(DataTestCase):
         db.session.add(license)
         db.session.commit()
         self.review = db_review.create(
-                release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+                entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+                entity_type="release_group",
                 text="Testing!",
                 user_id=self.author.id,
                 is_draft=False,
@@ -118,7 +119,11 @@ class UserTestCase(DataTestCase):
     def test_get_reviews(self):
         reviews = db_users.get_reviews(self.author.id)
         self.assertEqual(len(reviews), 1)
-        self.review.update(text="Testing Again")
+        db_review.update(
+            review_id=self.review["id"],
+            drafted=self.review["is_draft"],
+            text="Testing Again",
+        )
         reviews = db_users.get_reviews(self.author.id)
         self.assertEqual(len(reviews), 1)
         self.assertEqual(reviews[0]['creation_time'], self.review_created)

--- a/critiquebrainz/db/users_test.py
+++ b/critiquebrainz/db/users_test.py
@@ -31,7 +31,7 @@ class UserTestCase(DataTestCase):
                 text="Testing!",
                 user_id=self.author.id,
                 is_draft=False,
-                license_id=license.id,
+                license_id=license["id"],
         )
         db_vote.submit(self.user1.id, self.review["last_revision"]["id"], True)
         self.review_created = self.review["last_revision"]["timestamp"]

--- a/critiquebrainz/db/users_test.py
+++ b/critiquebrainz/db/users_test.py
@@ -32,7 +32,7 @@ class UserTestCase(DataTestCase):
                 is_draft=False,
                 license_id=license.id,
         )
-        vote = db_vote.submit(self.user1.id, self.review["last_revision"]["id"], True)
+        db_vote.submit(self.user1.id, self.review["last_revision"]["id"], True)
         self.review_created = self.review["last_revision"]["timestamp"]
         self.review_id = self.review["id"]
         self.revision_id = self.review["last_revision"]["id"]

--- a/critiquebrainz/db/vote.py
+++ b/critiquebrainz/db/vote.py
@@ -56,6 +56,7 @@ def submit(user_id, revision_id, vote):
             "vote": vote,
             "rated_at": datetime.utcnow(),
         })
+        return get(user_id, revision_id)
 
 
 def delete(user_id, revision_id):

--- a/critiquebrainz/db/vote.py
+++ b/critiquebrainz/db/vote.py
@@ -56,7 +56,6 @@ def submit(user_id, revision_id, vote):
             "vote": vote,
             "rated_at": datetime.utcnow(),
         })
-        return get(user_id, revision_id)
 
 
 def delete(user_id, revision_id):

--- a/critiquebrainz/db/vote_test.py
+++ b/critiquebrainz/db/vote_test.py
@@ -3,7 +3,7 @@ from critiquebrainz.data import db
 from critiquebrainz.data.model.vote import Vote
 from critiquebrainz.db.user import User
 import critiquebrainz.db.users as db_users
-from critiquebrainz.data.model.review import Review
+import critiquebrainz.db.review as db_review
 from critiquebrainz.data.model.license import License
 from critiquebrainz.db import exceptions
 from critiquebrainz.db import vote
@@ -27,7 +27,7 @@ class VoteTestCase(DataTestCase):
         license = License(id='Test', full_name='Test License')
         db.session.add(license)
         db.session.commit()
-        self.review = Review.create(release_group='e7aad618-fa86-3983-9e77-405e21796eca',
+        self.review = db_review.create(release_group='e7aad618-fa86-3983-9e77-405e21796eca',
                                text="Testing!",
                                user_id=author.id,
                                is_draft=False,
@@ -35,26 +35,26 @@ class VoteTestCase(DataTestCase):
 
     def test_get_missing(self):
         with self.assertRaises(exceptions.NoDataFoundException):
-            vote.get(self.user_1.id, self.review.last_revision.id)
+            vote.get(self.user_1.id, self.review["last_revision"]["id"])
 
     def test_get(self):
-        vote_1 = Vote.create(self.user_1.id, self.review, True)
-        vote_1_data = vote.get(self.user_1.id, self.review.last_revision.id)
+        vote_1 = vote.submit(self.user_1.id, self.review["last_revision"]["id"], True)
+        vote_1_data = vote.get(self.user_1.id, self.review["last_revision"]["id"])
         self.assertDictEqual(vote_1_data, {
-                "user_id": UUID(vote_1.user_id),
-                "revision_id": vote_1.revision_id,
+                "user_id": vote_1["user_id"],
+                "revision_id": vote_1["revision_id"],
                 "vote": True,
-                "rated_at": vote_1.rated_at
+                "rated_at": vote_1["rated_at"],
             })
         self.assertEqual(type(vote_1_data["user_id"]), UUID)
         self.assertEqual(type(vote_1_data["revision_id"]), int)
         self.assertEqual(type(vote_1_data["rated_at"]), datetime)
 
-        vote_2 = Vote.create(self.user_2.id, self.review, False)
-        vote_2_data = vote.get(self.user_2.id, self.review.last_revision.id)
+        vote_2 = vote.submit(self.user_2.id, self.review["last_revision"]["id"], False)
+        vote_2_data = vote.get(self.user_2.id, self.review["last_revision"]["id"])
         self.assertDictEqual(vote_2_data, {
-            "user_id": UUID(vote_2.user_id),
-            "revision_id": vote_2.revision_id,
+            "user_id": vote_2["user_id"],
+            "revision_id": vote_2["revision_id"],
             "vote": False,
-            "rated_at": vote_2.rated_at
+            "rated_at": vote_2["rated_at"]
         })

--- a/critiquebrainz/db/vote_test.py
+++ b/critiquebrainz/db/vote_test.py
@@ -38,23 +38,23 @@ class VoteTestCase(DataTestCase):
             vote.get(self.user_1.id, self.review["last_revision"]["id"])
 
     def test_get(self):
-        vote_1 = vote.submit(self.user_1.id, self.review["last_revision"]["id"], True)
+        vote.submit(self.user_1.id, self.review["last_revision"]["id"], True)
         vote_1_data = vote.get(self.user_1.id, self.review["last_revision"]["id"])
+        rated_at = vote_1_data.pop("rated_at")
         self.assertDictEqual(vote_1_data, {
-                "user_id": vote_1["user_id"],
-                "revision_id": vote_1["revision_id"],
-                "vote": True,
-                "rated_at": vote_1["rated_at"],
-            })
+            "user_id": UUID(self.user_1.id),
+            "revision_id": self.review["last_revision"]["id"],
+            "vote": True,
+        })
         self.assertEqual(type(vote_1_data["user_id"]), UUID)
         self.assertEqual(type(vote_1_data["revision_id"]), int)
-        self.assertEqual(type(vote_1_data["rated_at"]), datetime)
+        self.assertEqual(type(rated_at), datetime)
 
-        vote_2 = vote.submit(self.user_2.id, self.review["last_revision"]["id"], False)
+        vote.submit(self.user_2.id, self.review["last_revision"]["id"], False)
         vote_2_data = vote.get(self.user_2.id, self.review["last_revision"]["id"])
+        rated_at = vote_2_data.pop("rated_at")
         self.assertDictEqual(vote_2_data, {
-            "user_id": vote_2["user_id"],
-            "revision_id": vote_2["revision_id"],
+            "user_id": UUID(self.user_2.id),
+            "revision_id": self.review["last_revision"]["id"],
             "vote": False,
-            "rated_at": vote_2["rated_at"]
         })

--- a/critiquebrainz/db/vote_test.py
+++ b/critiquebrainz/db/vote_test.py
@@ -33,7 +33,7 @@ class VoteTestCase(DataTestCase):
             text="Testing!",
             user_id=author.id,
             is_draft=False,
-            license_id=license.id,
+            license_id=license["id"],
         )
 
     def test_get_missing(self):

--- a/critiquebrainz/db/vote_test.py
+++ b/critiquebrainz/db/vote_test.py
@@ -27,11 +27,14 @@ class VoteTestCase(DataTestCase):
         license = License(id='Test', full_name='Test License')
         db.session.add(license)
         db.session.commit()
-        self.review = db_review.create(release_group='e7aad618-fa86-3983-9e77-405e21796eca',
-                               text="Testing!",
-                               user_id=author.id,
-                               is_draft=False,
-                               license_id=license.id)
+        self.review = db_review.create(
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
+            text="Testing!",
+            user_id=author.id,
+            is_draft=False,
+            license_id=license.id
+        )
 
     def test_get_missing(self):
         with self.assertRaises(exceptions.NoDataFoundException):

--- a/critiquebrainz/frontend/views/artist.py
+++ b/critiquebrainz/frontend/views/artist.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, request, redirect, url_for
 from flask_babel import gettext
 from werkzeug.exceptions import BadRequest, NotFound
 from critiquebrainz.frontend.external import musicbrainz
-from critiquebrainz.data.model.review import Review
+import critiquebrainz.db.review as db_review
 from collections import OrderedDict
 
 artist_bp = Blueprint('artist', __name__)
@@ -35,7 +35,7 @@ def entity(mbid):
                                                               limit=limit, offset=offset)
     for release_group in release_groups:
         # TODO(roman): Count reviews instead of fetching them.
-        reviews, review_count = Review.list(entity_id=release_group['id'], entity_type='release_group', sort='created', limit=1)
+        reviews, review_count = db_review.list_reviews(entity_id=release_group['id'], entity_type='release_group', sort='created', limit=1)
         release_group['review_count'] = review_count
 
     return render_template(

--- a/critiquebrainz/frontend/views/event.py
+++ b/critiquebrainz/frontend/views/event.py
@@ -4,7 +4,7 @@ from flask import Blueprint, render_template, request
 from flask_login import current_user
 from flask_babel import gettext
 from critiquebrainz.frontend.external import musicbrainz
-from critiquebrainz.data.model.review import Review
+import critiquebrainz.db.review as db_review
 from werkzeug.exceptions import NotFound
 
 
@@ -23,7 +23,7 @@ def entity(id):
         event['artists_grouped'] = groupby(artists_sorted, itemgetter('type'))
 
     if current_user.is_authenticated:
-        my_reviews, my_count = Review.list(entity_id=id, entity_type='event', user_id=current_user.id)
+        my_reviews, my_count = db_review.list_reviews(entity_id=id, entity_type='event', user_id=current_user.id)
         if my_count != 0:
             my_review = my_reviews[0]
         else:
@@ -33,7 +33,7 @@ def entity(id):
 
     limit = int(request.args.get('limit', default=10))
     offset = int(request.args.get('offset', default=0))
-    reviews, count = Review.list(entity_id=id, entity_type='event', sort='rating', limit=limit, offset=offset)
+    reviews, count = db_review.list_reviews(entity_id=id, entity_type='event', sort='rating', limit=limit, offset=offset)
 
     return render_template('event/entity.html', id=id, event=event, reviews=reviews,
                            my_review=my_review, limit=limit, offset=offset, count=count)

--- a/critiquebrainz/frontend/views/index.py
+++ b/critiquebrainz/frontend/views/index.py
@@ -23,7 +23,7 @@ def index():
     recent_reviews, _ = db_review.list_reviews(sort='created', limit=9)
 
     # Statistics
-    review_count = format_number(db_review.get_count(is_draft = False))
+    review_count = format_number(db_review.get_count(is_draft=False))
     user_count = format_number(db_users.total_count())
 
     return render_template('index/index.html', popular_reviews=popular_reviews, recent_reviews=recent_reviews,

--- a/critiquebrainz/frontend/views/index.py
+++ b/critiquebrainz/frontend/views/index.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template
 from flask_babel import format_number
 import critiquebrainz.db.users as db_users
-from critiquebrainz.data.model.review import Review
+import critiquebrainz.db.review as db_review
 from bs4 import BeautifulSoup
 from markdown import markdown
 
@@ -13,17 +13,17 @@ frontend_bp = Blueprint('frontend', __name__)
 @frontend_bp.route('/')
 def index():
     # Popular reviews
-    popular_reviews = Review.get_popular(6)
+    popular_reviews = db_review.get_popular(6)
     for review in popular_reviews:
         # Preparing text for preview
         preview = markdown(review['text'], safe_mode="escape")
         review['preview'] = ''.join(BeautifulSoup(preview, "html.parser").findAll(text=True))
 
     # Recent reviews
-    recent_reviews, _ = Review.list(sort='created', limit=9)
+    recent_reviews, _ = db_review.list_reviews(sort='created', limit=9)
 
     # Statistics
-    review_count = format_number(Review.get_count(is_draft = False))
+    review_count = format_number(db_review.get_count(is_draft = False))
     user_count = format_number(db_users.total_count())
 
     return render_template('index/index.html', popular_reviews=popular_reviews, recent_reviews=recent_reviews,

--- a/critiquebrainz/frontend/views/place.py
+++ b/critiquebrainz/frontend/views/place.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, request
 from flask_login import current_user
 from flask_babel import gettext
 from critiquebrainz.frontend.external import musicbrainz
-from critiquebrainz.data.model.review import Review
+import critiquebrainz.db.review as db_review
 from werkzeug.exceptions import NotFound
 
 place_bp = Blueprint('place', __name__)
@@ -16,7 +16,7 @@ def entity(id):
         raise NotFound(gettext("Sorry, we couldn't find a place with that MusicBrainz ID."))
 
     if current_user.is_authenticated:
-        my_reviews, my_count = Review.list(entity_id=id, entity_type='place', user_id=current_user.id)
+        my_reviews, my_count = db_review.list_reviews(entity_id=id, entity_type='place', user_id=current_user.id)
         if my_count != 0:
             my_review = my_reviews[0]
         else:
@@ -26,7 +26,7 @@ def entity(id):
 
     limit = int(request.args.get('limit', default=10))
     offset = int(request.args.get('offset', default=0))
-    reviews, count = Review.list(entity_id=id, entity_type='place', sort='rating', limit=limit, offset=offset)
+    reviews, count = db_review.list_reviews(entity_id=id, entity_type='place', sort='rating', limit=limit, offset=offset)
 
     return render_template('place/entity.html', id=id, place=place, reviews=reviews,
                            my_review=my_review, limit=limit, offset=offset, count=count)

--- a/critiquebrainz/frontend/views/release_group.py
+++ b/critiquebrainz/frontend/views/release_group.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, request
 from flask_login import current_user
 from flask_babel import gettext
 from critiquebrainz.frontend.external import musicbrainz, mbspotify, soundcloud
-from critiquebrainz.data.model.review import Review
+import critiquebrainz.db.review as db_review
 from werkzeug.exceptions import NotFound
 
 
@@ -31,14 +31,14 @@ def entity(id):
     limit = int(request.args.get('limit', default=10))
     offset = int(request.args.get('offset', default=0))
     if current_user.is_authenticated:
-        my_reviews, my_count = Review.list(entity_id=id, entity_type='release_group', user_id=current_user.id)
+        my_reviews, my_count = db_review.list_reviews(entity_id=id, entity_type='release_group', user_id=current_user.id)
         if my_count != 0:
             my_review = my_reviews[0]
         else:
             my_review = None
     else:
         my_review = None
-    reviews, count = Review.list(entity_id=id, entity_type='release_group', sort='rating', limit=limit, offset=offset)
+    reviews, count = db_review.list_reviews(entity_id=id, entity_type='release_group', sort='rating', limit=limit, offset=offset)
     return render_template('release_group/entity.html', id=id, release_group=release_group, reviews=reviews,
                            release=release, my_review=my_review, spotify_mappings=spotify_mappings, tags=tags,
                            soundcloud_url=soundcloud_url, limit=limit, offset=offset, count=count)

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -1,5 +1,4 @@
 from math import ceil
-
 from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify, abort
 from flask_babel import gettext, get_locale, lazy_gettext
 from flask_login import login_required, current_user
@@ -23,7 +22,6 @@ import critiquebrainz.db.moderation_log as db_moderation_log
 
 
 review_bp = Blueprint('review', __name__)
-
 RESULTS_LIMIT = 10
 
 
@@ -37,7 +35,7 @@ def get_review_or_404(review_id):
 
 
 @review_bp.route('/')
-def browse(): 
+def browse():
     entity_type = request.args.get('entity_type', default=None)
     if entity_type == 'all':
         entity_type = None

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -1,6 +1,6 @@
 from math import ceil
 
-from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify
+from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify, abort
 from flask_babel import gettext, get_locale
 from flask_login import login_required, current_user
 from markdown import markdown
@@ -8,7 +8,7 @@ from sqlalchemy import desc
 from werkzeug.exceptions import Unauthorized, NotFound, Forbidden, BadRequest
 
 from critiquebrainz.data.model.moderation_log import ModerationLog, ACTION_HIDE_REVIEW
-from critiquebrainz.data.model.review import Review, ENTITY_TYPES
+from critiquebrainz.db.review import ENTITY_TYPES
 from critiquebrainz.data.model.revision import Revision
 from critiquebrainz.data.model.vote import Vote
 from critiquebrainz.db import vote as db_vote, exceptions as db_exceptions, revision as db_revision
@@ -19,6 +19,7 @@ from critiquebrainz.frontend.forms.review import ReviewCreateForm, ReviewEditFor
 from critiquebrainz.frontend.login import admin_view
 from critiquebrainz.utils import side_by_side_diff
 import critiquebrainz.db.spam_report as db_spam_report
+import critiquebrainz.db.review as db_review
 
 review_bp = Blueprint('review', __name__)
 
@@ -32,7 +33,7 @@ def browse():
         return redirect(url_for('.browse'))
     limit = 3 * 9  # 9 rows
     offset = (page - 1) * limit
-    reviews, count = Review.list(sort='created', limit=limit, offset=offset)
+    reviews, count = db_review.list_reviews(sort='created', limit=limit, offset=offset)
 
     if not reviews:
         if page - 1 > count / limit:
@@ -41,7 +42,7 @@ def browse():
             raise NotFound(gettext("No reviews to display."))
 
     # Loading info about entities for reviews
-    entities = [(review.entity_id, review.entity_type) for review in reviews]
+    entities = [(review["entity_id"], review["entity_type"]) for review in reviews]
     entities_info = musicbrainz.get_multiple_entities(entities)
 
     return render_template('review/browse.html', reviews=reviews, entities=entities_info,
@@ -51,12 +52,15 @@ def browse():
 @review_bp.route('/<uuid:id>/revisions/<int:rev>')
 @review_bp.route('/<uuid:id>')
 def entity(id, rev=None):
-    review = Review.query.get_or_404(str(id))
+    try:
+        review = db_review.get_by_id(id)
+    except db_exceptions.NoDataFoundException:
+        abort(404)
     # Not showing review if it isn't published yet and not viewed by author.
-    if review.is_draft and not (current_user.is_authenticated
-                                and current_user == review.user):
+    if review["is_draft"] and not (current_user.is_authenticated
+                                and current_user == review["user"]):
         raise NotFound(gettext("Can't find a review with the specified ID."))
-    if review.is_hidden:
+    if review["is_hidden"]:
         if not current_user.is_admin():
             raise Forbidden(gettext("Review has been hidden. "
                                     "You need to be an administrator to view it."))
@@ -65,9 +69,9 @@ def entity(id, rev=None):
 
     spotify_mappings = None
     soundcloud_url = None
-    if review.entity_type == 'release_group':
-        spotify_mappings = mbspotify.mappings(review.entity_id)
-        soundcloud_url = soundcloud.get_url(review.entity_id)
+    if review["entity_type"] == 'release_group':
+        spotify_mappings = mbspotify.mappings(str(review["entity_id"]))
+        soundcloud_url = soundcloud.get_url(str(review["entity_id"]))
     count = db_revision.get_count(id)
     if not rev:
         rev = count
@@ -77,18 +81,18 @@ def entity(id, rev=None):
         raise NotFound(gettext("The revision you are looking for does not exist."))
 
     revision = db_revision.get(id, offset=count-rev)[0]
-    if not review.is_draft and current_user.is_authenticated:  # if user is logged in, get their vote for this review
+    if not review["is_draft"] and current_user.is_authenticated:  # if user is logged in, get their vote for this review
         try:
             vote = db_vote.get(user_id=current_user.id, revision_id=revision['id'])
         except db_exceptions.NoDataFoundException:
             vote = None
     else:  # otherwise set vote to None, its value will not be used
         vote = None
-    review.text_html = markdown(revision['text'], safe_mode="escape")
+    review["text_html"] = markdown(revision['text'], safe_mode="escape")
 
-    user_all_reviews, review_count = Review.list(user_id=review.user_id, sort="random", exclude=[review.id])
+    user_all_reviews, review_count = db_review.list_reviews(user_id=review["user_id"], sort="random", exclude=[review["id"]])
     other_reviews = user_all_reviews[:3]
-    return render_template('review/entity/%s.html' % review.entity_type, review=review, spotify_mappings=spotify_mappings, soundcloud_url=soundcloud_url, vote=vote, other_reviews=other_reviews)
+    return render_template('review/entity/%s.html' % review["entity_type"], review=review, spotify_mappings=spotify_mappings, soundcloud_url=soundcloud_url, vote=vote, other_reviews=other_reviews)
 
 @review_bp.route('/<uuid:review_id>/revision/<int:revision_id>')
 def redirect_to_entity(review_id, revision_id):
@@ -100,11 +104,14 @@ def redirect_to_entity(review_id, revision_id):
 
 @review_bp.route('/<uuid:id>/revisions/compare')
 def compare(id):
-    review = Review.query.get_or_404(str(id))
-    if review.is_draft and not (current_user.is_authenticated
+    try:
+        review = db_review.get_by_id(id)
+    except db_exceptions.NoDataFoundException:
+        abort(404)
+    if review["is_draft"] and not (current_user.is_authenticated
                                 and current_user == review.user):
         raise NotFound(gettext("Can't find a review with the specified ID."))
-    if review.is_hidden and not current_user.is_admin():
+    if review["is_hidden"] and not current_user.is_admin():
         raise NotFound(gettext("Review has been hidden."))
     count = db_revision.get_count(id)
     old, new = int(request.args.get('old') or count - 1), int(request.args.get('new') or count)
@@ -121,33 +128,39 @@ def compare(id):
 
 @review_bp.route('/<uuid:id>/revisions')
 def revisions(id):
-    review = Review.query.get_or_404(str(id))
+    try:
+        review = db_review.get_by_id(id)
+    except db_exceptions.NoDataFoundException:
+        abort(404)
 
     # Not showing review if it isn't published yet and not viewed by author.
-    if review.is_draft and not (current_user.is_authenticated
-                                and current_user == review.user):
+    if review["is_draft"] and not (current_user.is_authenticated
+                                and current_user == review["user"]):
         raise NotFound("Can't find a review with the specified ID.")
-    if review.is_hidden and not current_user.is_admin():
+    if review["is_hidden"] and not current_user.is_admin():
         raise NotFound(gettext("Review has been hidden."))
     try:
         count = db_revision.get_count(id)
         revisions = db_revision.get(id, limit=RESULTS_LIMIT)
     except db_exceptions.NoDataFoundException:
         raise NotFound(gettext("The revision(s) you are looking for does not exist."))
-    votes = db_revision.get_votes(id)
+    votes = db_revision.get_all_votes(id)
     results = list(zip(reversed(range(count-RESULTS_LIMIT, count)), revisions))
     return render_template('review/revisions.html', review=review, results=results, count=count, limit=RESULTS_LIMIT, votes=votes)
 
 
 @review_bp.route('/<uuid:id>/revisions/more')
 def revisions_more(id):
-    review = Review.query.get_or_404(str(id))
+    try:
+        review = db_review.get_by_id(id)
+    except db_exceptions.NoDataFoundException:
+        abort(404)
 
     # Not showing review if it isn't published yet and not viewed by author.
-    if review.is_draft and not (current_user.is_authenticated
-                                and current_user == review.user):
+    if review["is_draft"] and not (current_user.is_authenticated
+                                and current_user == review["user"]):
         raise NotFound("Can't find a review with the specified ID.")
-    if review.is_hidden and not current_user.is_admin():
+    if review["is_hidden"] and not current_user.is_admin():
         raise NotFound(gettext("Review has been hidden."))
 
     page = int(request.args.get('page', default=0))
@@ -157,7 +170,7 @@ def revisions_more(id):
         revisions = db_revision.get(id, limit=RESULTS_LIMIT, offset=offset)
     except db_exceptions.NoDataFoundException:
         raise NotFound(gettext("The revision(s) you are looking for does not exist."))
-    votes = db_revision.get_votes(id)
+    votes = db_revision.get_all_votes(id)
     results = list(zip(reversed(range(count-offset-RESULTS_LIMIT, count-offset)), revisions))
 
     template = render_template('review/revision_results.html', review=review, results=results, votes=votes, count=count)
@@ -182,10 +195,10 @@ def create():
         return redirect(url_for('user.reviews', user_id=current_user.id))
 
     # Checking if the user already wrote a review for this entity
-    review = Review.query.filter_by(user_id=current_user.id, entity_id=entity_id).first()
+    review = db_review.list_reviews(user_id=current_user.id, entity_id=entity_id)[0]
     if review:
         flash.error(gettext("You have already published a review for this entity!"))
-        return redirect(url_for('review.entity', id=review.id))
+        return redirect(url_for('review.entity', id=review["id"]))
 
     form = ReviewCreateForm(default_language=get_locale())
 
@@ -195,14 +208,14 @@ def create():
             return redirect(url_for('user.reviews', user_id=current_user.id))
 
         is_draft = form.state.data == 'draft'
-        review = Review.create(user_id=current_user.id, entity_id=entity_id, entity_type=entity_type,
+        review = db_review.create(user_id=current_user.id, entity_id=entity_id, entity_type=entity_type,
                                text=form.text.data, license_id=form.license_choice.data,
                                language=form.language.data, is_draft=is_draft)
         if is_draft:
             flash.success(gettext("Review has been saved!"))
         else:
             flash.success(gettext("Review has been published!"))
-        return redirect(url_for('.entity', id=review.id))
+        return redirect(url_for('.entity', id=review['id']))
 
     entity = musicbrainz.get_entity_by_id(entity_id, entity_type)
     if not entity:
@@ -226,45 +239,56 @@ def preview():
 @review_bp.route('/<uuid:id>/edit', methods=('GET', 'POST'))
 @login_required
 def edit(id):
-    review = Review.query.get_or_404(str(id))
-    if review.is_draft and current_user != review.user:
+    try:
+        review = db_review.get_by_id(id)
+    except db_exceptions.NoDataFoundException:
+        abort(404)
+    if review["is_draft"] and current_user != review["user"]:
         raise NotFound(gettext("Can't find a review with the specified ID."))
-    if review.user != current_user:
+    if review["user"] != current_user:
         raise Unauthorized(gettext("Only author can edit this review."))
-    if review.is_hidden and not current_user.is_admin():
+    if review["is_hidden"] and not current_user.is_admin():
         raise NotFound(gettext("Review has been hidden."))
 
-    form = ReviewEditForm(default_license_id=review.license_id, default_language=review.language)
-    if not review.is_draft:
+    form = ReviewEditForm(default_license_id=review["license_id"], default_language=review["language"])
+    if not review["is_draft"]:
         # Can't change license if review is published.
         del form.license_choice
 
     if form.validate_on_submit():
-        if review.is_draft:
+        if review["is_draft"]:
             license_choice = form.license_choice.data
         else:
             license_choice = None
-        review.update(text=form.text.data, is_draft=(form.state.data == 'draft'),
-                      license_id=license_choice, language=form.language.data)
+        review = db_review.update(
+            review["id"],
+            review["is_draft"],
+            text=form.text.data,
+            is_draft=(form.state.data == 'draft'),
+            license_id=license_choice, language=form.language.data,
+        )
         flash.success(gettext("Review has been updated."))
-        return redirect(url_for('.entity', id=review.id))
+        return redirect(url_for('.entity', id=review["id"]))
     else:
-        form.text.data = review.text
-    if review.entity_type == 'release_group':
-        spotify_mappings = mbspotify.mappings(review.entity_id)
-        soundcloud_url = soundcloud.get_url(review.entity_id)
-        return render_template('review/modify/edit.html', form=form, review=review, entity_type=review.entity_type, entity=entity, spotify_mappings = spotify_mappings, soundcloud_url=soundcloud_url)
-    return render_template('review/modify/edit.html', form=form, review=review, entity_type=review.entity_type)
+        form.text.data = review["text"]
+    if review["entity_type"] == 'release_group':
+        spotify_mappings = mbspotify.mappings(str(review["entity_id"]))
+        soundcloud_url = soundcloud.get_url(str(review["entity_id"]))
+        return render_template('review/modify/edit.html', form=form, review=review, entity_type=review["entity_type"], entity=entity, spotify_mappings = spotify_mappings, soundcloud_url=soundcloud_url)
+    return render_template('review/modify/edit.html', form=form, review=review, entity_type=review["entity_type"])
 
 
 @review_bp.route('/<uuid:id>/delete', methods=['GET', 'POST'])
 @login_required
 def delete(id):
-    review = Review.query.get_or_404(str(id))
-    if review.user != current_user and not current_user.is_admin():
+    try:
+        review = db_review.get_by_id(id)
+    except db_exceptions.NoDataFoundException:
+        abort(404)
+    if review["user"] != current_user and not current_user.is_admin():
         raise Unauthorized(gettext("Only the author or an admin can delete this review."))
     if request.method == 'POST':
-        review.delete()
+        db_review.delete(review["id"])
         flash.success(gettext("Review has been deleted."))
         return redirect(url_for('user.reviews', user_id=current_user.id))
     return render_template('review/delete.html', review=review)
@@ -281,10 +305,13 @@ def vote_submit(review_id):
     else:
         vote = None
 
-    review = Review.query.get_or_404(review_id)
-    if review.is_hidden and not current_user.is_admin():
+    try:
+        review = db_review.get_by_id(review_id)
+    except db_exceptions.NoDataFoundException:
+        abort(404)
+    if review["is_hidden"] and not current_user.is_admin():
         raise NotFound(gettext("Review has been hidden."))
-    if review.user == current_user:
+    if review["user"] == current_user:
         flash.error(gettext("You cannot rate your own review."))
         return redirect(url_for('.entity', id=review_id))
     if current_user.is_vote_limit_exceeded is True and current_user.has_voted(review) is False:
@@ -297,7 +324,7 @@ def vote_submit(review_id):
 
     db_vote.submit(
         user_id=current_user.id,
-        revision_id=review.last_revision.id,
+        revision_id=review["last_revision"]["id"],
         vote=vote,  # overwrites an existing vote, if needed
     )
 
@@ -308,11 +335,14 @@ def vote_submit(review_id):
 @review_bp.route('/<uuid:id>/vote/delete', methods=['GET'])
 @login_required
 def vote_delete(id):
-    review = Review.query.get_or_404(str(id))
-    if review.is_hidden and not current_user.is_admin():
+    try:
+        review = db_review.get_by_id(id)
+    except db_exceptions.NoDataFoundException:
+        abort(404)
+    if review["is_hidden"] and not current_user.is_admin():
         raise NotFound(gettext("Review has been hidden."))
     try:
-        vote = db_vote.get(user_id=current_user.id, revision_id=review.last_revision.id)
+        vote = db_vote.get(user_id=current_user.id, revision_id=review["last_revision"]["id"])
         flash.success(gettext("You have deleted your vote for this review!"))
         db_vote.delete(user_id=vote["user_id"], revision_id=vote["revision_id"])
     except db_exceptions.NoDataFoundException:
@@ -323,10 +353,13 @@ def vote_delete(id):
 @review_bp.route('/<uuid:id>/report', methods=['GET', 'POST'])
 @login_required
 def report(id):
-    review = Review.query.get_or_404(str(id))
-    if review.is_hidden and not current_user.is_admin():
+    try:
+        review = db_review.get_by_id(id)
+    except db_exceptions.NoDataFoundException:
+        abort(404)
+    if review["is_hidden"] and not current_user.is_admin():
         raise NotFound(gettext("Review has been hidden."))
-    if review.user == current_user:
+    if review["user"] == current_user:
         flash.error(gettext("You cannot report your own review."))
         return redirect(url_for('.entity', id=id))
 
@@ -335,7 +368,7 @@ def report(id):
                             "your account has been blocked by a moderator."))
         return redirect(url_for('.entity', id=id))
 
-    last_revision_id = review.last_revision.id
+    last_revision_id = review["last_revision"]["id"]
     report = db_spam_report.get(current_user.id, last_revision_id)
     if report:
         flash.error(gettext("You have already reported this review."))
@@ -354,21 +387,25 @@ def report(id):
 @login_required
 @admin_view
 def hide(id):
-    review = Review.query.get_or_404(str(id))
+    try:
+        review = db_review.get_by_id(id)
+    except db_exceptions.NoDataFoundException:
+        abort(404)
 
-    if review.is_hidden:
+    if review["is_hidden"]:
         flash.info(gettext("Review is already hidden."))
-        return redirect(url_for('.entity', id=review.id))
+        return redirect(url_for('.entity', id=review["id"]))
 
     form = AdminActionForm()
     if form.validate_on_submit():
-        review.hide()
+        db_review.hide(review["id"])
         ModerationLog.create(admin_id=current_user.id, action=ACTION_HIDE_REVIEW,
-                             reason=form.reason.data, review_id=review.id)
-        for report in db_spam_report.list_reports(review_id=review.id):
+                             reason=form.reason.data, review_id=review["id"])
+        review_reports, count = db_spam_report.list_reports(review_id=review["id"])
+        for report in review_reports:
             db_spam_report.archive(report["user_id"], report["revision_id"])
         flash.success(gettext("Review has been hidden."))
-        return redirect(url_for('.entity', id=review.id))
+        return redirect(url_for('.entity', id=review["id"]))
 
     return render_template('log/action.html', review=review, form=form, action=ACTION_HIDE_REVIEW)
 
@@ -377,7 +414,10 @@ def hide(id):
 @login_required
 @admin_view
 def unhide(id):
-    review = Review.query.get_or_404(str(id))
-    review.unhide()
+    try:
+        review = db_review.get_by_id(id)
+    except db_exceptions.NoDataFoundException:
+        abort(404)
+    db_review.unhide(review["id"])
     flash.success(gettext("Review is not hidden anymore."))
     return redirect(request.referrer or url_for('user.reviews', user_id=current_user.id))

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -243,12 +243,13 @@ def edit(id):
             license_choice = form.license_choice.data
         else:
             license_choice = None
-        review = db_review.update(
+        db_review.update(
             review_id=review["id"],
             drafted=review["is_draft"],
             text=form.text.data,
             is_draft=(form.state.data == 'draft'),
-            license_id=license_choice, language=form.language.data,
+            license_id=license_choice,
+            language=form.language.data,
         )
         flash.success(gettext("Review has been updated."))
         return redirect(url_for('.entity', id=review["id"]))
@@ -365,7 +366,7 @@ def hide(id):
 
     form = AdminActionForm()
     if form.validate_on_submit():
-        db_review.hide(review["id"])
+        db_review.set_hidden_state(review["id"], is_hidden="True")
         ModerationLog.create(admin_id=current_user.id, action=ACTION_HIDE_REVIEW,
                              reason=form.reason.data, review_id=review["id"])
         review_reports, count = db_spam_report.list_reports(review_id=review["id"])
@@ -382,6 +383,6 @@ def hide(id):
 @admin_view
 def unhide(id):
     review = db_review.get_or_404(id)
-    db_review.unhide(review["id"])
+    db_review.set_hidden_state(review["id"], is_hidden="False")
     flash.success(gettext("Review is not hidden anymore."))
     return redirect(request.referrer or url_for('user.reviews', user_id=current_user.id))

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -1,5 +1,5 @@
 from critiquebrainz.frontend.testing import FrontendTestCase
-from critiquebrainz.data.model.review import Review
+import critiquebrainz.db.review as db_review
 from critiquebrainz.db.user import User
 from critiquebrainz.data.model.license import License
 import critiquebrainz.db.users as db_users
@@ -19,7 +19,7 @@ class ReviewViewsTestCase(FrontendTestCase):
         self.review_text = "Testing! This text should be on the page."
 
     def create_dummy_review(self, is_draft=False):
-        review = Review.create(
+        review = db_review.create(
             release_group="6b3cd75d-7453-39f3-86c4-1441f360e121",
             user_id=self.user.id,
             text=self.review_text,
@@ -34,13 +34,13 @@ class ReviewViewsTestCase(FrontendTestCase):
 
     def test_entity(self):
         review = self.create_dummy_review()
-        response = self.client.get("/review/%s" % review.id)
+        response = self.client.get("/review/%s" % review["id"])
         self.assert200(response)
         self.assertIn(self.review_text, str(response.data))
 
     def test_draft_review(self):
         review = self.create_dummy_review(is_draft=True)
-        response = self.client.get("/review/%s" % review.id)
+        response = self.client.get("/review/%s" % review["id"])
         self.assert404(response, "Drafts shouldn't be publicly visible.")
 
     def test_missing_review(self):
@@ -77,7 +77,7 @@ class ReviewViewsTestCase(FrontendTestCase):
         review = self.create_dummy_review()
 
         self.temporary_login(self.user)
-        response = self.client.post('/review/%s/edit' % review.id, data=data,
+        response = self.client.post('/review/%s/edit' % review["id"], data=data,
                                     query_string=data, follow_redirects=True)
         self.assert200(response)
         self.assertIn(updated_text, str(response.data))
@@ -86,26 +86,26 @@ class ReviewViewsTestCase(FrontendTestCase):
         review = self.create_dummy_review()
 
         self.temporary_login(self.hacker)
-        response = self.client.post("/review/%s/delete" % review.id, follow_redirects=True)
+        response = self.client.post("/review/%s/delete" % review["id"], follow_redirects=True)
         self.assert401(response, "Only the author can delete this review.")
 
         self.temporary_login(self.user)
-        response = self.client.post("/review/%s/delete" % review.id, follow_redirects=True)
+        response = self.client.post("/review/%s/delete" % review["id"], follow_redirects=True)
         self.assert200(response)
 
     def test_vote_submit_delete(self):
         review = self.create_dummy_review()
 
         self.temporary_login(self.user)
-        response = self.client.post("/review/%s/vote" % review.id, follow_redirects=True)
+        response = self.client.post("/review/%s/vote" % review["id"], follow_redirects=True)
         self.assertIn("You cannot rate your own review.", str(response.data))
 
         self.temporary_login(self.hacker)
-        response = self.client.post("/review/%s/vote" % review.id, data=dict(yes=True),
+        response = self.client.post("/review/%s/vote" % review["id"], data=dict(yes=True),
                                     follow_redirects=True)
         self.assertIn("You have rated this review!", str(response.data))
 
-        response = self.client.get("/review/%s/vote/delete" % review.id, follow_redirects=True)
+        response = self.client.get("/review/%s/vote/delete" % review["id"], follow_redirects=True)
         self.assertIn("You have deleted your vote for this review!", str(response.data))
 
     def test_report(self):
@@ -114,16 +114,16 @@ class ReviewViewsTestCase(FrontendTestCase):
         data = dict(reason="Testing reason.")
 
         self.temporary_login(self.user)
-        response = self.client.post("/review/%s/report" % review.id, follow_redirects=True)
+        response = self.client.post("/review/%s/report" % review["id"], follow_redirects=True)
         self.assertIn("You cannot report your own review.", str(response.data))
 
         self.temporary_login(self.hacker)
-        response = self.client.post("/review/%s/report" % review.id, data=data,
+        response = self.client.post("/review/%s/report" % review["id"], data=data,
                                     query_string=data, follow_redirects=True)
         self.assertIn("Review has been reported.", str(response.data))
 
     def test_event_review_pages(self):
-        review = Review.create(
+        review = db_review.create(
             entity_id="b4e75ef8-3454-4fdc-8af1-61038c856abc",
             entity_type="event",
             user_id=self.user.id,
@@ -132,12 +132,12 @@ class ReviewViewsTestCase(FrontendTestCase):
             license_id=self.license.id,
         )
 
-        response = self.client.get("/review/%s" % review.id)
+        response = self.client.get("/review/%s" % review["id"])
         self.assert200(response)
         self.assertIn("A great event, enjoyed it.", str(response.data))
 
     def test_place_review_pages(self):
-        review = Review.create(
+        review = db_review.create(
             entity_id="c5c9c210-b7a0-4f6e-937e-02a586c8e14c",
             entity_type="place",
             user_id=self.user.id,
@@ -146,6 +146,6 @@ class ReviewViewsTestCase(FrontendTestCase):
             license_id=self.license.id,
         )
 
-        response = self.client.get("/review/%s" % review.id)
+        response = self.client.get("/review/%s" % review["id"])
         self.assert200(response)
         self.assertIn("A great place.", str(response.data))

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -20,7 +20,8 @@ class ReviewViewsTestCase(FrontendTestCase):
 
     def create_dummy_review(self, is_draft=False):
         review = db_review.create(
-            release_group="6b3cd75d-7453-39f3-86c4-1441f360e121",
+            entity_id="6b3cd75d-7453-39f3-86c4-1441f360e121",
+            entity_type="release_group",
             user_id=self.user.id,
             text=self.review_text,
             is_draft=is_draft,

--- a/critiquebrainz/frontend/views/user.py
+++ b/critiquebrainz/frontend/views/user.py
@@ -10,7 +10,6 @@ import critiquebrainz.db.users as db_users
 import critiquebrainz.db.review as db_review
 import critiquebrainz.db.moderation_log as db_moderation_log
 
-
 user_bp = Blueprint('user', __name__)
 
 

--- a/critiquebrainz/frontend/views/user.py
+++ b/critiquebrainz/frontend/views/user.py
@@ -3,12 +3,12 @@ from flask_babel import gettext
 from flask_login import login_required, current_user
 
 from critiquebrainz.data.model.moderation_log import ModerationLog, ACTION_BLOCK_USER
-from critiquebrainz.data.model.review import Review
 from critiquebrainz.db.user import User
 from critiquebrainz.frontend.forms.log import AdminActionForm
 from critiquebrainz.frontend.login import admin_view
 from critiquebrainz.frontend import flash
 import critiquebrainz.db.users as db_users
+import critiquebrainz.db.review as db_review
 
 user_bp = Blueprint('user', __name__)
 
@@ -28,7 +28,7 @@ def reviews(user_id):
         return redirect(url_for('.reviews'))
     limit = 12
     offset = (page - 1) * limit
-    reviews, count = Review.list(user_id=user_id, sort='created', limit=limit, offset=offset,
+    reviews, count = db_review.list_reviews(user_id=user_id, sort='created', limit=limit, offset=offset,
                                  inc_hidden=current_user.is_admin(),
                                  inc_drafts=current_user.is_authenticated and current_user.id == user_id)
     return render_template('user/reviews.html', section='reviews', user=user,


### PR DESCRIPTION
Functions and tests for migrating `reviews` off the ORM. Changes have been made to the `frontend` component to use the migrated code. I have added the following functions in `db/review.py` and the corresponding tests (`db/review_test.py`):

+ `get_by_id` for getting review by id.
+ `hide` and `unhide` for hiding and unhiding reviews.
+ `get_count` for review count.
+ `update` for updating a reviews info.
+ `create` for creating a review.
+ `delete` for deleting a review.
+ `list` for list reviews and filter them on various filters.
+ `get_popular` for getting popular reviews.
+ `revision.create` for creating a revision.
+ `votes` for getting votes of a revision.