### PR TITLE
CB-230: Create database without using ORM models

### DIFF
--- a/admin/sql/create_extensions.sql
+++ b/admin/sql/create_extensions.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/admin/sql/create_foreign_keys.sql
+++ b/admin/sql/create_foreign_keys.sql
@@ -1,0 +1,95 @@
+BEGIN;
+
+ALTER TABLE review
+  ADD CONSTRAINT review_license_id_fkey
+  FOREIGN KEY (license_id)
+  REFERENCES license(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE moderation_log
+  ADD CONSTRAINT moderation_log_admin_id_fkey
+  FOREIGN KEY (admin_id)
+  REFERENCES "user"(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE moderation_log
+  ADD CONSTRAINT moderation_log_review_id_fkey
+  FOREIGN KEY (review_id)
+  REFERENCES review(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE moderation_log
+  ADD CONSTRAINT moderation_log_user_id_fkey
+  FOREIGN KEY (user_id)
+  REFERENCES "user"(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE oauth_client
+  ADD CONSTRAINT oauth_client_user_id_fkey
+  FOREIGN KEY (user_id)
+  REFERENCES "user"(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE oauth_grant
+  ADD CONSTRAINT oauth_grant_client_id_fkey
+  FOREIGN KEY (client_id)
+  REFERENCES oauth_client(client_id)
+  ON UPDATE CASCADE
+  ON DELETE CASCADE;
+
+ALTER TABLE oauth_token
+  ADD CONSTRAINT oauth_token_client_id_fkey
+  FOREIGN KEY (client_id)
+  REFERENCES oauth_client(client_id)
+  ON UPDATE CASCADE
+  ON DELETE CASCADE;
+
+ALTER TABLE oauth_grant
+  ADD CONSTRAINT oauth_grant_user_id_fkey
+  FOREIGN KEY (user_id)
+  REFERENCES "user"(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE oauth_token
+  ADD CONSTRAINT oauth_token_user_id_fkey
+  FOREIGN KEY (user_id)
+  REFERENCES "user"(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE review
+  ADD CONSTRAINT review_user_id_fkey
+  FOREIGN KEY (user_id)
+  REFERENCES "user"(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE spam_report
+  ADD CONSTRAINT spam_report_revision_id_fkey
+  FOREIGN KEY (revision_id)
+  REFERENCES revision(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE vote
+  ADD CONSTRAINT vote_revision_id_fkey
+  FOREIGN KEY (revision_id)
+  REFERENCES revision(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE spam_report
+  ADD CONSTRAINT spam_report_user_id_fkey
+  FOREIGN KEY (user_id)
+  REFERENCES "user"(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE vote
+  ADD CONSTRAINT vote_user_id_fkey
+  FOREIGN KEY (user_id)
+  REFERENCES "user"(id)
+  ON DELETE CASCADE;
+
+ALTER TABLE revision
+  ADD CONSTRAINT revision_review_id_fkey
+  FOREIGN KEY (review_id)
+  REFERENCES review(id)
+  ON DELETE CASCADE;
+
+COMMIT;

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-CREATE INDEX ix_oauth_grant_code ON oauth_grant (code);
-CREATE INDEX ix_review_entity_id ON review (entity_id);
-CREATE INDEX ix_revision_review_id ON revision (review_id);
+CREATE INDEX ix_oauth_grant_code ON oauth_grant USING btree (code);
+CREATE INDEX ix_review_entity_id ON review USING btree (entity_id);
+CREATE INDEX ix_revision_review_id ON revision USING btree (review_id);
 
 COMMIT;

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+CREATE INDEX ix_oauth_grant_code ON oauth_grant (code);
+CREATE INDEX ix_review_entity_id ON review (entity_id);
+CREATE INDEX ix_revision_review_id ON revision (review_id);
+
+COMMIT;

--- a/admin/sql/create_primary_keys.sql
+++ b/admin/sql/create_primary_keys.sql
@@ -1,0 +1,12 @@
+BEGIN;
+ALTER TABLE license ADD CONSTRAINT license_pkey PRIMARY KEY (id);
+ALTER TABLE moderation_log ADD CONSTRAINT moderation_log_pkey PRIMARY KEY (id);
+ALTER TABLE oauth_client ADD CONSTRAINT oauth_client_pkey PRIMARY KEY (client_id);
+ALTER TABLE oauth_grant ADD CONSTRAINT oauth_grant_pkey PRIMARY KEY (id);
+ALTER TABLE oauth_token ADD CONSTRAINT oauth_token_pkey PRIMARY KEY (id);
+ALTER TABLE review ADD CONSTRAINT review_pkey PRIMARY KEY (id);
+ALTER TABLE revision ADD CONSTRAINT revision_pkey PRIMARY KEY (id);
+ALTER TABLE spam_report ADD CONSTRAINT spam_report_pkey PRIMARY KEY (user_id, revision_id);
+ALTER TABlE "user" ADD CONSTRAINT user_pkey PRIMARY KEY (id);
+ALTER TABlE vote ADD CONSTRAINT vote_pkey PRIMARY KEY (user_id, revision_id);
+COMMIT;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -1,0 +1,99 @@
+BEGIN;
+
+CREATE TABLE license (
+  id        VARCHAR    NOT NULL,
+  full_name VARCHAR    NOT NULL,
+  info_url  VARCHAR
+);
+
+CREATE TABLE moderation_log (
+    id        SERIAL       NOT NULL,
+    admin_id  UUID         NOT NULL,
+    user_id   UUID,
+    review_id UUID,
+    action    action_types NOT NULL,
+    timestamp TIMESTAMP    NOT NULL,
+    reason    VARCHAR      NOT NULL
+);
+
+CREATE TABLE oauth_client (
+    client_id     VARCHAR NOT NULL,
+    client_secret VARCHAR NOT NULL,
+    redirect_uri  TEXT    NOT NULL,
+    user_id       UUID,
+    name          VARCHAR NOT NULL,
+    "desc"        VARCHAR NOT NULL,
+    website       VARCHAR NOT NULL
+);
+
+CREATE TABLE oauth_grant (
+    id           SERIAL    NOT NULL,
+    client_id    VARCHAR   NOT NULL,
+    code         VARCHAR   NOT NULL,
+    expires      TIMESTAMP NOT NULL,
+    redirect_uri TEXT      NOT NULL,
+    scopes       TEXT,
+    user_id      UUID      NOT NULL
+);
+
+CREATE TABLE oauth_token (
+    id            SERIAL    NOT NULL,
+    client_id     VARCHAR   NOT NULL,
+    access_token  VARCHAR   NOT NULL,
+    refresh_token VARCHAR   NOT NULL,
+    expires       TIMESTAMP NOT NULL,
+    scopes        TEXT,
+    user_id       UUID      NOT NULL
+);
+ALTER TABLE oauth_token ADD CONSTRAINT oauth_token_access_token_key UNIQUE (access_token);
+ALTER TABLE oauth_token ADD CONSTRAINT oauth_token_refresh_token_key UNIQUE (refresh_token);
+
+CREATE TABLE review (
+    id          UUID         NOT NULL DEFAULT uuid_generate_v4(),
+    entity_id   UUID         NOT NULL,
+    entity_type entity_types NOT NULL,
+    user_id     UUID         NOT NULL,
+    edits       INTEGER      NOT NULL,
+    is_draft    BOOLEAN      NOT NULL,
+    is_hidden   BOOLEAN      NOT NULL,
+    license_id  VARCHAR      NOT NULL,
+    language    VARCHAR(3)   NOT NULL,
+    source      VARCHAR,
+    source_url  VARCHAR
+);
+ALTER TABLE review ADD CONSTRAINT review_entity_id_user_id_key UNIQUE (entity_id, user_id);
+
+CREATE TABLE revision (
+    id        SERIAL    NOT NULL,
+    review_id UUID,
+    timestamp TIMESTAMP NOT NULL,
+    text      VARCHAR   NOT NULL
+);
+
+CREATE TABLE spam_report (
+    user_id     UUID      NOT NULL,
+    reason      VARCHAR,
+    revision_id INTEGER   NOT NULL,
+    reported_at TIMESTAMP NOT NULL,
+    is_archived BOOLEAN   NOT NULL
+);
+
+CREATE TABLE "user" (
+    id             UUID      NOT NULL DEFAULT uuid_generate_v4(),
+    display_name   VARCHAR   NOT NULL,
+    email          VARCHAR,
+    created        TIMESTAMP NOT NULL,
+    musicbrainz_id VARCHAR,
+    show_gravatar  BOOLEAN   NOT NULL DEFAULT False,
+    is_blocked     BOOLEAN   NOT NULL DEFAULT False
+);
+ALTER TABLE "user" ADD CONSTRAINT user_musicbrainz_id_key UNIQUE (musicbrainz_id);
+
+CREATE TABLE vote (
+    user_id     UUID      NOT NULL,
+    revision_id INTEGER   NOT NULL,
+    vote        BOOLEAN   NOT NULL,
+    rated_at    TIMESTAMP NOT NULL
+);
+
+COMMIT;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -7,13 +7,13 @@ CREATE TABLE license (
 );
 
 CREATE TABLE moderation_log (
-    id        SERIAL       NOT NULL,
-    admin_id  UUID         NOT NULL,
-    user_id   UUID,
-    review_id UUID,
-    action    action_types NOT NULL,
-    timestamp TIMESTAMP    NOT NULL,
-    reason    VARCHAR      NOT NULL
+    id          SERIAL       NOT NULL,
+    admin_id    UUID         NOT NULL,
+    user_id     UUID,
+    review_id   UUID,
+    action      action_types NOT NULL,
+    "timestamp" TIMESTAMPTZ  NOT NULL,
+    reason      VARCHAR      NOT NULL
 );
 
 CREATE TABLE oauth_client (
@@ -27,23 +27,23 @@ CREATE TABLE oauth_client (
 );
 
 CREATE TABLE oauth_grant (
-    id           SERIAL    NOT NULL,
-    client_id    VARCHAR   NOT NULL,
-    code         VARCHAR   NOT NULL,
-    expires      TIMESTAMP NOT NULL,
-    redirect_uri TEXT      NOT NULL,
+    id           SERIAL      NOT NULL,
+    client_id    VARCHAR     NOT NULL,
+    code         VARCHAR     NOT NULL,
+    expires      TIMESTAMPTZ NOT NULL,
+    redirect_uri TEXT        NOT NULL,
     scopes       TEXT,
-    user_id      UUID      NOT NULL
+    user_id      UUID        NOT NULL
 );
 
 CREATE TABLE oauth_token (
-    id            SERIAL    NOT NULL,
-    client_id     VARCHAR   NOT NULL,
-    access_token  VARCHAR   NOT NULL,
-    refresh_token VARCHAR   NOT NULL,
-    expires       TIMESTAMP NOT NULL,
+    id            SERIAL      NOT NULL,
+    client_id     VARCHAR     NOT NULL,
+    access_token  VARCHAR     NOT NULL,
+    refresh_token VARCHAR     NOT NULL,
+    expires       TIMESTAMPTZ NOT NULL,
     scopes        TEXT,
-    user_id       UUID      NOT NULL
+    user_id       UUID        NOT NULL
 );
 ALTER TABLE oauth_token ADD CONSTRAINT oauth_token_access_token_key UNIQUE (access_token);
 ALTER TABLE oauth_token ADD CONSTRAINT oauth_token_refresh_token_key UNIQUE (refresh_token);
@@ -64,36 +64,36 @@ CREATE TABLE review (
 ALTER TABLE review ADD CONSTRAINT review_entity_id_user_id_key UNIQUE (entity_id, user_id);
 
 CREATE TABLE revision (
-    id        SERIAL    NOT NULL,
-    review_id UUID,
-    timestamp TIMESTAMP NOT NULL,
-    text      VARCHAR   NOT NULL
+    id          SERIAL      NOT NULL,
+    review_idl  UUID,
+    "timestamp" TIMESTAMPTZ NOT NULL,
+    text        VARCHAR     NOT NULL
 );
 
 CREATE TABLE spam_report (
-    user_id     UUID      NOT NULL,
+    user_id     UUID        NOT NULL,
     reason      VARCHAR,
-    revision_id INTEGER   NOT NULL,
-    reported_at TIMESTAMP NOT NULL,
-    is_archived BOOLEAN   NOT NULL
+    revision_id INTEGER     NOT NULL,
+    reported_at TIMESTAMPTZ NOT NULL,
+    is_archived BOOLEAN     NOT NULL
 );
 
 CREATE TABLE "user" (
-    id             UUID      NOT NULL DEFAULT uuid_generate_v4(),
-    display_name   VARCHAR   NOT NULL,
+    id             UUID        NOT NULL DEFAULT uuid_generate_v4(),
+    display_name   VARCHAR     NOT NULL,
     email          VARCHAR,
-    created        TIMESTAMP NOT NULL,
+    created        TIMESTAMPTZ NOT NULL,
     musicbrainz_id VARCHAR,
-    show_gravatar  BOOLEAN   NOT NULL DEFAULT False,
-    is_blocked     BOOLEAN   NOT NULL DEFAULT False
+    show_gravatar  BOOLEAN     NOT NULL DEFAULT False,
+    is_blocked     BOOLEAN     NOT NULL DEFAULT False
 );
 ALTER TABLE "user" ADD CONSTRAINT user_musicbrainz_id_key UNIQUE (musicbrainz_id);
 
 CREATE TABLE vote (
-    user_id     UUID      NOT NULL,
-    revision_id INTEGER   NOT NULL,
-    vote        BOOLEAN   NOT NULL,
-    rated_at    TIMESTAMP NOT NULL
+    user_id     UUID        NOT NULL,
+    revision_id INTEGER     NOT NULL,
+    vote        BOOLEAN     NOT NULL,
+    rated_at    TIMESTAMPTZ NOT NULL
 );
 
 COMMIT;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -12,7 +12,7 @@ CREATE TABLE moderation_log (
     user_id     UUID,
     review_id   UUID,
     action      action_types NOT NULL,
-    "timestamp" TIMESTAMPTZ  NOT NULL,
+    "timestamp" TIMESTAMP    NOT NULL,
     reason      VARCHAR      NOT NULL
 );
 
@@ -30,7 +30,7 @@ CREATE TABLE oauth_grant (
     id           SERIAL      NOT NULL,
     client_id    VARCHAR     NOT NULL,
     code         VARCHAR     NOT NULL,
-    expires      TIMESTAMPTZ NOT NULL,
+    expires      TIMESTAMP   NOT NULL,
     redirect_uri TEXT        NOT NULL,
     scopes       TEXT,
     user_id      UUID        NOT NULL
@@ -41,7 +41,7 @@ CREATE TABLE oauth_token (
     client_id     VARCHAR     NOT NULL,
     access_token  VARCHAR     NOT NULL,
     refresh_token VARCHAR     NOT NULL,
-    expires       TIMESTAMPTZ NOT NULL,
+    expires       TIMESTAMP   NOT NULL,
     scopes        TEXT,
     user_id       UUID        NOT NULL
 );
@@ -65,8 +65,8 @@ ALTER TABLE review ADD CONSTRAINT review_entity_id_user_id_key UNIQUE (entity_id
 
 CREATE TABLE revision (
     id          SERIAL      NOT NULL,
-    review_idl  UUID,
-    "timestamp" TIMESTAMPTZ NOT NULL,
+    review_id   UUID,
+    "timestamp" TIMESTAMP   NOT NULL,
     text        VARCHAR     NOT NULL
 );
 
@@ -74,7 +74,7 @@ CREATE TABLE spam_report (
     user_id     UUID        NOT NULL,
     reason      VARCHAR,
     revision_id INTEGER     NOT NULL,
-    reported_at TIMESTAMPTZ NOT NULL,
+    reported_at TIMESTAMP   NOT NULL,
     is_archived BOOLEAN     NOT NULL
 );
 
@@ -82,7 +82,7 @@ CREATE TABLE "user" (
     id             UUID        NOT NULL DEFAULT uuid_generate_v4(),
     display_name   VARCHAR     NOT NULL,
     email          VARCHAR,
-    created        TIMESTAMPTZ NOT NULL,
+    created        TIMESTAMP   NOT NULL,
     musicbrainz_id VARCHAR,
     show_gravatar  BOOLEAN     NOT NULL DEFAULT False,
     is_blocked     BOOLEAN     NOT NULL DEFAULT False
@@ -93,7 +93,7 @@ CREATE TABLE vote (
     user_id     UUID        NOT NULL,
     revision_id INTEGER     NOT NULL,
     vote        BOOLEAN     NOT NULL,
-    rated_at    TIMESTAMPTZ NOT NULL
+    rated_at    TIMESTAMP   NOT NULL
 );
 
 COMMIT;

--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -1,0 +1,10 @@
+CREATE TYPE action_types AS ENUM (
+    'hide_review',
+    'block_user'
+);
+
+CREATE TYPE entity_types AS ENUM (
+    'release_group',
+    'event',
+    'place'
+);

--- a/critiquebrainz/data/fixtures.py
+++ b/critiquebrainz/data/fixtures.py
@@ -5,7 +5,6 @@ from critiquebrainz.data.model.license import License
 
 def install(app, *args):
     db.init_app(app)
-    create_tables(app)
     for arg in args:
         for key, entity in arg.__dict__.items():
             if not key.startswith("__"):

--- a/critiquebrainz/data/utils.py
+++ b/critiquebrainz/data/utils.py
@@ -1,4 +1,4 @@
-from critiquebrainz.data import db
+from critiquebrainz import db
 from sqlalchemy import create_engine
 import urllib.parse
 import unicodedata
@@ -8,11 +8,16 @@ import sys
 import os
 import re
 
+ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'admin', 'sql')
 
-def create_tables(app):
-    engine = create_engine(app.config['SQLALCHEMY_DATABASE_URI'], client_encoding='utf8')
-    db.metadata.create_all(engine)
-    return engine
+
+def create_tables():
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_extensions.sql'))
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_types.sql'))
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_tables.sql'))
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_primary_keys.sql'))
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_foreign_keys.sql'))
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_indexes.sql'))
 
 
 def explode_db_uri(uri):

--- a/manage.py
+++ b/manage.py
@@ -102,7 +102,7 @@ def init_db(skip_create_db=False):
         create_extension(db_uri)
 
     click.echo("Creating tables... ", nl=False)
-    data_utils.create_tables(frontend.create_app())
+    data_utils.create_tables()
     click.echo("Done!")
 
     click.echo("Adding fixtures... ")


### PR DESCRIPTION
Added `create_tables.sql`, `create_extensions.sql`, `create_types.sql`, `create_primary_keys.sql`, `create_foreign_keys.sql`, `create_indexes.sql` for creating database. Also, made changes to `data/utils.py/create_tables` function for creating database.