### PR TITLE
CB-231: Reduce db queries for entity: place

### DIFF
--- a/critiquebrainz/frontend/external/musicbrainz_db/place.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/place.py
@@ -79,5 +79,8 @@ def fetch_multiple_places(mbids, *, includes=None):
                 includes_data=includes_data,
             )
 
+        for place in places:
+            includes_data[place.id]['area'] = place.area
+            includes_data[place.id]['type'] = place.type
         places = {str(place.gid): to_dict_places(place, includes_data[place.id]) for place in places}
     return places

--- a/critiquebrainz/frontend/external/musicbrainz_db/place.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/place.py
@@ -1,13 +1,13 @@
 from collections import defaultdict
 from mbdata import models
-from mbdata.utils import get_something_by_gid
+from sqlalchemy.orm import joinedload
+from brainzutils import cache
 from critiquebrainz.frontend.external.musicbrainz_db import mb_session
 from critiquebrainz.frontend.external.musicbrainz_db.includes import check_includes
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 from critiquebrainz.frontend.external.musicbrainz_db.serialize import to_dict_places
 from critiquebrainz.frontend.external.musicbrainz_db.helpers import get_relationship_info
 from critiquebrainz.frontend.external.relationships import place as place_rel
-from brainzutils import cache
+from critiquebrainz.frontend.external.musicbrainz_db.utils import get_entities_by_gids
 
 
 DEFAULT_CACHE_EXPIRATION = 12 * 60 * 60 # seconds (12 hours)
@@ -48,13 +48,10 @@ def fetch_multiple_places(mbids, *, includes=None):
     includes_data = defaultdict(dict)
     check_includes('place', includes)
     with mb_session() as db:
-        query = db.query(models.Place)
-        places = []
-        for mbid in mbids:
-            place = get_something_by_gid(query, models.PlaceGIDRedirect, mbid)
-            if not place:
-                raise mb_exceptions.NoDataFoundException("Couldn't find a place with id: {mbid}".format(mbid=mbid))
-            places.append(place)
+        query = db.query(models.Place).\
+                options(joinedload("area")).\
+                options(joinedload("type"))
+        places = get_entities_by_gids(query, models.Place, models.PlaceGIDRedirect, mbids)
         place_ids = [place.id for place in places]
 
         if 'artist-rels' in includes:

--- a/critiquebrainz/frontend/external/musicbrainz_db/place.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/place.py
@@ -51,7 +51,11 @@ def fetch_multiple_places(mbids, *, includes=None):
         query = db.query(models.Place).\
                 options(joinedload("area")).\
                 options(joinedload("type"))
-        places = get_entities_by_gids(query, models.Place, models.PlaceGIDRedirect, mbids)
+        places = get_entities_by_gids(
+            query=query,
+            entity_type='place',
+            mbids=mbids,
+        )
         place_ids = [place.id for place in places]
 
         if 'artist-rels' in includes:

--- a/critiquebrainz/frontend/external/musicbrainz_db/serialize.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/serialize.py
@@ -74,8 +74,8 @@ def to_dict_places(place, includes=None):
         'address': place.address,
     }
 
-    if place.type:
-        data['type'] = place.type.name
+    if 'type' in includes and includes['type']:
+        data['type'] = includes['type'].name
 
     if place.coordinates:
         data['coordinates'] = {
@@ -83,8 +83,8 @@ def to_dict_places(place, includes=None):
             'longitude': place.coordinates[1],
         }
 
-    if place.area:
-        data['area'] = to_dict_areas(place.area)
+    if 'area' in includes and includes['area']:
+        data['area'] = to_dict_areas(includes['area'])
 
     if 'relationship_objs' in includes:
         to_dict_relationships(data, place, includes['relationship_objs'])

--- a/critiquebrainz/frontend/external/musicbrainz_db/utils.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/utils.py
@@ -13,5 +13,5 @@ def get_entities_by_gids(query, entity_model, redirect_model, mbids):
         entities.extend(redirected_entities)
     remaining_gids = list(set(mbids) - {entity.gid for entity in entities})
     if remaining_gids:
-        raise mb_exceptions.NoDataFoundException("Couldn't find a place with id(s): {mbids}".format(mbids=remaining_gids))
+        raise mb_exceptions.NoDataFoundException("Couldn't find an entity with id(s): {mbids}".format(mbids=remaining_gids))
     return entities

--- a/critiquebrainz/frontend/external/musicbrainz_db/utils.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/utils.py
@@ -2,6 +2,17 @@ import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptio
 
 
 def get_entities_by_gids(query, entity_model, redirect_model, mbids):
+    """Get entities using their mbids.
+
+    Args:
+        query (Query): sqlalchemy Query object.
+        entity_model (mbdata.models): Model of the target entity.
+        redirect_model (mbdata.models): Redirect Model of the target entity.
+        mbids (list): IDs of the target entities.
+
+    Returns:
+        List of objects of target entities.
+    """
     entities = query.filter(entity_model.gid.in_(mbids)).all()
     remaining_gids = list(set(mbids) - {entity.gid for entity in entities})
     if remaining_gids:
@@ -13,5 +24,5 @@ def get_entities_by_gids(query, entity_model, redirect_model, mbids):
         entities.extend(redirected_entities)
     remaining_gids = list(set(mbids) - {entity.gid for entity in entities})
     if remaining_gids:
-        raise mb_exceptions.NoDataFoundException("Couldn't find an entity with id(s): {mbids}".format(mbids=remaining_gids))
+        raise mb_exceptions.NoDataFoundException("Couldn't find entities with IDs: {mbids}".format(mbids=remaining_gids))
     return entities

--- a/critiquebrainz/frontend/external/musicbrainz_db/utils.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/utils.py
@@ -1,0 +1,17 @@
+import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
+
+
+def get_entities_by_gids(query, entity_model, redirect_model, mbids):
+    entities = query.filter(entity_model.gid.in_(mbids)).all()
+    remaining_gids = list(set(mbids) - {entity.gid for entity in entities})
+    if remaining_gids:
+        redirects = query.session.query(redirect_model).filter(redirect_model.gid.in_(remaining_gids))
+        redirect_gids = {redirect.redirect_id: redirect.gid for redirect in redirects}
+        redirected_entities = query.filter(redirect_model.redirect.property.primaryjoin.left.in_(redirect_gids.keys())).all()
+        for entity in redirected_entities:
+            entity.gid = redirect_gids[entity.id]
+        entities.extend(redirected_entities)
+    remaining_gids = list(set(mbids) - {entity.gid for entity in entities})
+    if remaining_gids:
+        raise mb_exceptions.NoDataFoundException("Couldn't find a place with id(s): {mbids}".format(mbids=remaining_gids))
+    return entities

--- a/critiquebrainz/frontend/external/musicbrainz_db/utils.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/utils.py
@@ -1,18 +1,46 @@
 import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
+from mbdata import models
 
 
-def get_entities_by_gids(query, entity_model, redirect_model, mbids):
-    """Get entities using their mbids.
+# Entity models
+ENTITY_MODELS = {
+    'artist': models.Artist,
+    'place': models.Place,
+    'release_group': models.ReleaseGroup,
+    'release': models.Release,
+    'event': models.Event,
+}
+
+
+# Redirect models
+REDIRECT_MODELS = {
+    'place': models.PlaceGIDRedirect,
+    'artist': models.ArtistGIDRedirect,
+    'release': models.ReleaseGIDRedirect,
+    'release_group': models.ReleaseGroupGIDRedirect,
+    'event': models.EventGIDRedirect,
+}
+
+
+def get_entities_by_gids(*, query, entity_type, mbids):
+    """Get entities using their MBIDs.
+
+    An entity can have multiple MBIDs. This function may be passed another
+    MBID of an entity, in which case, it is redirected to the original entity.
+
+    Note that the query may be modified before passing it to this
+    function in order to save queries made to the database.
 
     Args:
-        query (Query): sqlalchemy Query object.
-        entity_model (mbdata.models): Model of the target entity.
-        redirect_model (mbdata.models): Redirect Model of the target entity.
+        query (Query): SQLAlchemy Query object.
+        entity_type (str): Type of entity being queried.
         mbids (list): IDs of the target entities.
 
     Returns:
         List of objects of target entities.
     """
+    entity_model = ENTITY_MODELS[entity_type]
+    redirect_model = REDIRECT_MODELS[entity_type]
     entities = query.filter(entity_model.gid.in_(mbids)).all()
     remaining_gids = list(set(mbids) - {entity.gid for entity in entities})
     if remaining_gids:


### PR DESCRIPTION
Reduces the number of db queries for entity: `place`. Using `joinedload` for `area` and `type` saves two queries. Also, added `get_entities_by_gid` which reduces the number of queries to fetch many places by `gid`.(to max 3 queries (in case of redirected entities, otherwise 1)). Also, fixes fetching entities for redirected mbids. A single `fetch_multiple_places` method now makes atmost 7 queries (4 for relationships + 3 for fetching all places(at max)) (for any number of `entity-gids`). 
I will also later update the tests for checking on the number of queries.