### PR TITLE
CB-230: Migrate dump_manager.py off the ORM

### DIFF
--- a/critiquebrainz/db/__init__.py
+++ b/critiquebrainz/db/__init__.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
 
 # This value must be incremented after schema changes on exported tables!
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 1
 
 engine = None
 

--- a/critiquebrainz/db/__init__.py
+++ b/critiquebrainz/db/__init__.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
 
 # This value must be incremented after schema changes on exported tables!
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 6
 
 engine = None
 

--- a/critiquebrainz/db/license.py
+++ b/critiquebrainz/db/license.py
@@ -48,7 +48,7 @@ def delete(*, id):
 
 
 def list_licenses():
-    """Get a list of licenses in CritiqueBrainz.
+    """Get a list of licenses.
 
     Returns:
         List of dictionaries with the following structure
@@ -65,5 +65,4 @@ def list_licenses():
                    full_name
               FROM license
         """))
-        rows = results.fetchall()
-    return [dict(row) for row in rows]
+        return [dict(row) for row in results.fetchall()]

--- a/critiquebrainz/db/license.py
+++ b/critiquebrainz/db/license.py
@@ -45,3 +45,25 @@ def delete(*, id):
         """), {
             "id": id,
         })
+
+
+def list_licenses():
+    """Get a list of licenses in CritiqueBrainz.
+
+    Returns:
+        List of dictionaries with the following structure
+        {
+            "id": (str),
+            "info_url": (str),
+            "full_name": (str),
+        }
+    """
+    with db.engine.connect() as connection:
+        results = connection.execute(sqlalchemy.text("""
+            SELECT id,
+                   info_url,
+                   full_name
+              FROM license
+        """))
+        rows = results.fetchall()
+    return [dict(row) for row in rows]

--- a/critiquebrainz/db/license_test.py
+++ b/critiquebrainz/db/license_test.py
@@ -21,7 +21,7 @@ class LicenseTestCase(DataTestCase):
         )
         db_license.delete(id=license["id"])
 
-    def test_list_license(self):
+    def test_list_licenses(self):
         license = db_license.create(
             id="test",
             full_name="Test license",
@@ -29,3 +29,8 @@ class LicenseTestCase(DataTestCase):
         )
         licenses = db_license.list_licenses()
         self.assertEqual(len(licenses), 1)
+        self.assertDictEqual({
+            "id": "test",
+            "full_name": "Test license",
+            "info_url":"www.example.com"
+        }, licenses[0])

--- a/critiquebrainz/db/license_test.py
+++ b/critiquebrainz/db/license_test.py
@@ -20,3 +20,12 @@ class LicenseTestCase(DataTestCase):
             info_url="www.example.com",
         )
         db_license.delete(id=license["id"])
+
+    def test_list_license(self):
+        license = db_license.create(
+            id="test",
+            full_name="Test license",
+            info_url="www.example.com",
+        )
+        licenses = db_license.list_licenses()
+        self.assertEqual(len(licenses), 1)

--- a/critiquebrainz/db/license_test.py
+++ b/critiquebrainz/db/license_test.py
@@ -28,7 +28,6 @@ class LicenseTestCase(DataTestCase):
             info_url="www.example.com",
         )
         licenses = db_license.list_licenses()
-        self.assertEqual(len(licenses), 1)
         self.assertDictEqual({
             "id": "test",
             "full_name": "Test license",

--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -578,19 +578,15 @@ def delete(review_id):
 
 
 def distinct_entities():
-    """Get a list of ID(s) of entities reviewed on CritiqueBrainz.
+    """Get a list of ID(s) of entities reviewed.
 
     Returns:
-        List of dictionaries of ID(s) of entities reviewed.
-        {
-            "entity_id": (uuid),
-        }
+        List of ID(s) of distinct entities reviewed.
+
     """
     with db.engine.connect() as connection:
         results = connection.execute(sqlalchemy.text("""
-            SELECT
-          DISTINCT entity_id
+            SELECT DISTINCT entity_id
               FROM review
         """))
-        rows = results.fetchall()
-    return [dict(row) for row in rows]
+        return [row[0] for row in results.fetchall()]

--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -578,15 +578,14 @@ def delete(review_id):
 
 
 def distinct_entities():
-    """Get a list of ID(s) of entities reviewed.
+    """Get a set of ID(s) of entities reviewed.
 
     Returns:
-        List of ID(s) of distinct entities reviewed.
-
+        Set of ID(s) of distinct entities reviewed.
     """
     with db.engine.connect() as connection:
         results = connection.execute(sqlalchemy.text("""
             SELECT DISTINCT entity_id
               FROM review
         """))
-        return [row[0] for row in results.fetchall()]
+        return {row[0] for row in results.fetchall()}

--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -575,3 +575,22 @@ def delete(review_id):
         """), {
             "review_id": review_id,
         })
+
+
+def distinct_entities():
+    """Get a list of ID(s) of entities reviewed on CritiqueBrainz.
+
+    Returns:
+        List of dictionaries of ID(s) of entities reviewed.
+        {
+            "entity_id": (uuid),
+        }
+    """
+    with db.engine.connect() as connection:
+        results = connection.execute(sqlalchemy.text("""
+            SELECT
+          DISTINCT entity_id
+              FROM review
+        """))
+        rows = results.fetchall()
+    return [dict(row) for row in rows]

--- a/critiquebrainz/db/review_test.py
+++ b/critiquebrainz/db/review_test.py
@@ -15,6 +15,10 @@ class ReviewTestCase(DataTestCase):
         self.user = User(db_users.get_or_create("Tester", new_user_data={
             "display_name": "test user",
         }))
+        self.user_2 = User(db_users.get_or_create("Tester 2", new_user_data={
+            "display_name": "test user 2",
+        }))
+
         # And license
         self.license = db_license.create(
             id=u'Test',
@@ -212,3 +216,23 @@ class ReviewTestCase(DataTestCase):
         )
         count = db_review.get_count(is_draft=False, is_hidden=False)
         self.assertEqual(count, 1)
+
+    def test_distinct_entities(self):
+        review = db_review.create(
+            user_id=self.user.id,
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
+            text="Awesome",
+            is_draft=False,
+            license_id=self.license["id"],
+        )
+        review = db_review.create(
+            user_id=self.user_2.id,
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
+            text="Awesome Album",
+            is_draft=False,
+            license_id=self.license["id"],
+        )
+        entities = db_review.distinct_entities()
+        self.assertEqual(len(entities), 1)


### PR DESCRIPTION
Migrated all functions i.e `public`, `import` and `json` of the `dump_manager.py` off the ORM. 