### PR TITLE
CB-231: Use direct db access for entity: release

### DIFF
--- a/critiquebrainz/frontend/external/musicbrainz_db/includes.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/includes.py
@@ -21,6 +21,9 @@ VALID_INCLUDES = {
     'place': ["aliases", "annotation"] + RELATION_INCLUDES + TAG_INCLUDES,
     'event': ["aliases"] + RELATION_INCLUDES + TAG_INCLUDES,
     'release_group': ["artists", "media", "releases"] + TAG_INCLUDES + RELATION_INCLUDES,
+    'release': [
+        "artists", "labels", "recordings", "release-groups", "media", "annotation", "aliases"
+    ] + TAG_INCLUDES + RELATION_INCLUDES
 }
 
 

--- a/critiquebrainz/frontend/external/musicbrainz_db/release.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/release.py
@@ -1,0 +1,109 @@
+from collections import defaultdict
+from mbdata import models
+from sqlalchemy.orm import joinedload
+from brainzutils import cache
+from critiquebrainz.frontend.external.musicbrainz_db import mb_session, DEFAULT_CACHE_EXPIRATION
+from critiquebrainz.frontend.external.musicbrainz_db.includes import check_includes
+from critiquebrainz.frontend.external.musicbrainz_db.serialize import to_dict_releases
+from critiquebrainz.frontend.external.musicbrainz_db.utils import get_entities_by_gids
+from critiquebrainz.frontend.external.musicbrainz_db.helpers import get_relationship_info
+
+
+def get_release_by_id(mbid):
+    """Get release with the MusicBrainz ID.
+
+    Args:
+        mbid (uuid): MBID(gid) of the release.
+    Returns:
+        Dictionary containing the release information.
+    """
+    key = cache.gen_key(mbid)
+    release = cache.get(key)
+    if not release:
+        release = _get_release_by_id(mbid)
+        cache.set(key=key, val=release, time=DEFAULT_CACHE_EXPIRATION)
+    return release
+
+
+def _get_release_by_id(mbid):
+    return fetch_multiple_releases(
+        [mbid],
+        includes=['media', 'release-groups'],
+    ).get(mbid)
+
+
+def fetch_multiple_releases(mbids, *, includes=None):
+    """Get info related to multiple releases using their MusicBrainz IDs.
+
+    Args:
+        mbids (list): List of MBIDs of releases.
+        includes (list): List of information to be included.
+
+    Returns:
+        Dictionary containing info of multiple releases keyed by their mbid.
+    """
+    if includes is None:
+        includes = []
+    includes_data = defaultdict(dict)
+    check_includes('release', includes)
+    with mb_session() as db:
+        query = db.query(models.Release)
+        if 'release-groups' in includes:
+            query = query.options(joinedload('release_group'))
+        if 'media' in includes:
+            # Fetch media with tracks
+            query = query.options(joinedload('mediums')).\
+                    options(joinedload('mediums.tracks')).\
+                    options(joinedload('mediums.format')).\
+                    options(joinedload('mediums.tracks.recording'))
+        releases = get_entities_by_gids(
+            query=query,
+            entity_type='release',
+            mbids=mbids,
+        )
+        release_ids = [release.id for release in releases.values()]
+
+        if 'release-groups' in includes:
+            for release in releases.values():
+                includes_data[release.id]['release-groups'] = release.release_group
+
+        if 'media' in includes:
+            for release in releases.values():
+                includes_data[release.id]['media'] = release.mediums
+
+        if 'url-rels' in includes:
+            get_relationship_info(
+                db=db,
+                target_type='url',
+                source_type='release',
+                source_entity_ids=release_ids,
+                includes_data=includes_data,
+            )
+        releases = {str(mbid): to_dict_releases(releases[mbid], includes_data[releases[mbid].id]) for mbid in mbids}
+    return releases
+
+
+def browse_releases(*, release_group_id, includes=None):
+    """Get all the releases by a certain release group.
+    You need to provide the Release Group's MusicBrainz ID.
+    """
+    if includes is None:
+        includes = []
+    with mb_session() as db:
+        release_ids = db.query(models.Release.gid).\
+                      join(models.ReleaseGroup).\
+                      filter(models.ReleaseGroup.gid == release_group_id).all()
+        release_ids = [release_id[0] for release_id in release_ids]
+    releases = fetch_multiple_releases(release_ids, includes=includes)
+    return releases
+
+
+def get_url_rels_from_releases(releases):
+    """Returns all url-rels for a list of releases in a single list (of url-rel dictionaries)
+    Typical usage with browse_releases()
+    """
+    all_url_rels = []
+    for release_gid in releases.keys():
+        if 'url-rels' in releases[release_gid]:
+            all_url_rels.extend([url_rel for url_rel in releases[release_gid]['url-rels']])
+    return all_url_rels

--- a/critiquebrainz/frontend/external/musicbrainz_db/test_data.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/test_data.py
@@ -324,6 +324,54 @@ release_numb_encore.mediums = [
 release_numb_encore.release_group = releasegroup_numb_encore
 release_numb_encore.status = releasestatus_official
 
+track_numb_encore_explicit_1 = Track()
+track_numb_encore_explicit_1.id = 7878846
+track_numb_encore_explicit_1.gid = '13aa9571-c0a0-3aaf-8159-9511658e5978'
+track_numb_encore_explicit_1.position = 1
+track_numb_encore_explicit_1.number = '1'
+track_numb_encore_explicit_1.name = 'Numb/Encore (explicit)'
+track_numb_encore_explicit_1.length = 208253
+track_numb_encore_explicit_1.is_data_track = False
+track_numb_encore_explicit_1.artist_credit = artistcredit_jay_z_linkin_park
+track_numb_encore_explicit_1.recording = recording_numb_encore_explicit
+
+track_numb_encore_instrumental_1 = Track()
+track_numb_encore_instrumental_1.id = 7878847
+track_numb_encore_instrumental_1.gid = '8f0abcc1-0ec0-3427-9e3e-925ee1e5b3e6'
+track_numb_encore_instrumental_1.position = 2
+track_numb_encore_instrumental_1.number = '2'
+track_numb_encore_instrumental_1.name = 'Numb/Encore (instrumental)'
+track_numb_encore_instrumental_1.length = 207453
+track_numb_encore_instrumental_1.is_data_track = False
+track_numb_encore_instrumental_1.artist_credit = artistcredit_jay_z_linkin_park
+track_numb_encore_instrumental_1.recording = recording_numb_encore_instrumental
+
+medium_2 = Medium()
+medium_2.id = 527716
+medium_2.position = 1
+medium_2.name = ''
+medium_2.track_count = 2
+medium_2.format = mediumformat_cd
+medium_2.tracks = [
+    track_numb_encore_explicit_1,
+    track_numb_encore_instrumental_1,
+]
+
+release_numb_encore_1 = Release()
+release_numb_encore_1.id = 527716
+release_numb_encore_1.gid = 'a64a0467-9d7a-4ffa-90b8-d87d9b41e311'
+release_numb_encore_1.name = 'Numb/Encore'
+release_numb_encore_1.barcode = '054391612328'
+release_numb_encore_1.comment = ''
+release_numb_encore_1.quality = -1
+release_numb_encore_1.artist_credit = artistcredit_jay_z_linkin_park
+release_numb_encore_1.mediums = [
+    medium_2,
+]
+release_numb_encore_1.release_group = releasegroup_numb_encore
+release_numb_encore_1.script = script_latin
+release_numb_encore_1.status = releasestatus_official
+
 releasegroupmeta_1 = ReleaseGroupMeta()
 releasegroupmeta_1.release_count = 4
 releasegroupmeta_1.first_release_date_year = 2004
@@ -361,3 +409,10 @@ event_ra_hall_uk.name = '1996-04-17: Royal Albert Hall, London, England, UK'
 event_ra_hall_uk.cancelled = False
 event_ra_hall_uk.ended = True
 event_ra_hall_uk.type = eventtype_concert
+
+release_collision_course = Release()
+release_collision_course.id = 28459
+release_collision_course.release_group = releasegroup_collision_course
+release_collision_course.gid = 'f51598f5-4ef9-4b8a-865d-06a077bf78cf'
+release_collision_course.name = 'Collision Course'
+release_collision_course.status = releasestatus_official

--- a/critiquebrainz/frontend/external/musicbrainz_db/tests/helpers_test.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/tests/helpers_test.py
@@ -29,6 +29,7 @@ class HelpersTestCase(TestCase):
             'url-rels': [
                 {
                     'type': 'official homepage',
+                    'type-id': '696b79da-7e45-40e6-a9d4-b31438eb7e5d',
                     'direction': 'forward',
                     'url': {
                         'id': '7462ea62-7439-47f7-93bc-a425d1d989e8',
@@ -37,6 +38,7 @@ class HelpersTestCase(TestCase):
                 },
                 {
                     'type': 'social network',
+                    'type-id': '040de4d5-ace5-4cfb-8a45-95c5c73bce01',
                     'direction': 'forward',
                     'url': {
                         'id': '8de22e00-c8e8-475f-814e-160ef761da63',

--- a/critiquebrainz/frontend/external/musicbrainz_db/tests/release_test.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/tests/release_test.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+from critiquebrainz.frontend.external.musicbrainz_db.tests import setup_cache
+from critiquebrainz.frontend.external.musicbrainz_db.test_data import release_numb_encore, release_collision_course, release_numb_encore_1
+from critiquebrainz.frontend.external.musicbrainz_db import release as mb_release
+
+
+class ReleaseTestCase(TestCase):
+
+    def setUp(self):
+        setup_cache()
+        mb_release.mb_session = MagicMock()
+        self.mock_db = mb_release.mb_session.return_value.__enter__.return_value
+        self.release_query = self.mock_db.query.return_value.options.return_value.options.return_value.\
+            options.return_value.options.return_value.options.return_value.filter.return_value.all
+
+    def test_get_by_id(self):
+        self.release_query.return_value = [release_numb_encore]
+        release = mb_release.get_release_by_id(
+            '16bee711-d7ce-48b0-adf4-51f124bcc0df'
+        )
+        self.assertEqual(release["name"], "Numb/Encore")
+        self.assertEqual(len(release["medium-list"][0]["track-list"]), 2)
+        self.assertDictEqual(release["medium-list"][0]["track-list"][0], {
+            "id": "dfe024b2-95b2-453f-b03e-3b9fa06f44e6",
+            "name": "Numb/Encore (explicit)",
+            "number": "1",
+            "position": 1,
+            "length": 207000,
+            "recording_id": "daccb724-8023-432a-854c-e0accb6c8678",
+            "recording_title": "Numb/Encore (explicit)"
+        })
+
+    def test_fetch_multiple_releases(self):
+        self.mock_db.query.return_value.filter.return_value.all.return_value = [release_numb_encore_1, release_collision_course]
+        releases = mb_release.fetch_multiple_releases(
+            mbids=['f51598f5-4ef9-4b8a-865d-06a077bf78cf', 'a64a0467-9d7a-4ffa-90b8-d87d9b41e311'],
+        )
+        self.assertEqual(len(releases), 2)
+        self.assertEqual(releases['a64a0467-9d7a-4ffa-90b8-d87d9b41e311']['name'], 'Numb/Encore')
+        self.assertEqual(releases['f51598f5-4ef9-4b8a-865d-06a077bf78cf']['name'], 'Collision Course')

--- a/critiquebrainz/frontend/external/soundcloud.py
+++ b/critiquebrainz/frontend/external/soundcloud.py
@@ -1,13 +1,13 @@
 import re
-from critiquebrainz.frontend.external import musicbrainz
+import critiquebrainz.frontend.external.musicbrainz_db.release as mb_release
 
 
 def get_url(mbid):
-    all_url_rels = musicbrainz.get_url_rels_from_releases(
-        musicbrainz.browse_releases(release_group=mbid, includes=['url-rels']) or []
+    all_url_rels = mb_release.get_url_rels_from_releases(
+        mb_release.browse_releases(release_group_id=mbid, includes=['url-rels']) or {}
     )
     for url_rel in all_url_rels:
         if url_rel['type-id'] == '08445ccf-7b99-4438-9f9a-fb9ac18099ee':  # "streaming music"
-            if re.match(r'^(http|https)://soundcloud.com', url_rel['target']):
-                return url_rel['target']
+            if re.match(r'^(http|https)://soundcloud.com', url_rel['url']['url']):
+                return url_rel['url']['url']
     return None

--- a/critiquebrainz/frontend/templates/release_group/entity.html
+++ b/critiquebrainz/frontend/templates/release_group/entity.html
@@ -111,13 +111,13 @@
               <tr>
                 <td>{{ track.number }}</td>
                 <td>
-                  <a href="http://acousticbrainz.org/{{ track.recording.id }}" title="View on AcousticBrainz">
-                    {{ track.recording.title }}
+                  <a href="http://acousticbrainz.org/{{ track.recording_id }}" title="View on AcousticBrainz">
+                    {{ track.recording_title }}
                   </a>
                 </td>
                 <td>
-                  {% if track.recording.length %}
-                    {{ track.recording.length | track_length }}
+                  {% if track.length %}
+                    {{ track.length | track_length }}
                   {% else %}
                     -
                   {% endif %}

--- a/critiquebrainz/frontend/views/release.py
+++ b/critiquebrainz/frontend/views/release.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, redirect
 from flask_babel import gettext
-from critiquebrainz.frontend.external import musicbrainz
+import critiquebrainz.frontend.external.musicbrainz_db.release as mb_release
 from werkzeug.exceptions import NotFound
 
 release_bp = Blueprint('release', __name__)
@@ -9,7 +9,7 @@ release_bp = Blueprint('release', __name__)
 @release_bp.route('/<uuid:id>')
 def entity(id):
     id = str(id)
-    release_data = musicbrainz.get_release_by_id(id)
+    release_data = mb_release.get_release_by_id(id)
     if release_data:
         group_id = release_data['release-group']['id']
         url = '/release-group/' + str(group_id)

--- a/critiquebrainz/frontend/views/release_group.py
+++ b/critiquebrainz/frontend/views/release_group.py
@@ -1,10 +1,11 @@
 from flask import Blueprint, render_template, request
 from flask_login import current_user
 from flask_babel import gettext
-from critiquebrainz.frontend.external import musicbrainz, mbspotify, soundcloud
+from critiquebrainz.frontend.external import mbspotify, soundcloud
 import critiquebrainz.frontend.external.musicbrainz_db.release_group as mb_release_group
 import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 import critiquebrainz.db.review as db_review
+import critiquebrainz.frontend.external.musicbrainz_db.release as mb_release
 from werkzeug.exceptions import NotFound
 
 
@@ -24,7 +25,7 @@ def entity(id):
     else:
         tags = None
     if 'release-list' in release_group and release_group['release-list']:
-        release = musicbrainz.get_release_by_id(release_group['release-list'][0]['id'])
+        release = mb_release.get_release_by_id(release_group['release-list'][0]['id'])
     else:
         release = None
     soundcloud_url = soundcloud.get_url(release_group['id'])

--- a/critiquebrainz/frontend/views/test/test_release.py
+++ b/critiquebrainz/frontend/views/test/test_release.py
@@ -1,8 +1,24 @@
+from unittest.mock import MagicMock
 from critiquebrainz.frontend.testing import FrontendTestCase
+import critiquebrainz.frontend.external.musicbrainz_db.release as mb_release
 
 
 class ReleaseViewsTestCase(FrontendTestCase):
 
+
+    def setUp(self):
+        super(ReleaseViewsTestCase, self).setUp()
+        mb_release.get_release_by_id = MagicMock()
+        mb_release.get_release_by_id.return_value = {
+            'id': '57ebb904-03de-47cd-89d6-ae444a31fc88',
+            'name': 'The 20/20 Experience',
+            'release-group': {
+                'id': 'deae6fc2-a675-4f35-9565-d2aaea4872c7',
+                'name': 'The 20/20 Experience',
+            }
+        }
+
+
     def test_release_page(self):
-        response = self.client.get("/release/4a3541a7-db1d-4da2-a36b-172c5f8b2cc4")
-        self.assertRedirects(response, "/release-group/4d1e6020-324d-4e8c-af1d-c7a2525a15ee")
+        response = self.client.get("/release/57ebb904-03de-47cd-89d6-ae444a31fc88")
+        self.assertRedirects(response, "/release-group/deae6fc2-a675-4f35-9565-d2aaea4872c7")


### PR DESCRIPTION
Used db access for entity: `release`. The work for using db for releases is complete but the tests (failing) are remaining. Will rebase this when I finish the `test_db` PR.