### PR TITLE
CB-237: Make data import work in local setup

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,5 +1,20 @@
 FROM metabrainz/python:3.6
 
+ RUN set -x \
+	&& buildDeps='curl gcc libbz2-dev libc6-dev libsqlite3-dev libssl-dev make xz-utils zlib1g-dev' \
+ 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+ 	&& mkdir -p /usr/src/python \
+ 	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz" -o python.tar.xz \
+ 	&& curl -SL "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz.asc" -o python.tar.xz.asc \
+ 	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+ 	&& rm python.tar.xz* \
+ 	&& cd /usr/src/python \
+ 	&& ./configure --enable-shared --enable-unicode=ucs4 \
+ 	&& make -j$(nproc) \
+ 	&& make install \
+ 	&& ldconfig \
+ 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python3
+
 RUN apt-get update \
      && apt-get install -y --no-install-recommends \
                         build-essential \


### PR DESCRIPTION
Make data import using dumps work in development setup by installing `libbz2-dev` and rebuilding python from source.