### PR TITLE
Constrain rating storage conversions within one module

### DIFF
--- a/critiquebrainz/db/__init__.py
+++ b/critiquebrainz/db/__init__.py
@@ -3,6 +3,10 @@ from sqlalchemy.pool import NullPool
 
 # This value must be incremented after schema changes on exported tables!
 SCHEMA_VERSION = 1
+VALID_RATING_VALUES = [None, 1, 2, 3, 4, 5]
+# Scales for rating conversion
+RATING_SCALE_0_100 = {1: 20, 2: 40, 3: 60, 4: 80, 5: 100}
+RATING_SCALE_1_5 = {20: 1, 40: 2, 60: 3, 80: 4, 100: 5}
 
 engine = None
 

--- a/critiquebrainz/db/avg_rating.py
+++ b/critiquebrainz/db/avg_rating.py
@@ -116,4 +116,4 @@ def get(entity_id, entity_type):
         avg_rating = dict(avg_rating)
         avg_rating["rating"] = round(avg_rating["rating"] / 20, 1)
 
-    return (avg_rating)
+    return avg_rating

--- a/critiquebrainz/db/avg_rating.py
+++ b/critiquebrainz/db/avg_rating.py
@@ -113,5 +113,7 @@ def get(entity_id, entity_type):
         if not avg_rating:
             raise db_exceptions.NoDataFoundException("""No rating for the entity with ID: {id} and Type: {type}""".
                                                      format(id=entity_id, type=entity_type))
+        avg_rating = dict(avg_rating)
+        avg_rating["rating"] = round(avg_rating["rating"] / 20, 1)
 
-    return dict(avg_rating)
+    return (avg_rating)

--- a/critiquebrainz/db/avg_rating_test.py
+++ b/critiquebrainz/db/avg_rating_test.py
@@ -31,7 +31,7 @@ class AvgRatingTestCase(DataTestCase):
             entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
             entity_type="release_group",
             text=u"Testing!",
-            rating=100,
+            rating=5,
             user_id=self.user.id,
             is_draft=False,
             license_id=self.license["id"],
@@ -39,7 +39,7 @@ class AvgRatingTestCase(DataTestCase):
         avg_rating = db_avg_rating.get(review["entity_id"], review["entity_type"])
         self.assertEqual(avg_rating["entity_id"], review["entity_id"])
         self.assertEqual(avg_rating["entity_type"], review["entity_type"])
-        self.assertEqual(avg_rating["rating"], review["rating"])
+        self.assertEqual(avg_rating["rating"], 5.0)
         self.assertEqual(avg_rating["count"], 1)
 
     def test_update(self):
@@ -49,7 +49,7 @@ class AvgRatingTestCase(DataTestCase):
             entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
             entity_type="release_group",
             text=u"Testing!",
-            rating=100,
+            rating=5,
             user_id=self.user.id,
             is_draft=False,
             license_id=self.license["id"],
@@ -58,7 +58,7 @@ class AvgRatingTestCase(DataTestCase):
             entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
             entity_type="release_group",
             text=u"Testing!",
-            rating=80,
+            rating=4,
             user_id=self.user_2.id,
             is_draft=False,
             license_id=self.license["id"],
@@ -66,7 +66,7 @@ class AvgRatingTestCase(DataTestCase):
         avg_rating = db_avg_rating.get(review["entity_id"], review["entity_type"])
         self.assertEqual(avg_rating["entity_id"], review["entity_id"])
         self.assertEqual(avg_rating["entity_type"], review["entity_type"])
-        self.assertEqual(avg_rating["rating"], 90)
+        self.assertEqual(avg_rating["rating"], 4.5)
         self.assertEqual(avg_rating["count"], 2)
 
         db_review.update(
@@ -77,7 +77,7 @@ class AvgRatingTestCase(DataTestCase):
         )
         # Check if avg_rating is updated after change in rating
         avg_rating = db_avg_rating.get(review["entity_id"], review["entity_type"])
-        self.assertEqual(avg_rating["rating"], 100)
+        self.assertEqual(avg_rating["rating"], 5.0)
         self.assertEqual(avg_rating["count"], 1)
 
         # Check if avg_rating is updated after a review with rating is deleted
@@ -92,7 +92,7 @@ class AvgRatingTestCase(DataTestCase):
             entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
             entity_type="release_group",
             text=u"Testing!",
-            rating=100,
+            rating=5,
             user_id=self.user.id,
             is_draft=False,
             license_id=self.license["id"],

--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -19,6 +19,7 @@ ENTITY_TYPES = [
     "place",
     "release_group",
 ]
+RATING_SCALE_1_5 = {20: 1, 40: 2, 60: 3, 80: 4, 100: 5}
 
 
 supported_languages = []
@@ -119,6 +120,7 @@ def get_by_id(review_id):
             raise db_exceptions.NoDataFoundException("Can't find review with ID: {id}".format(id=review_id))
 
         review = dict(review)
+        review["rating"] = RATING_SCALE_1_5.get(review["rating"])
         review["last_revision"] = {
             "id": review.pop("last_revision_id"),
             "timestamp": review.pop("timestamp"),
@@ -473,6 +475,7 @@ def list_reviews(*, inc_drafts=False, inc_hidden=False, entity_id=None,
         # Organise last revision info in reviews
         if rows:
             for row in rows:
+                row["rating"] = RATING_SCALE_1_5.get(row["rating"])
                 row["last_revision"] = {
                     "id": row.pop("latest_revision_id"),
                     "timestamp": row.pop("latest_revision_timestamp"),
@@ -575,6 +578,7 @@ def get_popular(limit=None):
         reviews = [dict(review) for review in reviews]
         if reviews:
             for review in reviews:
+                review["rating"] = RATING_SCALE_1_5.get(review["rating"])
                 review["last_revision"] = {
                     "id": review.pop("latest_revision_id"),
                     "timestamp": review.pop("latest_revision_timestamp"),

--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -7,7 +7,8 @@ from critiquebrainz import db
 from critiquebrainz.db import (exceptions as db_exceptions,
                                revision as db_revision,
                                users as db_users,
-                               avg_rating as db_avg_rating)
+                               avg_rating as db_avg_rating,
+                               RATING_SCALE_1_5)
 from critiquebrainz.db.user import User
 import pycountry
 
@@ -19,7 +20,6 @@ ENTITY_TYPES = [
     "place",
     "release_group",
 ]
-RATING_SCALE_1_5 = {20: 1, 40: 2, 60: 3, 80: 4, 100: 5}
 
 
 supported_languages = []

--- a/critiquebrainz/db/review_test.py
+++ b/critiquebrainz/db/review_test.py
@@ -32,7 +32,7 @@ class ReviewTestCase(DataTestCase):
             entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
             entity_type="release_group",
             text="Testing",
-            rating=100,
+            rating=5,
             is_draft=False,
             license_id=self.license["id"],
         )
@@ -98,7 +98,7 @@ class ReviewTestCase(DataTestCase):
             entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
             entity_type="release_group",
             text="Testing",
-            rating=100,
+            rating=5,
             is_draft=True,
             license_id=self.license["id"],
         )
@@ -110,7 +110,7 @@ class ReviewTestCase(DataTestCase):
         db_review.update(
             review_id=review["id"],
             drafted=review["is_draft"],
-            rating=80,
+            rating=4,
             is_draft=False,
             license_id=another_license["id"],
             language="es",
@@ -118,7 +118,7 @@ class ReviewTestCase(DataTestCase):
         # Checking if contents are updated
         retrieved_review = db_review.list_reviews()[0][0]
         self.assertEqual(retrieved_review["text"], None)
-        self.assertEqual(retrieved_review["rating"], 80)
+        self.assertEqual(retrieved_review["rating"], 4)
         self.assertFalse(retrieved_review["is_draft"])
         self.assertEqual(retrieved_review["license_id"], another_license["id"])
         self.assertEqual(retrieved_review["language"], "es")
@@ -170,7 +170,7 @@ class ReviewTestCase(DataTestCase):
             entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
             entity_type="release_group",
             text="Awesome",
-            rating=100,
+            rating=5,
             is_draft=False,
             license_id=self.license["id"],
         )
@@ -178,19 +178,19 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
         self.assertEqual(reviews[0]["text"], "Awesome")
-        self.assertEqual(reviews[0]["rating"], 100)
+        self.assertEqual(reviews[0]["rating"], 5)
 
         db_review.update(
             review_id=review["id"],
             drafted=review["is_draft"],
             text="Beautiful!",
-            rating=80,
+            rating=4,
         )
         reviews, count = db_review.list_reviews()
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
         self.assertEqual(reviews[0]["text"], "Beautiful!")
-        self.assertEqual(reviews[0]["rating"], 80)
+        self.assertEqual(reviews[0]["rating"], 4)
 
         reviews, count = db_review.list_reviews(sort="popularity")
         self.assertEqual(count, 1)
@@ -243,7 +243,7 @@ class ReviewTestCase(DataTestCase):
             user_id=self.user.id,
             entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
             entity_type="release_group",
-            rating=100,
+            rating=5,
             is_draft=False,
             license_id=self.license["id"],
         )
@@ -263,7 +263,7 @@ class ReviewTestCase(DataTestCase):
             user_id=self.user_2.id,
             entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
             entity_type="release_group",
-            rating=100,
+            rating=5,
             is_draft=False,
             license_id=self.license["id"],
         )

--- a/critiquebrainz/db/revision.py
+++ b/critiquebrainz/db/revision.py
@@ -3,11 +3,8 @@ from critiquebrainz import db
 from critiquebrainz.db import review as db_review
 from critiquebrainz.db import avg_rating as db_avg_rating
 from critiquebrainz.db import exceptions as db_exceptions
+from critiquebrainz.db import VALID_RATING_VALUES, RATING_SCALE_1_5, RATING_SCALE_0_100
 import sqlalchemy
-
-VALID_RATING_VALUES = [None, 1, 2, 3, 4, 5]
-RATING_SCALE_0_100 = {1: 20, 2: 40, 3: 60, 4: 80, 5: 100}
-RATING_SCALE_1_5 = {20: 1, 40: 2, 60: 3, 80: 4, 100: 5}
 
 
 def get(review_id, limit=1, offset=0):

--- a/critiquebrainz/db/revision.py
+++ b/critiquebrainz/db/revision.py
@@ -5,6 +5,9 @@ from critiquebrainz.db import avg_rating as db_avg_rating
 from critiquebrainz.db import exceptions as db_exceptions
 import sqlalchemy
 
+VALID_RATING_VALUES = [None, 1, 2, 3, 4, 5]
+RATING_SCALE_0_100 = {1: 20, 2: 40, 3: 60, 4: 80, 5: 100}
+
 
 def get(review_id, limit=1, offset=0):
     """Get revisions on a review ordered by the timestamp
@@ -163,6 +166,10 @@ def create(review_id, text=None, rating=None):
     """
     if text is None and rating is None:
         raise db_exceptions.BadDataException("Text part and rating part of a revision can not be None simultaneously")
+    if rating not in VALID_RATING_VALUES:
+        raise ValueError("{} is not a valid rating value. It must be on the scale 1-5".format(rating))
+    # Convert ratings to values on a scale 0-100
+    rating = RATING_SCALE_0_100.get(rating)
 
     with db.engine.connect() as connection:
         connection.execute(sqlalchemy.text("""

--- a/critiquebrainz/db/revision.py
+++ b/critiquebrainz/db/revision.py
@@ -7,6 +7,7 @@ import sqlalchemy
 
 VALID_RATING_VALUES = [None, 1, 2, 3, 4, 5]
 RATING_SCALE_0_100 = {1: 20, 2: 40, 3: 60, 4: 80, 5: 100}
+RATING_SCALE_1_5 = {20: 1, 40: 2, 60: 3, 80: 4, 100: 5}
 
 
 def get(review_id, limit=1, offset=0):
@@ -61,6 +62,9 @@ def get(review_id, limit=1, offset=0):
         if not rows:
             raise db_exceptions.NoDataFoundException("Cannot find specified review.")
         rows = [dict(row) for row in rows]
+        # Convert ratings to values on a scale 1-5
+        for row in rows:
+            row["rating"] = RATING_SCALE_1_5.get(row["rating"])
     return rows
 
 

--- a/critiquebrainz/db/revision_test.py
+++ b/critiquebrainz/db/revision_test.py
@@ -29,7 +29,7 @@ class RevisionTestCase(DataTestCase):
             entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
             entity_type="release_group",
             text=u"Testing!",
-            rating=100,
+            rating=5,
             is_draft=False,
             license_id=self.license["id"],
         )
@@ -43,7 +43,7 @@ class RevisionTestCase(DataTestCase):
         first_revision = revision.get(review_id)[0]
         self.assertEqual(count, 1)
         self.assertEqual(first_revision['text'], "Testing!")
-        self.assertEqual(first_revision['rating'], 100)
+        self.assertEqual(first_revision['rating'], 5)
         self.assertEqual(type(first_revision['timestamp']), datetime)
         self.assertEqual(type(first_revision['id']), int)
 
@@ -51,13 +51,13 @@ class RevisionTestCase(DataTestCase):
             review_id=self.review["id"],
             drafted=self.review["is_draft"],
             text="Testing Again!",
-            rating=80,
+            rating=4,
         )
         second_revision = revision.get(review_id)[0]
         count = revision.get_count(review_id)
         self.assertEqual(count, 2)
         self.assertEqual(second_revision['text'], "Testing Again!")
-        self.assertEqual(second_revision['rating'], 80)
+        self.assertEqual(second_revision['rating'], 4)
         self.assertEqual(type(second_revision['timestamp']), datetime)
         self.assertEqual(type(second_revision['id']), int)
 
@@ -65,7 +65,7 @@ class RevisionTestCase(DataTestCase):
             review_id=self.review["id"],
             drafted=self.review["is_draft"],
             text="Testing Once Again!",
-            rating=60,
+            rating=3,
         )
         # Testing offset and limit
         first_two_revisions = revision.get(review_id, limit=2, offset=1)
@@ -73,8 +73,8 @@ class RevisionTestCase(DataTestCase):
         self.assertEqual(count, 3)
         self.assertEqual(first_two_revisions[1]['text'], "Testing!")
         self.assertEqual(first_two_revisions[0]['text'], "Testing Again!")
-        self.assertEqual(first_two_revisions[1]['rating'], 100)
-        self.assertEqual(first_two_revisions[0]['rating'], 80)
+        self.assertEqual(first_two_revisions[1]['rating'], 5)
+        self.assertEqual(first_two_revisions[0]['rating'], 4)
 
     def test_get_all_votes(self):
         """Test to get the number of votes on revisions of a review"""

--- a/critiquebrainz/db/vote_test.py
+++ b/critiquebrainz/db/vote_test.py
@@ -30,7 +30,7 @@ class VoteTestCase(DataTestCase):
             entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
             entity_type="release_group",
             text="Testing!",
-            rating=100,
+            rating=5,
             user_id=author.id,
             is_draft=False,
             license_id=license["id"],


### PR DESCRIPTION
Now, the whole CB codebase can use the scale of 1-5 for ratings.
For storage, ratings will be converted to the scale 0-100 right before inserting them into the database.