### PR TITLE
CB-84: Add checkbox to filter releases with reviews on artist discography pages.

### DIFF
--- a/critiquebrainz/frontend/static/gulpfile.js
+++ b/critiquebrainz/frontend/static/gulpfile.js
@@ -99,11 +99,15 @@ function buildScripts() {
   let spotifyBundle = runYarb('spotify.js', function (b) {
     b.external(commonBundle);
   });
+  let releaseGroupBundle = runYarb('release_groups.js', function (b) {
+    b.external(commonBundle);
+  });
 
   return Q.all([
     writeScript(commonBundle, 'common.js'),
     writeScript(leafletBundle, 'leaflet.js'),
     writeScript(spotifyBundle, 'spotify.js'),
+    writeScript(releaseGroupBundle, 'release_groups.js'),
   ]).then(writeManifest);
 }
 

--- a/critiquebrainz/frontend/static/scripts/release_groups.js
+++ b/critiquebrainz/frontend/static/scripts/release_groups.js
@@ -1,16 +1,72 @@
 $(document).ready(function() {
+  var page = 0, releaseGroups, totalPages, limit=20;
+  releaseGroups = $('.release-group');
+  showReleaseGroups(releaseGroups);
+
   $("#only-reviewed").change(function() {
     if($('#only-reviewed').is(":checked")) {
-      $(".not_reviewed").hide();
-      var reviewed = $('.reviewed').length;
-      var release_group_count = $('.release-group').length;
-      if(reviewed == 0 && release_group_count != 0) {
-          $("#no-reviewed-entities").removeClass('hidden');
+      if(!$('.has-review').length){
+        $('#no-reviewed-entities').removeClass('hidden');
       }
+      showReleaseGroups('.has-review');
     }
     else {
-      $(".not_reviewed").show();
-      $("#no-reviewed-entities").addClass('hidden');
+      $('#no-reviewed-entities').addClass('hidden');
+      showReleaseGroups('.release-group');
     }
-  })
+  });
+
+  $('.nextLink').click(function(link) {
+    link.preventDefault();
+    changePage(page, 1);
+    if(page === 0){
+      $('.previous').removeClass('hidden');
+    }
+    page += 1;
+    if(page === totalPages - 1) {
+      $('.next').addClass('hidden');
+    }
+  });
+
+  $('.previousLink').click(function(link) {
+    link.preventDefault();
+    changePage(page, -1);
+    if(page === totalPages - 1) {
+      $('.next').removeClass('hidden');
+    }
+    page -= 1;
+    if(page === 0) {
+      $('.previous').addClass('hidden');
+    }
+  });
+
+  function showReleaseGroups(className) {
+    releaseGroups = $(className);
+    totalPages = Math.floor(releaseGroups.length / 20);
+    if(releaseGroups.length % 20) {
+      totalPages += 1;
+    }
+    page = 0;
+    $('.release-group').addClass('hidden');
+    $('.previous').addClass('hidden');
+    if(totalPages <= 1) {
+      $('.next').addClass('hidden');
+    } else {
+      $('.next').removeClass('hidden');
+    }
+    changePage(page, 0);
+  }
+
+  function changePage(current, change) {
+    var prev = releaseGroups.slice(current*limit, current*limit + limit);
+    var cur = releaseGroups.slice((current+change)*limit, (current+change)*limit + limit);
+    if(change){
+      [].forEach.call(prev, function(element) {
+        $(element).addClass('hidden');
+      });
+    }
+    [].forEach.call(cur, function(element) {
+      $(element).removeClass('hidden');
+    });
+  }
 })

--- a/critiquebrainz/frontend/static/scripts/release_groups.js
+++ b/critiquebrainz/frontend/static/scripts/release_groups.js
@@ -1,0 +1,16 @@
+$(document).ready(function() {
+  $("#only-reviewed").change(function() {
+    if($('#only-reviewed').is(":checked")) {
+      $(".not_reviewed").hide();
+      var reviewed = $('.reviewed').length;
+      var release_group_count = $('.release-group').length;
+      if(reviewed == 0 && release_group_count != 0) {
+          $("#no-reviewed-entities").removeClass('hidden');
+      }
+    }
+    else {
+      $(".not_reviewed").show();
+      $("#no-reviewed-entities").addClass('hidden');
+    }
+  })
+})

--- a/critiquebrainz/frontend/templates/artist/entity.html
+++ b/critiquebrainz/frontend/templates/artist/entity.html
@@ -85,7 +85,7 @@
       <div id="release-groups" class="row">
         {% for release_group in release_groups %}
         {% set has_reviews = (release_group.review_count > 0) %}
-          <div class="col-sm-4 col-md-4 col-lg-3 release-group {% if not has_reviews %}not_reviewed{% endif %}">
+          <div class="col-sm-4 col-md-4 col-lg-3 hidden release-group {% if has_reviews %}has-review{% endif %}">
             <div class="thumbnail clearfix {% if has_reviews %}reviewed{% endif %}">
               {% if has_reviews %}
                 <div class="review-count">
@@ -108,18 +108,12 @@
         {% endfor %}
         <div class="clearfix"></div>
 
-        {% if count > limit %}
-          <div class="col-md-12">
-            <ul class="pager">
-              {% if page > 1 %}
-                <li class="previous"><a href="{{ url_for('artist.entity', mbid=id, release_type=release_type, page=page-1) }}">&larr; {{ _('Previous') }}</a></li>
-              {% endif %}
-              {% if page-1 < count//limit %}
-                <li class="next"><a href="{{ url_for('artist.entity', mbid=id, release_type=release_type, page=page+1) }}">{{ _('Next') }} &rarr;</a></li>
-              {% endif %}
-            </ul>
-          </div>
-        {% endif %}
+        <div class="col-md-12">
+          <ul class="pager">
+            <li class="previous"><a href="#" class="previousLink">&larr; {{ _('Previous') }}</a></li>
+            <li class="next"><a href="#" class="nextLink">{{ _('Next') }} &rarr;</a></li>
+          </ul>
+        </div>
       </div>
     {% endif %}
   </div>

--- a/critiquebrainz/frontend/templates/artist/entity.html
+++ b/critiquebrainz/frontend/templates/artist/entity.html
@@ -54,8 +54,8 @@
       </div>
       <div class="col-sm-4">
         <div>
-          <input type="checkbox" name="only-reviewed" value="1" class="only-reviewed" onchange="showOnlyReviewed()"/>
-          {{ _('Filter releases here with reviews') }}<br/>
+          <input type="checkbox" name="only-reviewed" value="1" id="only-reviewed"/>
+          {{ _('Only show releases with reviews') }}<br/>
         </div>
       </div>
     </div>
@@ -76,7 +76,7 @@
         <a href="{{ url_for('artist.entity', mbid=artist.id) }}?release_type=other">{{ _('Other releases') }}</a>
       </li>
     </ul>
-    <div class="no_reviewed_entities">
+    <div id="no-reviewed-entities" class="hidden">
       <p class="lead" style="text-align:center; margin-top:20px;">{{ _('No reviewed releases found here') }}</p>
     </div>
     {% if count==0 %}
@@ -198,20 +198,21 @@
 {% block scripts %}
   {{ super() }}
   <script>
-  $(".no_reviewed_entities").hide();
-  function showOnlyReviewed() {
-      if($('.only-reviewed').is(":checked")) {
-        $(".not_reviewed").hide();
-        var reviewed = $('.reviewed').length;
-        var release_group_count = $('.release-group').length;
-        if(reviewed == 0 && release_group_count != 0) {
-            $(".no_reviewed_entities").show();
+    $(document).ready(function() {
+      $("#only-reviewed").change(function() {
+        if($('#only-reviewed').is(":checked")) {
+          $(".not_reviewed").hide();
+          var reviewed = $('.reviewed').length;
+          var release_group_count = $('.release-group').length;
+          if(reviewed == 0 && release_group_count != 0) {
+              $("#no-reviewed-entities").removeClass('hidden');
+          }
         }
-      }
-      else {
-        $(".not_reviewed").show();
-        $(".no_reviewed_entities").hide();
-      }
-  }
+        else {
+          $(".not_reviewed").show();
+          $("#no-reviewed-entities").addClass('hidden');
+        }
+      })
+    })
   </script>
 {% endblock %}

--- a/critiquebrainz/frontend/templates/artist/entity.html
+++ b/critiquebrainz/frontend/templates/artist/entity.html
@@ -55,7 +55,7 @@
       <div class="col-sm-4">
         <div>
           <input type="checkbox" name="only-reviewed" value="1" id="only-reviewed"/>
-          {{ _('Only show releases with reviews') }}<br/>
+          {{ _('Only show release groups with reviews') }}<br/>
         </div>
       </div>
     </div>
@@ -197,22 +197,5 @@
 
 {% block scripts %}
   {{ super() }}
-  <script>
-    $(document).ready(function() {
-      $("#only-reviewed").change(function() {
-        if($('#only-reviewed').is(":checked")) {
-          $(".not_reviewed").hide();
-          var reviewed = $('.reviewed').length;
-          var release_group_count = $('.release-group').length;
-          if(reviewed == 0 && release_group_count != 0) {
-              $("#no-reviewed-entities").removeClass('hidden');
-          }
-        }
-        else {
-          $(".not_reviewed").show();
-          $("#no-reviewed-entities").addClass('hidden');
-        }
-      })
-    })
-  </script>
+  <script src="{{ get_static_path('release_groups.js') }}"></script>
 {% endblock %}

--- a/critiquebrainz/frontend/templates/artist/entity.html
+++ b/critiquebrainz/frontend/templates/artist/entity.html
@@ -48,7 +48,17 @@
 
 <div class="row">
   <div class="col-sm-9">
-    <h4>{{ _('Discography') }}</h4>
+    <div class="row">
+      <div class="col-sm-8">
+        <h4>{{ _('Discography') }}</h4>
+      </div>
+      <div class="col-sm-4">
+        <div>
+          <input type="checkbox" name="only-reviewed" value="1" class="only-reviewed" onchange="showOnlyReviewed()"/>
+          {{ _('Filter releases here with reviews') }}<br/>
+        </div>
+      </div>
+    </div>
     <ul class="nav nav-tabs">
       <li {% if release_type=='album' %}class="active"{% endif %}>
         <a href="{{ url_for('artist.entity', mbid=artist.id) }}?release_type=album">{{ _('Albums') }}</a>
@@ -66,13 +76,16 @@
         <a href="{{ url_for('artist.entity', mbid=artist.id) }}?release_type=other">{{ _('Other releases') }}</a>
       </li>
     </ul>
+    <div class="no_reviewed_entities">
+      <p class="lead" style="text-align:center; margin-top:20px;">{{ _('No reviewed releases found here') }}</p>
+    </div>
     {% if count==0 %}
       <p class="lead" style="text-align:center; margin-top:20px;">{{ _('No releases found') }}</p>
     {% else %}
       <div id="release-groups" class="row">
         {% for release_group in release_groups %}
-          <div class="col-sm-4 col-md-4 col-lg-3">
-            {% set has_reviews = (release_group.review_count > 0) %}
+        {% set has_reviews = (release_group.review_count > 0) %}
+          <div class="col-sm-4 col-md-4 col-lg-3 release-group {% if not has_reviews %}not_reviewed{% endif %}">
             <div class="thumbnail clearfix {% if has_reviews %}reviewed{% endif %}">
               {% if has_reviews %}
                 <div class="review-count">
@@ -180,4 +193,25 @@
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script>
+  $(".no_reviewed_entities").hide();
+  function showOnlyReviewed() {
+      if($('.only-reviewed').is(":checked")) {
+        $(".not_reviewed").hide();
+        var reviewed = $('.reviewed').length;
+        var release_group_count = $('.release-group').length;
+        if(reviewed == 0 && release_group_count != 0) {
+            $(".no_reviewed_entities").show();
+        }
+      }
+      else {
+        $(".not_reviewed").show();
+        $(".no_reviewed_entities").hide();
+      }
+  }
+  </script>
 {% endblock %}

--- a/critiquebrainz/frontend/views/artist.py
+++ b/critiquebrainz/frontend/views/artist.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from flask import Blueprint, render_template, request, redirect, url_for
+from flask import Blueprint, render_template, request
 from flask_babel import gettext
 from werkzeug.exceptions import BadRequest, NotFound
 import critiquebrainz.db.review as db_review
@@ -29,16 +29,9 @@ def entity(mbid):
     if release_type not in ['album', 'single', 'ep', 'broadcast', 'other']:  # supported release types
         raise BadRequest("Unsupported release type.")
 
-    page = int(request.args.get('page', default=1))
-    if page < 1:
-        return redirect(url_for('.reviews'))
-    limit = 20
-    offset = (page - 1) * limit
     release_groups, count = mb_release_group.browse_release_groups(
         artist_id=artist['id'],
         release_types=[release_type],
-        limit=limit,
-        offset=offset,
     )
     for release_group in release_groups:
         # TODO(roman): Count reviews instead of fetching them.
@@ -55,8 +48,6 @@ def entity(mbid):
         artist=artist,
         release_type=release_type,
         release_groups=release_groups,
-        page=page,
-        limit=limit,
         count=count,
         band_members=band_members,
     )


### PR DESCRIPTION
Added checkbox on artist discography pages to filter only those releases (on that page) which have reviews. 

To fetch only those releases which have a review (rather than filtering on that page), I guess we can later fetch all releases (rather than applying the limit) and then show them (shouldn't slow down the page).  