### PR TITLE
CB-231: Update documentation for setting up MB database

### DIFF
--- a/critiquebrainz/frontend/__init__.py
+++ b/critiquebrainz/frontend/__init__.py
@@ -49,6 +49,10 @@ def create_app(debug=None, config_path=None):
 
     add_robots(app)
 
+    # MusicBrainz Database
+    from critiquebrainz.frontend.external import musicbrainz_db
+    musicbrainz_db.init_db_engine(app.config.get('MB_DATABASE_URI'))
+
     # Redis (cache)
     from brainzutils import cache
     if "REDIS_HOST" in app.config and \

--- a/critiquebrainz/frontend/external/musicbrainz_db/__init__.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/__init__.py
@@ -1,0 +1,8 @@
+from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
+
+engine = None
+
+def init_db_engine(connect_str):
+    global engine
+    engine = create_engine(connect_str, poolclass=NullPool)

--- a/default_config.py
+++ b/default_config.py
@@ -7,6 +7,9 @@ SECRET_KEY = "CHANGE_THIS"
 SQLALCHEMY_DATABASE_URI = "postgresql://critiquebrainz:critiquebrainz@db:5432/critiquebrainz"
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+# MusicBrainz Database
+MB_DATABASE_URI = "postgresql://musicbrainz:musicbrainz@musicbrainz_db:5432/musicbrainz_db"
+
 # Redis
 REDIS_HOST = "critiquebrainz_redis"
 REDIS_PORT = 6379

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -35,6 +35,17 @@ services:
       - db
       - db_test
       - critiquebrainz_redis
+      - musicbrainz_db
 
   critiquebrainz_redis:
     image: redis:3.2.1
+
+  musicbrainz_db:
+    image: metabrainz/musicbrainz-test-database:schema-change-2017-q2
+    volumes:
+      - ../data/mbdata:/var/lib/postgresql/data/pgdata
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      MB_IMPORT_DUMPS: "true"
+    ports:
+      - "5430:5432"

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -40,14 +40,37 @@ respectively.
 
 Startup
 ^^^^^^^
+Then you can build all the services::
+
+   $ docker-compose -f docker/docker-compose.dev.yml build
+
+You need MusicBrainz database containing all the MusicBrainz music metadata for setting up your application. Data dumps provided from https://musicbrainz.org can be downloaded from https://musicbrainz.org/doc/MusicBrainz_Database/Download. ``mbdump.tar.bz2`` is the core MusicBrainz database including the tables for artist, release groups etc. ``mbdump-derived.tar.bz2`` contains annotations, user tags and search indexes. The core and the derived database covers almost all the data required for a CritiqueBrainz server.
+
+Then you can create and populate the database::
+
+   $ docker-compose -f docker/docker-compose.dev.yml run -v $DUMPS_DIR:/home/musicbrainz/musicbrainz-server -v $PWD/data/mbdata:/var/lib/postgresql/data/pgdata musicbrainz_db
+
+**Note** ``DUMP_DIR`` should be set to the path containing the downloaded dumps.
+
+You can skip downloading the dumps separately. Get the dumps, create and populate the database using::
+
+   $ docker-compose -f docker/docker-compose.dev.yml run -v $PWD/data/mbdata:/var/lib/postgresql/data/pgdata musicbrainz_db
+
+**Note** The above command downloads only the latest ``mbdump.tar.bz2`` and ``mbdump-derived.tar.bz2`` dumps for populating the database.
+
+Initialization of CritiqueBrainz database is also required::
+
+   $ docker-compose -f docker/docker-compose.dev.yml run critiquebrainz python3 manage.py init_db --skip-create-db
 
 Then you can start all the services::
 
+   $ docker-compose -f docker/docker-compose.dev.yml up -d
+
+**Note** Alternative way to build, download and import dumps for MusicBrainz database and run all services::
+
    $ docker-compose -f docker/docker-compose.dev.yml up -d --build
 
-The first time you do that, database initialization is also required::
-
-   $ docker-compose -f docker/docker-compose.dev.yml run critiquebrainz python3 manage.py init_db --skip-create-db
+This will set up the MusicBrainz database by downloading the dumps. The first time after this is run, initialization of CritiqueBrainz database is also required.
 
 Building static files
 '''''''''''''''''''''


### PR DESCRIPTION
Updated the documentation for setting up the MusicBrainz database for development and thus, added instructions for setting up by mounting a host directory containing dumps or by downloading the dumps.