### PR TITLE
CB-231: Retrieve artist data directly from the MB database

### DIFF
--- a/critiquebrainz/frontend/external/musicbrainz_db/artist.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/artist.py
@@ -1,0 +1,79 @@
+from collections import defaultdict
+from sqlalchemy.orm import joinedload
+from mbdata import models
+from critiquebrainz.frontend.external.musicbrainz_db import mb_session, DEFAULT_CACHE_EXPIRATION
+from critiquebrainz.frontend.external.musicbrainz_db.helpers import get_relationship_info
+from critiquebrainz.frontend.external.relationships import artist as artist_rel
+from critiquebrainz.frontend.external.musicbrainz_db.utils import get_entities_by_gids
+from critiquebrainz.frontend.external.musicbrainz_db.serialize import to_dict_artists
+from brainzutils import cache
+
+
+def get_artist_by_id(mbid):
+    """Get artist with MusicBrainz ID.
+
+    Args:
+        mbid (uuid): MBID(gid) of the artist.
+    Returns:
+        Dictionary containing the artist information
+    """
+    key = cache.gen_key(mbid)
+    artist = cache.get(key)
+    if not artist:
+        artist = _get_artist_by_id(mbid)
+        cache.set(key=key, val=artist, time=DEFAULT_CACHE_EXPIRATION)
+    return artist_rel.process(artist)
+
+
+def _get_artist_by_id(mbid):
+    return fetch_multiple_artists(
+        [mbid],
+        includes=['artist-rels', 'url-rels'],
+    ).get(mbid)
+
+
+def fetch_multiple_artists(mbids, *, includes=None):
+    """Get info related to multiple artists using their MusicBrainz IDs.
+
+    Args:
+        mbids (list): List of MBIDs of artists.
+        includes (list): List of information to be included.
+
+    Returns:
+        Dictionary containing info of multiple artists keyed by their mbid.
+    """
+    if includes is None:
+        includes = []
+    includes_data = defaultdict(dict)
+    # TODO(ferbncode): Check includes
+    with mb_session() as db:
+        query = db.query(models.Artist).\
+                options(joinedload("type"))
+        artists = get_entities_by_gids(
+            query=query,
+            entity_type='artist',
+            mbids=mbids,
+        )
+        artist_ids = [artist.id for artist in artists.values()]
+
+        if 'artist-rels' in includes:
+            get_relationship_info(
+                db=db,
+                target_type='artist',
+                source_type='artist',
+                source_entity_ids=artist_ids,
+                includes_data=includes_data,
+            )
+        if 'url-rels' in includes:
+            get_relationship_info(
+                db=db,
+                target_type='url',
+                source_type='artist',
+                source_entity_ids=artist_ids,
+                includes_data=includes_data,
+            )
+
+    for artist in artists.values():
+        includes_data[artist.id]['type'] = artist.type
+    artists = {str(mbid): to_dict_artists(artists[mbid], includes_data[artists[mbid].id]) for mbid in mbids}
+    return artists

--- a/critiquebrainz/frontend/external/musicbrainz_db/artist.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/artist.py
@@ -6,6 +6,7 @@ from critiquebrainz.frontend.external.musicbrainz_db.helpers import get_relation
 from critiquebrainz.frontend.external.relationships import artist as artist_rel
 from critiquebrainz.frontend.external.musicbrainz_db.utils import get_entities_by_gids
 from critiquebrainz.frontend.external.musicbrainz_db.serialize import to_dict_artists
+from critiquebrainz.frontend.external.musicbrainz_db.includes import check_includes
 from brainzutils import cache
 
 
@@ -45,7 +46,7 @@ def fetch_multiple_artists(mbids, *, includes=None):
     if includes is None:
         includes = []
     includes_data = defaultdict(dict)
-    # TODO(ferbncode): Check includes
+    check_includes('artist', includes)
     with mb_session() as db:
         query = db.query(models.Artist).\
                 options(joinedload("type"))

--- a/critiquebrainz/frontend/external/musicbrainz_db/includes.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/includes.py
@@ -23,7 +23,8 @@ VALID_INCLUDES = {
     'release_group': ["artists", "media", "releases"] + TAG_INCLUDES + RELATION_INCLUDES,
     'release': [
         "artists", "labels", "recordings", "release-groups", "media", "annotation", "aliases"
-    ] + TAG_INCLUDES + RELATION_INCLUDES
+    ] + TAG_INCLUDES + RELATION_INCLUDES,
+    'artist': ["recordings", "releases", "media", "aliases", "annotation"] + RELATION_INCLUDES + TAG_INCLUDES,
 }
 
 

--- a/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from brainzutils import cache
 from sqlalchemy.orm import joinedload
+from sqlalchemy import case
 from mbdata import models
 from critiquebrainz.frontend.external.musicbrainz_db import mb_session, DEFAULT_CACHE_EXPIRATION
 from critiquebrainz.frontend.external.musicbrainz_db.helpers import get_relationship_info, get_tags
@@ -33,7 +34,8 @@ def fetch_multiple_release_groups(mbids, *, includes=None):
     check_includes('release_group', includes)
     with mb_session() as db:
         # Join table meta which contains release date for a release group
-        query = db.query(models.ReleaseGroup).options(joinedload("meta"))
+        query = db.query(models.ReleaseGroup).options(joinedload("meta")).\
+                options(joinedload("type"))
 
         if 'artists' in includes:
             query = query.\
@@ -98,6 +100,49 @@ def fetch_multiple_release_groups(mbids, *, includes=None):
 
         for release_group in release_groups.values():
             includes_data[release_group.id]['meta'] = release_group.meta
+            includes_data[release_group.id]['type'] = release_group.type
         release_groups = {str(mbid): to_dict_release_groups(release_groups[mbid], includes_data[release_groups[mbid].id])
                           for mbid in mbids}
         return release_groups
+
+
+def browse_release_groups(*, artist_id, release_types=None, limit=None, offset=None):
+    """Get all release groups linked to an artist.
+
+    Args:
+        artist_id (uuid): MBID of the artist.
+        release_types (list): List of types of release groups to be fetched.
+        limit (int): Max number of release groups to return.
+        offset (int): Offset that can be used in conjunction with the limit.
+
+    Returns:
+        Tuple containing the list of dictionaries of release groups ordered by release year
+        and the total count of the release groups.
+    """
+    artist_id = str(artist_id)
+    includes_data = defaultdict(dict)
+    if release_types is None:
+        release_types = []
+    release_types = [release_type.capitalize() for release_type in release_types]
+    key = cache.gen_key(artist_id, limit, offset, *release_types)
+    release_groups = cache.get(key)
+    if not release_groups:
+        with mb_session() as db:
+            release_groups = db.query(models.ReleaseGroup).\
+                options(joinedload('meta')).\
+                join(models.ReleaseGroupPrimaryType).join(models.ReleaseGroupMeta).\
+                join(models.ArtistCreditName, models.ArtistCreditName.artist_credit_id == models.ReleaseGroup.artist_credit_id).\
+                join(models.Artist, models.Artist.id == models.ArtistCreditName.artist_id).\
+                filter(models.Artist.gid == artist_id).filter(models.ReleaseGroupPrimaryType.name.in_(release_types))
+
+            count = release_groups.count()
+            release_groups = release_groups.order_by(
+                case([(models.ReleaseGroupMeta.first_release_date_year.is_(None), 1)], else_=0),
+                models.ReleaseGroupMeta.first_release_date_year.desc()
+            ).limit(limit).offset(offset)
+
+        for release_group in release_groups:
+            includes_data[release_group.id]['meta'] = release_group.meta
+        release_groups = ([to_dict_release_groups(release_group, includes_data[release_group.id]) for release_group in release_groups], count)
+        cache.set(key=key, val=release_groups, time=DEFAULT_CACHE_EXPIRATION)
+    return release_groups

--- a/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
@@ -143,6 +143,7 @@ def browse_release_groups(*, artist_id, release_types=None, limit=None, offset=N
 
         for release_group in release_groups:
             includes_data[release_group.id]['meta'] = release_group.meta
-        release_groups = ([to_dict_release_groups(release_group, includes_data[release_group.id]) for release_group in release_groups], count)
+        release_groups = ([to_dict_release_groups(release_group, includes_data[release_group.id])
+                           for release_group in release_groups], count)
         cache.set(key=key, val=release_groups, time=DEFAULT_CACHE_EXPIRATION)
     return release_groups

--- a/critiquebrainz/frontend/external/musicbrainz_db/serialize.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/serialize.py
@@ -18,7 +18,12 @@ def to_dict_relationships(data, source_obj, relationship_objs):
         if relation in relationship_objs:
             data[relation] = []
             for obj in relationship_objs[relation]:
-                link_data = {'type': obj.link.link_type.name, 'type-id': obj.link.link_type.gid}
+                link_data = {
+                    'type': obj.link.link_type.name,
+                    'type-id': obj.link.link_type.gid,
+                    'begin-year': obj.link.begin_date_year,
+                    'end-year': obj.link.end_date_year,
+                }
                 link_data['direction'] = 'forward' if source_obj.id == obj.entity0_id else 'backward'
                 if obj.link.ended:
                     link_data['ended'] = True
@@ -47,6 +52,9 @@ def to_dict_artists(artist, includes=None):
         'name': artist.name,
         'sort_name': artist.sort_name,
     }
+
+    if 'type' in includes and includes['type']:
+        data['type'] = includes['type'].name
 
     if 'relationship_objs' in includes:
         to_dict_relationships(data, artist, includes['relationship_objs'])
@@ -110,6 +118,9 @@ def to_dict_release_groups(release_group, includes=None):
         'id': release_group.gid,
         'title': release_group.name,
     }
+
+    if 'type' in includes and includes['type']:
+        data['type'] = includes['type'].name
 
     if 'artist-credit-phrase' in includes:
         data['artist-credit-phrase'] = includes['artist-credit-phrase']

--- a/critiquebrainz/frontend/external/musicbrainz_db/tests/artist_test.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/tests/artist_test.py
@@ -7,13 +7,11 @@ from critiquebrainz.frontend.external.musicbrainz_db.tests import setup_cache
 
 class ArtistTestCase(TestCase):
 
-
     def setUp(self):
         setup_cache()
         mb_artist.mb_session = MagicMock()
         self.mock_db = mb_artist.mb_session.return_value.__enter__.return_value
         self.artist_query = self.mock_db.query.return_value.options.return_value.filter.return_value.all
-
 
     def test_get_by_id(self):
         self.artist_query.return_value = [artist_linkin_park]
@@ -24,7 +22,6 @@ class ArtistTestCase(TestCase):
             "sort_name": "Linkin Park",
             "type": "Group"
         })
-
 
     def test_fetch_multiple_artists(self):
         self.artist_query.return_value = [artist_jay_z, artist_linkin_park]

--- a/critiquebrainz/frontend/external/musicbrainz_db/tests/artist_test.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/tests/artist_test.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+from critiquebrainz.frontend.external.musicbrainz_db.test_data import artist_linkin_park, artist_jay_z
+from critiquebrainz.frontend.external.musicbrainz_db import artist as mb_artist
+from critiquebrainz.frontend.external.musicbrainz_db.tests import setup_cache
+
+
+class ArtistTestCase(TestCase):
+
+
+    def setUp(self):
+        setup_cache()
+        mb_artist.mb_session = MagicMock()
+        self.mock_db = mb_artist.mb_session.return_value.__enter__.return_value
+        self.artist_query = self.mock_db.query.return_value.options.return_value.filter.return_value.all
+
+
+    def test_get_by_id(self):
+        self.artist_query.return_value = [artist_linkin_park]
+        artist = mb_artist.get_artist_by_id("f59c5520-5f46-4d2c-b2c4-822eabf53419")
+        self.assertDictEqual(artist, {
+            "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+            "name": "Linkin Park",
+            "sort_name": "Linkin Park",
+            "type": "Group"
+        })
+
+
+    def test_fetch_multiple_artists(self):
+        self.artist_query.return_value = [artist_jay_z, artist_linkin_park]
+        artists = mb_artist.fetch_multiple_artists([
+            "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+            "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+        ])
+        self.assertDictEqual(artists["f82bcf78-5b69-4622-a5ef-73800768d9ac"], {
+            "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+            "name": "JAY Z",
+            "sort_name": "JAY Z",
+            "type": "Person",
+        })
+        self.assertDictEqual(artists["f59c5520-5f46-4d2c-b2c4-822eabf53419"], {
+            "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+            "name": "Linkin Park",
+            "sort_name": "Linkin Park",
+            "type": "Group",
+        })

--- a/critiquebrainz/frontend/external/musicbrainz_db/tests/helpers_test.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/tests/helpers_test.py
@@ -32,6 +32,8 @@ class HelpersTestCase(TestCase):
                 {
                     'type': 'official homepage',
                     'type-id': '696b79da-7e45-40e6-a9d4-b31438eb7e5d',
+                    'begin-year': None,
+                    'end-year': None,
                     'direction': 'forward',
                     'url': {
                         'id': '7462ea62-7439-47f7-93bc-a425d1d989e8',
@@ -41,6 +43,8 @@ class HelpersTestCase(TestCase):
                 {
                     'type': 'social network',
                     'type-id': '040de4d5-ace5-4cfb-8a45-95c5c73bce01',
+                    'begin-year': None,
+                    'end-year': None,
                     'direction': 'forward',
                     'url': {
                         'id': '8de22e00-c8e8-475f-814e-160ef761da63',

--- a/critiquebrainz/frontend/external/musicbrainz_db/tests/release_group_test.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/tests/release_group_test.py
@@ -11,6 +11,7 @@ class ReleaseGroupTestCase(TestCase):
         setup_cache()
         mb_release_group.mb_session = MagicMock()
         self.mock_db = mb_release_group.mb_session.return_value.__enter__.return_value
+        # Mock sql query for fetching release groups and alter the return value to return SQLAlchemy objects.
         self._release_group_query = self.mock_db.query.return_value.options.return_value.options.return_value
         self._release_group_query_with_artists = self._release_group_query.options.return_value.options.return_value.\
             options.return_value
@@ -55,14 +56,11 @@ class ReleaseGroupTestCase(TestCase):
         self.assertEqual(release_groups['8ef859e3-feb2-4dd1-93da-22b91280d768']['title'], 'Collision Course')
 
     def test_fetch_browse_release_groups(self):
-        self._query = self.mock_db.query.return_value.options.return_value
-        self._joined_query = self._query.join.return_value.join.return_value.join.return_value.join.return_value
-        self._joined_filtered_query = self._joined_query.filter.return_value.filter.return_value
-        self.browse_release_groups_query_count = self._joined_filtered_query.count
-        self.browse_release_groups_query = self._joined_filtered_query.order_by.return_value.limit.return_value.offset
-
-        self.browse_release_groups_query_count.return_value = 2
-        self.browse_release_groups_query.return_value = [releasegroup_collision_course, releasegroup_numb_encore]
+        mb_release_group._browse_release_groups_query = MagicMock()
+        mock_query = mb_release_group._browse_release_groups_query.return_value
+        mock_query.count.return_value = 2
+        mock_query.order_by.return_value.limit.return_value.offset.\
+            return_value.all.return_value = [releasegroup_collision_course, releasegroup_numb_encore]
         release_groups = mb_release_group.browse_release_groups(
             artist_id='f59c5520-5f46-4d2c-b2c4-822eabf53419',
             release_types=['Single', 'EP'],

--- a/critiquebrainz/frontend/external/musicbrainz_db/tests/release_group_test.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/tests/release_group_test.py
@@ -11,14 +11,14 @@ class ReleaseGroupTestCase(TestCase):
         setup_cache()
         mb_release_group.mb_session = MagicMock()
         self.mock_db = mb_release_group.mb_session.return_value.__enter__.return_value
-        self.release_group_query = self.mock_db.query.return_value.options.return_value.options.return_value.\
-            options.return_value.options.return_value.options.return_value.filter.return_value.all
-        self.release_group_query_without_artists = self.mock_db.query.return_value.\
-            options.return_value.options.return_value.filter.return_value.all
-
+        self._release_group_query = self.mock_db.query.return_value.options.return_value.options.return_value
+        self._release_group_query_with_artists = self._release_group_query.options.return_value.options.return_value.\
+            options.return_value
+        self.release_group_query = self._release_group_query.filter.return_value.all
+        self.release_group_query_with_artists = self._release_group_query_with_artists.filter.return_value.all
 
     def test_get_by_id(self):
-        self.release_group_query.return_value = [releasegroup_numb_encore]
+        self.release_group_query_with_artists.return_value = [releasegroup_numb_encore]
         release_group = mb_release_group.get_release_group_by_id(
             '7c1014eb-454c-3867-8854-3c95d265f8de',
         )
@@ -46,7 +46,7 @@ class ReleaseGroupTestCase(TestCase):
         })
 
     def test_fetch_release_groups(self):
-        self.release_group_query_without_artists.return_value = [releasegroup_numb_encore, releasegroup_collision_course]
+        self.release_group_query.return_value = [releasegroup_numb_encore, releasegroup_collision_course]
         release_groups = mb_release_group.fetch_multiple_release_groups(
             mbids=['8ef859e3-feb2-4dd1-93da-22b91280d768', '7c1014eb-454c-3867-8854-3c95d265f8de'],
         )
@@ -54,12 +54,13 @@ class ReleaseGroupTestCase(TestCase):
         self.assertEqual(release_groups['7c1014eb-454c-3867-8854-3c95d265f8de']['title'], 'Numb/Encore')
         self.assertEqual(release_groups['8ef859e3-feb2-4dd1-93da-22b91280d768']['title'], 'Collision Course')
 
-
     def test_fetch_browse_release_groups(self):
-        self.browse_release_groups_query = self.mock_db.query.return_value.options.return_value.join.return_value.\
-            join.return_value.join.return_value.join.return_value.filter.return_value.filter.return_value
-        self.browse_release_groups_query_count = self.browse_release_groups_query.count
-        self.browse_release_groups_query = self.browse_release_groups_query.order_by.return_value.limit.return_value.offset
+        self._query = self.mock_db.query.return_value.options.return_value
+        self._joined_query = self._query.join.return_value.join.return_value.join.return_value.join.return_value
+        self._joined_filtered_query = self._joined_query.filter.return_value.filter.return_value
+        self.browse_release_groups_query_count = self._joined_filtered_query.count
+        self.browse_release_groups_query = self._joined_filtered_query.order_by.return_value.limit.return_value.offset
+
         self.browse_release_groups_query_count.return_value = 2
         self.browse_release_groups_query.return_value = [releasegroup_collision_course, releasegroup_numb_encore]
         release_groups = mb_release_group.browse_release_groups(

--- a/critiquebrainz/frontend/external/musicbrainz_db/tests/release_group_test.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/tests/release_group_test.py
@@ -11,10 +11,11 @@ class ReleaseGroupTestCase(TestCase):
         setup_cache()
         mb_release_group.mb_session = MagicMock()
         self.mock_db = mb_release_group.mb_session.return_value.__enter__.return_value
-        self.release_group_query = self.mock_db.query.return_value.options.return_value.\
+        self.release_group_query = self.mock_db.query.return_value.options.return_value.options.return_value.\
             options.return_value.options.return_value.options.return_value.filter.return_value.all
         self.release_group_query_without_artists = self.mock_db.query.return_value.\
-            options.return_value.filter.return_value.all
+            options.return_value.options.return_value.filter.return_value.all
+
 
     def test_get_by_id(self):
         self.release_group_query.return_value = [releasegroup_numb_encore]
@@ -52,3 +53,29 @@ class ReleaseGroupTestCase(TestCase):
         self.assertEqual(len(release_groups), 2)
         self.assertEqual(release_groups['7c1014eb-454c-3867-8854-3c95d265f8de']['title'], 'Numb/Encore')
         self.assertEqual(release_groups['8ef859e3-feb2-4dd1-93da-22b91280d768']['title'], 'Collision Course')
+
+
+    def test_fetch_browse_release_groups(self):
+        self.browse_release_groups_query = self.mock_db.query.return_value.options.return_value.join.return_value.\
+            join.return_value.join.return_value.join.return_value.filter.return_value.filter.return_value
+        self.browse_release_groups_query_count = self.browse_release_groups_query.count
+        self.browse_release_groups_query = self.browse_release_groups_query.order_by.return_value.limit.return_value.offset
+        self.browse_release_groups_query_count.return_value = 2
+        self.browse_release_groups_query.return_value = [releasegroup_collision_course, releasegroup_numb_encore]
+        release_groups = mb_release_group.browse_release_groups(
+            artist_id='f59c5520-5f46-4d2c-b2c4-822eabf53419',
+            release_types=['Single', 'EP'],
+        )
+        self.assertListEqual(release_groups[0], [
+            {
+                'id': '8ef859e3-feb2-4dd1-93da-22b91280d768',
+                'title': 'Collision Course',
+                'first-release-year': 2004,
+            },
+            {
+                'id': '7c1014eb-454c-3867-8854-3c95d265f8de',
+                'title': 'Numb/Encore',
+                'first-release-year': 2004,
+            }
+        ])
+        self.assertEqual(release_groups[1], 2)

--- a/critiquebrainz/frontend/external/relationships/artist.py
+++ b/critiquebrainz/frontend/external/relationships/artist.py
@@ -7,10 +7,10 @@ from flask_babel import lazy_gettext
 
 def process(artist):
     """Handles processing supported relation lists."""
-    if 'artist-relation-list' in artist and artist['artist-relation-list']:
-        artist['band-members'] = _artist(artist['artist-relation-list'])
-    if 'url-relation-list' in artist and artist['url-relation-list']:
-        artist['external-urls'] = _url(artist['url-relation-list'])
+    if 'artist-rels' in artist and artist['artist-rels']:
+        artist['band-members'] = _artist(artist['artist-rels'])
+    if 'url-rels' in artist and artist['url-rels']:
+        artist['external-urls'] = _url(artist['url-rels'])
     return artist
 
 

--- a/critiquebrainz/frontend/templates/artist/entity.html
+++ b/critiquebrainz/frontend/templates/artist/entity.html
@@ -88,7 +88,7 @@
                 <div class="release-group-title">
                   <a href="{{ url_for('release_group.entity', id=release_group.id) }}">{{ release_group.title }}</a>
                 </div>
-                {{ release_group['first-release-date'][:4] }}
+                {{ release_group['first-release-year'] }}
               </div>
             </div>
           </div>
@@ -167,7 +167,7 @@
                 <img src="{{ get_static_path('favicons/external-16.png') }}" />
               {% endif %}
             </div>
-            <a href="{{ url.target }}">{{ url.name }}</a>
+            <a href="{{ url.url.url }}">{{ url.name }}</a>
             {% if url.disambiguation %}<span class="text-muted">({{ url.disambiguation }})</span>{% endif %}
           </li>
         {% endfor %}

--- a/critiquebrainz/frontend/views/artist.py
+++ b/critiquebrainz/frontend/views/artist.py
@@ -2,8 +2,10 @@ from collections import OrderedDict
 from flask import Blueprint, render_template, request, redirect, url_for
 from flask_babel import gettext
 from werkzeug.exceptions import BadRequest, NotFound
-from critiquebrainz.frontend.external import musicbrainz
 import critiquebrainz.db.review as db_review
+import critiquebrainz.frontend.external.musicbrainz_db.artist as mb_artist
+import critiquebrainz.frontend.external.musicbrainz_db.release_group as mb_release_group
+import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 
 artist_bp = Blueprint('artist', __name__)
 
@@ -15,8 +17,9 @@ def entity(mbid):
     Displays release groups (split up into several sections depending on their
     type), artist information (type, members/member of, external links).
     """
-    artist = musicbrainz.get_artist_by_id(mbid)
-    if not artist:
+    try:
+        artist = mb_artist.get_artist_by_id(str(mbid))
+    except mb_exceptions.NoDataFoundException:
         raise NotFound(gettext("Sorry, we couldn't find an artist with that MusicBrainz ID."))
 
     # Note that some artists might not have a list of members because they are not a band
@@ -31,8 +34,12 @@ def entity(mbid):
         return redirect(url_for('.reviews'))
     limit = 20
     offset = (page - 1) * limit
-    count, release_groups = musicbrainz.browse_release_groups(artist_id=mbid, release_types=[release_type],
-                                                              limit=limit, offset=offset)
+    release_groups, count = mb_release_group.browse_release_groups(
+        artist_id=artist['id'],
+        release_types=[release_type],
+        limit=limit,
+        offset=offset,
+    )
     for release_group in release_groups:
         # TODO(roman): Count reviews instead of fetching them.
         reviews, review_count = db_review.list_reviews(  # pylint: disable=unused-variable
@@ -44,7 +51,7 @@ def entity(mbid):
 
     return render_template(
         'artist/entity.html',
-        id=mbid,
+        id=artist['id'],
         artist=artist,
         release_type=release_type,
         release_groups=release_groups,
@@ -58,8 +65,8 @@ def entity(mbid):
 def _get_band_members(artist):
     band_members = artist.get('band-members', [])
 
-    former_members = [member for member in band_members if member.get('ended', 'false') == 'true']
-    current_members = [member for member in band_members if member.get('ended', 'false') == 'false']
+    former_members = [member for member in band_members if member.get('ended', False) is True]
+    current_members = [member for member in band_members if member.get('ended', False) is False]
 
     return {
         'former_members': _squash_duplicated_members(former_members),
@@ -91,15 +98,9 @@ def _squash_duplicated_members(members):
 
 
 def _get_period(member):
-    begin_date = member.get('begin', None)
-    end_date = member.get('end', None)
+    begin_date = member.get('begin-year', '')
+    end_date = member.get('end-year', '')
 
-    def get_year_from_date(date):
-        if not date:
-            return ''
-        return date.split('-')[0]
-
-    begin_date, end_date = get_year_from_date(begin_date), get_year_from_date(end_date)
     if not (begin_date or end_date):
         return None
-    return begin_date, end_date
+    return str(begin_date), str(end_date)

--- a/critiquebrainz/frontend/views/artist.py
+++ b/critiquebrainz/frontend/views/artist.py
@@ -98,6 +98,15 @@ def _squash_duplicated_members(members):
 
 
 def _get_period(member):
+    """Get period for which an artist is/was part of a group, orchestra or choir.
+
+    Args:
+        member (Dict): Dictionary containing the artist information.
+
+    Returns:
+        Tuple containing the begin and end year during which an artist was part of
+        a group.
+    """
     begin_date = member.get('begin-year', '')
     end_date = member.get('end-year', '')
 

--- a/critiquebrainz/frontend/views/test/test_artist.py
+++ b/critiquebrainz/frontend/views/test/test_artist.py
@@ -24,17 +24,15 @@ def return_release_groups(*, artist_id, release_types=None, limit=None, offset=N
             'title': 'A Thousand Suns',
             'first-release-year': 2010,
         }], 1)
-    return ([], 0)
+    return [], 0
 
 
 class ArtistViewsTestCase(FrontendTestCase):
-
 
     def setUp(self):
         super(ArtistViewsTestCase, self).setUp()
         mb_artist.get_artist_by_id = MagicMock()
         mb_release_group.browse_release_groups = MagicMock(side_effect=return_release_groups)
-
 
     def test_artist_page(self):
         # Basic artist page should be available.

--- a/critiquebrainz/frontend/views/test/test_artist.py
+++ b/critiquebrainz/frontend/views/test/test_artist.py
@@ -7,23 +7,23 @@ import critiquebrainz.frontend.external.musicbrainz_db.artist as mb_artist
 def return_release_groups(*, artist_id, release_types=None, limit=None, offset=None):
     # pylint: disable=unused-argument
     if release_types == ['ep']:
-        return ([{
+        return [{
             'id': '8ef859e3-feb2-4dd1-93da-22b91280d768',
             'title': 'Collision Course',
             'first-release-year': 2004,
-        }], 1)
+        }], 1
     if release_types == ['single']:
-        return ([{
+        return [{
             'id': '7c1014eb-454c-3867-8854-3c95d265f8de',
             'title': 'Numb/Encore',
             'first-release-year': 2004,
-        }], 1)
+        }], 1
     if release_types == ['album']:
-        return ([{
+        return [{
             'id': '65404106-2976-4f98-a0e2-4e76923ea06d',
             'title': 'A Thousand Suns',
             'first-release-year': 2010,
-        }], 1)
+        }], 1
     return [], 0
 
 

--- a/critiquebrainz/frontend/views/test/test_artist.py
+++ b/critiquebrainz/frontend/views/test/test_artist.py
@@ -1,33 +1,71 @@
+from unittest.mock import MagicMock
 from critiquebrainz.frontend.testing import FrontendTestCase
+import critiquebrainz.frontend.external.musicbrainz_db.release_group as mb_release_group
+import critiquebrainz.frontend.external.musicbrainz_db.artist as mb_artist
+
+
+def return_release_groups(*, artist_id, release_types=None, limit=None, offset=None):
+    # pylint: disable=unused-argument
+    if release_types == ['ep']:
+        return ([{
+            'id': '8ef859e3-feb2-4dd1-93da-22b91280d768',
+            'title': 'Collision Course',
+            'first-release-year': 2004,
+        }], 1)
+    if release_types == ['single']:
+        return ([{
+            'id': '7c1014eb-454c-3867-8854-3c95d265f8de',
+            'title': 'Numb/Encore',
+            'first-release-year': 2004,
+        }], 1)
+    if release_types == ['album']:
+        return ([{
+            'id': '65404106-2976-4f98-a0e2-4e76923ea06d',
+            'title': 'A Thousand Suns',
+            'first-release-year': 2010,
+        }], 1)
+    return ([], 0)
 
 
 class ArtistViewsTestCase(FrontendTestCase):
 
+
+    def setUp(self):
+        super(ArtistViewsTestCase, self).setUp()
+        mb_artist.get_artist_by_id = MagicMock()
+        mb_release_group.browse_release_groups = MagicMock(side_effect=return_release_groups)
+
+
     def test_artist_page(self):
         # Basic artist page should be available.
-        response = self.client.get("/artist/aef06569-098f-4218-a577-b413944d9493")
+        mb_artist.get_artist_by_id.return_value = {
+            'id': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
+            'name': 'Linkin Park',
+            'sort-name': 'Linkin Park',
+        }
+        response = self.client.get('/artist/f59c5520-5f46-4d2c-b2c4-822eabf53419')
         self.assert200(response)
-        self.assertIn("HAIM", str(response.data))
+        self.assertIn('Linkin Park', str(response.data))
 
         # Album tab
-        response = self.client.get("/artist/aef06569-098f-4218-a577-b413944d9493?release_type=album")
+        response = self.client.get('/artist/f59c5520-5f46-4d2c-b2c4-822eabf53419?release_type=album')
         self.assert200(response)
-        self.assertIn("Days Are Gone", str(response.data))
+        self.assertIn('A Thousand Suns', str(response.data))
 
         # Singles tab
-        response = self.client.get("/artist/aef06569-098f-4218-a577-b413944d9493?release_type=single")
+        response = self.client.get('/artist/f59c5520-5f46-4d2c-b2c4-822eabf53419?release_type=single')
         self.assert200(response)
-        self.assertIn("The Wire", str(response.data))
+        self.assertIn('Numb/Encore', str(response.data))
 
         # EPs tab
-        response = self.client.get("/artist/aef06569-098f-4218-a577-b413944d9493?release_type=ep")
+        response = self.client.get('/artist/f59c5520-5f46-4d2c-b2c4-822eabf53419?release_type=ep')
         self.assert200(response)
-        self.assertIn("Forever", str(response.data))
+        self.assertIn('Collision Course', str(response.data))
 
         # Broadcasts tab
-        response = self.client.get("/artist/aef06569-098f-4218-a577-b413944d9493?release_type=broadcast")
+        response = self.client.get('/artist/f59c5520-5f46-4d2c-b2c4-822eabf53419?release_type=broadcast')
         self.assert200(response)
 
         # Other releases tab
-        response = self.client.get("/artist/aef06569-098f-4218-a577-b413944d9493?release_type=other")
+        response = self.client.get('/artist/f59c5520-5f46-4d2c-b2c4-822eabf53419?release_type=other')
         self.assert200(response)


### PR DESCRIPTION
Added functions for fetching artists information from mb database. 
Tasks remaining:
- [x] Tests
- [x] Fetching `release_groups` for an artist and sorting them by release year