### PR TITLE
Update current usage of the term 'rating'

### DIFF
--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -59,7 +59,7 @@ def get_by_id(review_id):
             "source_url": str,
             "last_revision: dict,
             "votes": dict,
-            "rating": int,
+            "popularity": int,
             "text": str,
             "created": datetime,
             "license": dict,
@@ -137,7 +137,7 @@ def get_by_id(review_id):
         votes = db_revision.votes(review["last_revision"]["id"])
         review["votes_positive_count"] = votes["positive"]
         review["votes_negative_count"] = votes["negative"]
-        review["rating"] = review["votes_positive_count"] - review["votes_negative_count"]
+        review["popularity"] = review["votes_positive_count"] - review["votes_negative_count"]
     return review
 
 
@@ -263,7 +263,7 @@ def create(*, entity_id, entity_type, user_id, is_draft, text,
             "source_url": str,
             "last_revision: dict,
             "votes": dict,
-            "rating": int,
+            "popularity": int,
             "text": str,
             "created": datetime,
             "license": dict,
@@ -419,7 +419,6 @@ def list_reviews(*, inc_drafts=False, inc_hidden=False, entity_id=None,
                latest_revision.id as latest_revision_id,
                latest_revision.timestamp as latest_revision_timestamp,
                latest_revision.text as text,
-               latest_revision.rating as rating,
                license.full_name,
                license.info_url
           FROM review
@@ -460,7 +459,6 @@ def list_reviews(*, inc_drafts=False, inc_hidden=False, entity_id=None,
                     "id": row.pop("latest_revision_id"),
                     "timestamp": row.pop("latest_revision_timestamp"),
                     "text": row["text"],
-                    "rating": row["rating"],
                     "review_id": row["id"],
                 }
                 row["user"] = User({
@@ -516,7 +514,6 @@ def get_popular(limit=None):
                        latest_revision.id AS latest_revision_id,
                        latest_revision.timestamp AS latest_revision_timestamp,
                        latest_revision.text AS text,
-                       latest_revision.rating AS rating
                   FROM review
                   JOIN revision ON revision.review_id = review.id
              LEFT JOIN (
@@ -561,7 +558,6 @@ def get_popular(limit=None):
                     "id": review.pop("latest_revision_id"),
                     "timestamp": review.pop("latest_revision_timestamp"),
                     "text": review["text"],
-                    "rating": review["rating"],
                     "review_id": review["id"],
                 }
             reviews = [to_dict(review, confidential=True) for review in reviews]

--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -513,7 +513,7 @@ def get_popular(limit=None):
                        ) AS popularity,
                        latest_revision.id AS latest_revision_id,
                        latest_revision.timestamp AS latest_revision_timestamp,
-                       latest_revision.text AS text,
+                       latest_revision.text AS text
                   FROM review
                   JOIN revision ON revision.review_id = review.id
              LEFT JOIN (

--- a/critiquebrainz/db/review_test.py
+++ b/critiquebrainz/db/review_test.py
@@ -159,7 +159,7 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(len(reviews), 1)
         self.assertEqual(reviews[0]["text"], "Beautiful!")
 
-        reviews, count = db_review.list_reviews(sort="rating")
+        reviews, count = db_review.list_reviews(sort="popularity")
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
 

--- a/critiquebrainz/frontend/views/event.py
+++ b/critiquebrainz/frontend/views/event.py
@@ -33,7 +33,7 @@ def entity(id):
 
     limit = int(request.args.get('limit', default=10))
     offset = int(request.args.get('offset', default=0))
-    reviews, count = db_review.list_reviews(entity_id=id, entity_type='event', sort='rating', limit=limit, offset=offset)
+    reviews, count = db_review.list_reviews(entity_id=id, entity_type='event', sort='popularity', limit=limit, offset=offset)
 
     return render_template('event/entity.html', id=id, event=event, reviews=reviews,
                            my_review=my_review, limit=limit, offset=offset, count=count)

--- a/critiquebrainz/frontend/views/place.py
+++ b/critiquebrainz/frontend/views/place.py
@@ -28,7 +28,7 @@ def entity(id):
 
     limit = int(request.args.get('limit', default=10))
     offset = int(request.args.get('offset', default=0))
-    reviews, count = db_review.list_reviews(entity_id=id, entity_type='place', sort='rating', limit=limit, offset=offset)
+    reviews, count = db_review.list_reviews(entity_id=id, entity_type='place', sort='popularity', limit=limit, offset=offset)
 
     return render_template('place/entity.html', id=id, place=place, reviews=reviews,
                            my_review=my_review, limit=limit, offset=offset, count=count)

--- a/critiquebrainz/frontend/views/release_group.py
+++ b/critiquebrainz/frontend/views/release_group.py
@@ -38,7 +38,7 @@ def entity(id):
             my_review = None
     else:
         my_review = None
-    reviews, count = db_review.list_reviews(entity_id=id, entity_type='release_group', sort='rating', limit=limit, offset=offset)
+    reviews, count = db_review.list_reviews(entity_id=id, entity_type='release_group', sort='popularity', limit=limit, offset=offset)
     return render_template('release_group/entity.html', id=id, release_group=release_group, reviews=reviews,
                            release=release, my_review=my_review, spotify_mappings=spotify_mappings, tags=tags,
                            soundcloud_url=soundcloud_url, limit=limit, offset=offset, count=count)

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -60,7 +60,7 @@ def review_entity_handler(review_id):
               "id": "CC BY-NC-SA 3.0",
               "info_url": "https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/"
             },
-            "rating": 0,
+            "popularity": 0,
             "source": "BBC",
             "source_url": "http:\/\/www.bbc.co.uk\/music\/reviews\/3vfd",
             "text": "REVIEW GOES HERE",
@@ -283,7 +283,7 @@ def review_list_handler():
                 "id": "CC BY-NC-SA 3.0",
                 "info_url": "https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/"
               },
-              "rating": 0,
+              "popularity": 0,
               "source": "BBC",
               "source_url": "http:\/\/www.bbc.co.uk\/music\/reviews\/vh54",
               "text": "REVIEW TEXT GOES HERE",

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -60,10 +60,10 @@ def review_entity_handler(review_id):
               "id": "CC BY-NC-SA 3.0",
               "info_url": "https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/"
             },
-            "rating": 0,
             "source": "BBC",
             "source_url": "http:\/\/www.bbc.co.uk\/music\/reviews\/3vfd",
             "text": "REVIEW GOES HERE",
+            "rating": 100, (Rating part of the review)
             "user": {
               "created": "Wed, 07 May 2014 14:55:23 GMT",
               "display_name": "Paul Clarke",
@@ -283,10 +283,10 @@ def review_list_handler():
                 "id": "CC BY-NC-SA 3.0",
                 "info_url": "https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/"
               },
-              "rating": 0,
               "source": "BBC",
               "source_url": "http:\/\/www.bbc.co.uk\/music\/reviews\/vh54",
               "text": "REVIEW TEXT GOES HERE",
+              "rating": 100, (Rating part of the review)
               "user": {
                 "created": "Wed, 07 May 2014 16:20:47 GMT",
                 "display_name": "Jenny Nelson",
@@ -303,7 +303,7 @@ def review_list_handler():
     :json uuid entity_id: UUID of the release group that is being reviewed
     :json string entity_type: One of the supported reviewable entities. 'release_group' or 'event' etc. **(optional)**
     :query user_id: user's UUID **(optional)**
-    :query sort: ``rating`` or ``created`` **(optional)**
+    :query sort: ``popularity`` or ``created`` **(optional)**
     :query limit: results limit, min is 0, max is 50, default is 50 **(optional)**
     :query offset: result offset, default is 0 **(optional)**
     :query language: language code (ISO 639-1) **(optional)**
@@ -320,7 +320,7 @@ def review_list_handler():
         entity_type = Parser.string('uri', 'entity_type', valid_values=ENTITY_TYPES, optional=True)
 
     user_id = Parser.uuid('uri', 'user_id', optional=True)
-    sort = Parser.string('uri', 'sort', valid_values=['rating', 'created'], optional=True)
+    sort = Parser.string('uri', 'sort', valid_values=['popularity', 'created'], optional=True)
     limit = Parser.int('uri', 'limit', min=1, max=50, optional=True) or 50
     offset = Parser.int('uri', 'offset', optional=True) or 0
     language = Parser.string('uri', 'language', min=2, max=3, optional=True)

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -60,10 +60,10 @@ def review_entity_handler(review_id):
               "id": "CC BY-NC-SA 3.0",
               "info_url": "https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/"
             },
+            "rating": 0,
             "source": "BBC",
             "source_url": "http:\/\/www.bbc.co.uk\/music\/reviews\/3vfd",
             "text": "REVIEW GOES HERE",
-            "rating": 100, (Rating part of the review)
             "user": {
               "created": "Wed, 07 May 2014 14:55:23 GMT",
               "display_name": "Paul Clarke",
@@ -283,10 +283,10 @@ def review_list_handler():
                 "id": "CC BY-NC-SA 3.0",
                 "info_url": "https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/"
               },
+              "rating": 0,
               "source": "BBC",
               "source_url": "http:\/\/www.bbc.co.uk\/music\/reviews\/vh54",
               "text": "REVIEW TEXT GOES HERE",
-              "rating": 100, (Rating part of the review)
               "user": {
                 "created": "Wed, 07 May 2014 16:20:47 GMT",
                 "display_name": "Jenny Nelson",


### PR DESCRIPTION
- Currently 'rating' is used as difference in +/- votes to list and determine
  popular reviews
- Changed it to 'net_votes' to avoid conflict with entity rating

I didn't change it to 'popularity' because we may change the criteria to determine popular reviews after the rating system has been implemented