### PR TITLE
Remove 'popularity' where its not used in correct form

### DIFF
--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -59,7 +59,6 @@ def get_by_id(review_id):
             "source_url": str,
             "last_revision: dict,
             "votes": dict,
-            "popularity": int,
             "text": str,
             "created": datetime,
             "license": dict,
@@ -137,7 +136,6 @@ def get_by_id(review_id):
         votes = db_revision.votes(review["last_revision"]["id"])
         review["votes_positive_count"] = votes["positive"]
         review["votes_negative_count"] = votes["negative"]
-        review["popularity"] = review["votes_positive_count"] - review["votes_negative_count"]
     return review
 
 
@@ -263,7 +261,6 @@ def create(*, entity_id, entity_type, user_id, is_draft, text,
             "source_url": str,
             "last_revision: dict,
             "votes": dict,
-            "popularity": int,
             "text": str,
             "created": datetime,
             "license": dict,

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -60,7 +60,6 @@ def review_entity_handler(review_id):
               "id": "CC BY-NC-SA 3.0",
               "info_url": "https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/"
             },
-            "popularity": 0,
             "source": "BBC",
             "source_url": "http:\/\/www.bbc.co.uk\/music\/reviews\/3vfd",
             "text": "REVIEW GOES HERE",
@@ -283,7 +282,6 @@ def review_list_handler():
                 "id": "CC BY-NC-SA 3.0",
                 "info_url": "https:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/"
               },
-              "popularity": 0,
               "source": "BBC",
               "source_url": "http:\/\/www.bbc.co.uk\/music\/reviews\/vh54",
               "text": "REVIEW TEXT GOES HERE",


### PR DESCRIPTION
In list_review and get_popular functions in db/review, all revisions' votes are considered in popularity which was not the case where changes are made.