### PR TITLE
Don't include reviews without text into the popular list

### DIFF
--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -559,6 +559,7 @@ def get_popular(limit=None):
                       ORDER BY RANDOM()
                       ) AS randomized_entity_ids
                     )
+                   AND latest_revision.text IS NOT NULL
               GROUP BY review.id, latest_revision.id
               ORDER BY popularity
                  LIMIT :limit


### PR DESCRIPTION
Modified the criteria for popular_reviews.
Consider only those reviews with text for popular_reviews. lt doesn't seem right to display reviews with only rating on the index page.