### PR TITLE
CB-230: Fix error in getting revisions in ws and add test.

### DIFF
--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -167,7 +167,7 @@ def review_revision_entity_handler(review_id, rev):
     if rev > count:
         raise NotFound("Can't find the revision you are looking for.")
 
-    revision = db_revision.get(review_id, offset=count-rev)
+    revision = db_revision.get(review_id, offset=count-rev)[0]
     revision.update(id=rev)
     return jsonify(revision=revision)
 

--- a/critiquebrainz/ws/review/views_test.py
+++ b/critiquebrainz/ws/review/views_test.py
@@ -124,3 +124,12 @@ class ReviewViewsTestCase(WebServiceTestCase):
         self.client.put('/review/%s/vote' % review["id"], headers=self.header(self.another_user), data=json.dumps(vote))
         resp = self.client.delete('/review/%s/vote' % review["id"], headers=self.header(self.another_user))
         self.assert200(resp)
+
+    def test_revision_entity_handler(self):
+        review = self.create_dummy_review()
+        resp = self.client.get('/review/%s/revisions/1' % review["id"])
+        self.assert200(resp)
+        data = dict(text="This is an updated review")
+        resp = self.client.post('/review/%s' % review["id"], headers=self.header(self.user), data=json.dumps(data))
+        resp = self.client.get('/review/%s/revisions/2' % review["id"])
+        self.assert200(resp)


### PR DESCRIPTION
Fixes `AttributeError` in ws while getting revisions. Also added test `test_revision_entity_handler` for testing the ws endpoint.