### PR TITLE
CB-257: Fix filtering reviews based on entity type

### DIFF
--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -42,7 +42,7 @@ def browse():
         return redirect(url_for('.browse'))
     limit = 3 * 9  # 9 rows
     offset = (page - 1) * limit
-    reviews, count = db_review.list_reviews(sort='created', limit=limit, offset=offset)
+    reviews, count = db_review.list_reviews(sort='created', limit=limit, offset=offset, entity_type=entity_type)
     if not reviews:
         if page - 1 > count / limit:
             return redirect(url_for('review.browse', page=int(ceil(count/limit))))


### PR DESCRIPTION
Reviews are currently not getting filtered according to entity type on browse review pages. Eg: https://critiquebrainz.org/review/?entity_type=event.