### PR TITLE
Fix ISE on entity pages involving MBID redirects

### DIFF
--- a/critiquebrainz/frontend/external/musicbrainz_db/place.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/place.py
@@ -52,7 +52,7 @@ def fetch_multiple_places(mbids, *, includes=None):
             entity_type='place',
             mbids=mbids,
         )
-        place_ids = [place.id for place in places]
+        place_ids = [place.id for place in places.values()]
 
         if 'artist-rels' in includes:
             get_relationship_info(
@@ -79,8 +79,8 @@ def fetch_multiple_places(mbids, *, includes=None):
                 includes_data=includes_data,
             )
 
-        for place in places:
+        for place in places.values():
             includes_data[place.id]['area'] = place.area
             includes_data[place.id]['type'] = place.type
-        places = {str(place.gid): to_dict_places(place, includes_data[place.id]) for place in places}
+        places = {str(mbid): to_dict_places(places[mbid], includes_data[places[mbid].id]) for mbid in mbids}
     return places

--- a/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
@@ -45,10 +45,10 @@ def fetch_multiple_release_groups(mbids, *, includes=None):
             entity_type='release_group',
             mbids=mbids,
         )
-        release_group_ids = [release_group.id for release_group in release_groups]
+        release_group_ids = [release_group.id for release_group in release_groups.values()]
 
         if 'artists' in includes:
-            for release_group in release_groups:
+            for release_group in release_groups.values():
                 artist_credit_names = release_group.artist_credit.artists
                 includes_data[release_group.id]['artist-credit-names'] = artist_credit_names
                 includes_data[release_group.id]['artist-credit-phrase'] = release_group.artist_credit.name
@@ -95,8 +95,8 @@ def fetch_multiple_release_groups(mbids, *, includes=None):
             for release_group_id, tags in release_group_tags:
                 includes_data[release_group_id]['tags'] = tags
 
-        for release_group in release_groups:
+        for release_group in release_groups.values():
             includes_data[release_group.id]['meta'] = release_group.meta
-        release_groups = {str(release_group.gid): to_dict_release_groups(release_group, includes_data[release_group.id])
-                          for release_group in release_groups}
+        release_groups = {str(mbid): to_dict_release_groups(release_groups[mbid], includes_data[release_groups[mbid].id])
+                          for mbid in mbids}
         return release_groups

--- a/critiquebrainz/frontend/external/musicbrainz_db/utils.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/utils.py
@@ -37,7 +37,7 @@ def get_entities_by_gids(*, query, entity_type, mbids):
         mbids (list): IDs of the target entities.
 
     Returns:
-        Dictionary of objects of target entities keyed by their mbid.
+        Dictionary of objects of target entities keyed by their MBID.
     """
     entity_model = ENTITY_MODELS[entity_type]
     results = query.filter(entity_model.gid.in_(mbids)).all()

--- a/critiquebrainz/frontend/external/musicbrainz_db/utils.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/utils.py
@@ -1,5 +1,4 @@
 import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
-from critiquebrainz.frontend.external.musicbrainz_db import mb_session
 from mbdata import models
 
 
@@ -38,23 +37,19 @@ def get_entities_by_gids(*, query, entity_type, mbids):
         mbids (list): IDs of the target entities.
 
     Returns:
-        List of objects of target entities.
+        Dictionary of objects of target entities keyed by their mbid.
     """
     entity_model = ENTITY_MODELS[entity_type]
-    redirect_model = REDIRECT_MODELS[entity_type]
-    entities = query.filter(entity_model.gid.in_(mbids)).all()
-    remaining_gids = list(set(mbids) - {entity.gid for entity in entities})
+    results = query.filter(entity_model.gid.in_(mbids)).all()
+    remaining_gids = list(set(mbids) - {entity.gid for entity in results})
+    entities = {str(entity.gid): entity for entity in results}
     if remaining_gids:
-        redirects = query.session.query(redirect_model).filter(redirect_model.gid.in_(remaining_gids))
-        redirect_gids = {redirect.redirect_id: redirect.gid for redirect in redirects}
-        redirected_entities = query.filter(redirect_model.redirect.property.primaryjoin.left.in_(redirect_gids.keys())).all()
-        # Change gid of fetched redirected entities to the original gid.
-        with mb_session() as session:
-            with session.no_autoflush:
-                for entity in redirected_entities:
-                    entity.gid = redirect_gids[entity.id]
-        entities.extend(redirected_entities)
-    remaining_gids = list(set(mbids) - {entity.gid for entity in entities})
+        redirect_model = REDIRECT_MODELS[entity_type]
+        query = query.add_entity(redirect_model).join(redirect_model)
+        results = query.filter(redirect_model.gid.in_(remaining_gids))
+        for entity, redirect_obj in results:
+            entities[redirect_obj.gid] = entity
+        remaining_gids = list(set(mbids) - {redirect_obj.gid for entity, redirect_obj in results})
     if remaining_gids:
         raise mb_exceptions.NoDataFoundException("Couldn't find entities with IDs: {mbids}".format(mbids=remaining_gids))
     return entities

--- a/critiquebrainz/frontend/views/place.py
+++ b/critiquebrainz/frontend/views/place.py
@@ -18,7 +18,7 @@ def entity(id):
         raise NotFound(gettext("Sorry, we couldn't find a place with that MusicBrainz ID."))
 
     if current_user.is_authenticated:
-        my_reviews, my_count = db_review.list_reviews(entity_id=id, entity_type='place', user_id=current_user.id)
+        my_reviews, my_count = db_review.list_reviews(entity_id=place['id'], entity_type='place', user_id=current_user.id)
         if my_count != 0:
             my_review = my_reviews[0]
         else:
@@ -28,7 +28,7 @@ def entity(id):
 
     limit = int(request.args.get('limit', default=10))
     offset = int(request.args.get('offset', default=0))
-    reviews, count = db_review.list_reviews(entity_id=id, entity_type='place', sort='popularity', limit=limit, offset=offset)
+    reviews, count = db_review.list_reviews(entity_id=place['id'], entity_type='place', sort='popularity', limit=limit, offset=offset)
 
-    return render_template('place/entity.html', id=id, place=place, reviews=reviews,
+    return render_template('place/entity.html', id=place['id'], place=place, reviews=reviews,
                            my_review=my_review, limit=limit, offset=offset, count=count)

--- a/critiquebrainz/frontend/views/release_group.py
+++ b/critiquebrainz/frontend/views/release_group.py
@@ -27,22 +27,22 @@ def entity(id):
         release = musicbrainz.get_release_by_id(release_group['release-list'][0]['id'])
     else:
         release = None
-    soundcloud_url = soundcloud.get_url(id)
+    soundcloud_url = soundcloud.get_url(release_group['id'])
     if soundcloud_url:
         spotify_mappings = None
     else:
-        spotify_mappings = mbspotify.mappings(id)
+        spotify_mappings = mbspotify.mappings(release_group['id'])
     limit = int(request.args.get('limit', default=10))
     offset = int(request.args.get('offset', default=0))
     if current_user.is_authenticated:
-        my_reviews, my_count = db_review.list_reviews(entity_id=id, entity_type='release_group', user_id=current_user.id)
+        my_reviews, my_count = db_review.list_reviews(entity_id=release_group['id'], entity_type='release_group', user_id=current_user.id)
         if my_count != 0:
             my_review = my_reviews[0]
         else:
             my_review = None
     else:
         my_review = None
-    reviews, count = db_review.list_reviews(entity_id=id, entity_type='release_group', sort='popularity', limit=limit, offset=offset)
-    return render_template('release_group/entity.html', id=id, release_group=release_group, reviews=reviews,
+    reviews, count = db_review.list_reviews(entity_id=release_group['id'], entity_type='release_group', sort='popularity', limit=limit, offset=offset)
+    return render_template('release_group/entity.html', id=release_group['id'], release_group=release_group, reviews=reviews,
                            release=release, my_review=my_review, spotify_mappings=spotify_mappings, tags=tags,
                            soundcloud_url=soundcloud_url, limit=limit, offset=offset, count=count)


### PR DESCRIPTION
Due to sqlalchemy's `autoflushing`, it issues an `update` query while modifying redirected entity's `gid` field and this issue is raised https://sentry.metabrainz.org/share/issue/342e32363535/. I've updated the function `get_entities_by_gids` for fixing this. Eg. https://critiquebrainz.org/release-group/820ba931-840d-45f1-97ed-0cceaff26da0