### PR TITLE
CB-231: Retrieve data from database directly for browse review pages

### DIFF
--- a/critiquebrainz/frontend/__init__.py
+++ b/critiquebrainz/frontend/__init__.py
@@ -94,11 +94,12 @@ def create_app(debug=None, config_path=None):
     # Template utilities
     app.jinja_env.add_extension('jinja2.ext.do')
     from critiquebrainz.utils import reformat_date, reformat_datetime, track_length, parameterize
+    from critiquebrainz.frontend.external.musicbrainz_db.entities import get_entity_by_id
     app.jinja_env.filters['date'] = reformat_date
     app.jinja_env.filters['datetime'] = reformat_datetime
     app.jinja_env.filters['track_length'] = track_length
     app.jinja_env.filters['parameterize'] = parameterize
-    app.jinja_env.filters['entity_details'] = musicbrainz.get_entity_by_id
+    app.jinja_env.filters['entity_details'] = get_entity_by_id
     from flask_babel import Locale, get_locale
     app.jinja_env.filters['language_name'] = lambda language_code: Locale(language_code).get_language_name(get_locale())
     app.context_processor(lambda: dict(get_static_path=static_manager.get_static_path))

--- a/critiquebrainz/frontend/external/musicbrainz_db/entities.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/entities.py
@@ -10,37 +10,37 @@ def get_multiple_entities(entities):
         entites: List of tuples containing the entity_id and the entity_type.
 
     Returns:
-        Dictionary containing the entities keyed by their mbid.
+        Dictionary containing the basic information related to the entites.
+        {
+            "id": uuid,
+            "name/title": str,
+        }
+        Information related to the artists of release groups and the
+        coordinates of the places is also included.
     """
     entities_info = {}
     release_group_mbids = [entity[0] for entity in filter(lambda entity: entity[1] == 'release_group', entities)]
     place_mbids = [entity[0] for entity in filter(lambda entity: entity[1] == 'place', entities)]
     event_mbids = [entity[0] for entity in filter(lambda entity: entity[1] == 'event', entities)]
-    if release_group_mbids:
-        release_groups = fetch_multiple_release_groups(
-            release_group_mbids,
-            includes=['artists'],
-        )
-        entities_info.update(release_groups)
-    if place_mbids:
-        places = fetch_multiple_places(
-            place_mbids,
-        )
-        entities_info.update(places)
-    if event_mbids:
-        events = fetch_multiple_events(
-            event_mbids,
-        )
-        entities_info.update(events)
+    entities_info.update(fetch_multiple_release_groups(
+        release_group_mbids,
+        includes=['artists'],
+    ))
+    entities_info.update(fetch_multiple_places(
+        place_mbids,
+    ))
+    entities_info.update(fetch_multiple_events(
+        event_mbids,
+    ))
     return entities_info
 
 
 def get_entity_by_id(id, type='release_group'):
     """A wrapper to call the correct get_*_by_id function."""
     if type == 'release_group':
-        entity = get_release_group_by_id(id)
+        entity = get_release_group_by_id(str(id))
     elif type == 'place':
-        entity = get_place_by_id(id)
+        entity = get_place_by_id(str(id))
     elif type == 'event':
-        entity = get_event_by_id(id)
+        entity = get_event_by_id(str(id))
     return entity

--- a/critiquebrainz/frontend/external/musicbrainz_db/entities.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/entities.py
@@ -1,0 +1,46 @@
+from critiquebrainz.frontend.external.musicbrainz_db.release_group import fetch_multiple_release_groups, get_release_group_by_id
+from critiquebrainz.frontend.external.musicbrainz_db.place import fetch_multiple_places, get_place_by_id
+from critiquebrainz.frontend.external.musicbrainz_db.event import fetch_multiple_events, get_event_by_id
+
+
+def get_multiple_entities(entities):
+    """Fetch multiple entities using their mbids.
+
+    Args:
+        entites: List of tuples containing the entity_id and the entity_type.
+
+    Returns:
+        Dictionary containing the entities keyed by their mbid.
+    """
+    entities_info = {}
+    release_group_mbids = [entity[0] for entity in filter(lambda entity: entity[1] == 'release_group', entities)]
+    place_mbids = [entity[0] for entity in filter(lambda entity: entity[1] == 'place', entities)]
+    event_mbids = [entity[0] for entity in filter(lambda entity: entity[1] == 'event', entities)]
+    if release_group_mbids:
+        release_groups = fetch_multiple_release_groups(
+            release_group_mbids,
+            includes=['artists'],
+        )
+        entities_info.update(release_groups)
+    if place_mbids:
+        places = fetch_multiple_places(
+            place_mbids,
+        )
+        entities_info.update(places)
+    if event_mbids:
+        events = fetch_multiple_events(
+            event_mbids,
+        )
+        entities_info.update(events)
+    return entities_info
+
+
+def get_entity_by_id(id, type='release_group'):
+    """A wrapper to call the correct get_*_by_id function."""
+    if type == 'release_group':
+        entity = get_release_group_by_id(id)
+    elif type == 'place':
+        entity = get_place_by_id(id)
+    elif type == 'event':
+        entity = get_event_by_id(id)
+    return entity

--- a/critiquebrainz/frontend/external/musicbrainz_db/entities.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/entities.py
@@ -4,13 +4,13 @@ from critiquebrainz.frontend.external.musicbrainz_db.event import fetch_multiple
 
 
 def get_multiple_entities(entities):
-    """Fetch multiple entities using their mbids.
+    """Fetch multiple entities using their MBIDs.
 
     Args:
-        entites: List of tuples containing the entity_id and the entity_type.
+        entites: List of tuples containing the entity ID and the entity type.
 
     Returns:
-        Dictionary containing the basic information related to the entites.
+        Dictionary containing the basic information related to the entities.
         {
             "id": uuid,
             "name/title": str,

--- a/critiquebrainz/frontend/external/musicbrainz_db/serialize.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/serialize.py
@@ -139,8 +139,9 @@ def to_dict_medium(medium, includes=None):
         'name': medium.name,
         'track_count': medium.track_count,
         'position': medium.position,
-        'format': medium.format.name,
     }
+    if medium.format:
+        data['format'] = medium.format.name
 
     if 'tracks' in includes and includes['tracks']:
         data['track-list'] = [to_dict_track(track) for track in includes['tracks']]

--- a/critiquebrainz/frontend/external/musicbrainz_db/utils.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/utils.py
@@ -51,7 +51,7 @@ def get_entities_by_gids(*, query, entity_type, mbids):
         results = query.filter(redirect_model.gid.in_(remaining_gids))
         for entity, redirect_obj in results:
             entities[redirect_obj.gid] = entity
-        remaining_gids = list(set(mbids) - {redirect_obj.gid for entity, redirect_obj in results})
+        remaining_gids = list(set(remaining_gids) - {redirect_obj.gid for entity, redirect_obj in results})
     if remaining_gids:
         raise mb_exceptions.NoDataFoundException("Couldn't find entities with IDs: {mbids}".format(mbids=remaining_gids))
     return entities

--- a/critiquebrainz/frontend/templates/review/browse.html
+++ b/critiquebrainz/frontend/templates/review/browse.html
@@ -22,7 +22,7 @@
   <p class="lead" style="text-align: center;">{{ _('No reviews found') }}</p>
 {% else %}
   {% for review in reviews %}
-    {% set entity = entities[review.entity_id] %}
+    {% set entity = entities[review.entity_id | string] %}
     <div class="col-md-4 review">
       <div class="cover-art-container pull-left">
         <a href="{{ url_for('review.entity', id=review.id) }}">

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -9,7 +9,7 @@ from critiquebrainz.db.review import ENTITY_TYPES
 from critiquebrainz.db.moderation_log import ACTION_HIDE_REVIEW
 from critiquebrainz.db import vote as db_vote, exceptions as db_exceptions, revision as db_revision
 from critiquebrainz.frontend import flash
-from critiquebrainz.frontend.external import mbspotify, musicbrainz, soundcloud
+from critiquebrainz.frontend.external import mbspotify, soundcloud
 from critiquebrainz.frontend.forms.log import AdminActionForm
 from critiquebrainz.frontend.forms.review import ReviewCreateForm, ReviewEditForm, ReviewReportForm
 from critiquebrainz.frontend.login import admin_view
@@ -17,6 +17,7 @@ from critiquebrainz.utils import side_by_side_diff
 import critiquebrainz.db.spam_report as db_spam_report
 import critiquebrainz.db.review as db_review
 import critiquebrainz.db.moderation_log as db_moderation_log
+from critiquebrainz.frontend.external.musicbrainz_db.entities import get_multiple_entities, get_entity_by_id
 
 
 review_bp = Blueprint('review', __name__)
@@ -51,8 +52,8 @@ def browse():
                 raise NotFound(gettext("No reviews to display."))
 
     # Loading info about entities for reviews
-    entities = [(review["entity_id"], review["entity_type"]) for review in reviews]
-    entities_info = musicbrainz.get_multiple_entities(entities)
+    entities = [(str(review["entity_id"]), review["entity_type"]) for review in reviews]
+    entities_info = get_multiple_entities(entities)
 
     return render_template('review/browse.html', reviews=reviews, entities=entities_info,
                            page=page, limit=limit, count=count, entity_type=entity_type)
@@ -227,7 +228,7 @@ def create():
             flash.success(gettext("Review has been published!"))
         return redirect(url_for('.entity', id=review['id']))
 
-    entity = musicbrainz.get_entity_by_id(entity_id, entity_type)
+    entity = get_entity_by_id(entity_id, entity_type)
     if not entity:
         flash.error(gettext("You can only write a review for an entity that exists on MusicBrainz!"))
         return redirect(url_for('search.selector', next=url_for('.create')))

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -8,18 +8,18 @@ import critiquebrainz.frontend.external.musicbrainz_db.release as mb_release
 from flask import current_app
 
 
-def mock_get_entity_by_id(id, type='release_group'): # pylint: disable=unused-argument
-    if type == 'release_group':
+def mock_get_entity_by_id(id, type='release_group'):
+    if id == '6b3cd75d-7453-39f3-86c4-1441f360e121' and type == 'release_group':
         return {
             'id': '6b3cd75d-7453-39f3-86c4-1441f360e121',
             'title': 'Moderat',
         }
-    if type == 'event':
+    if id == 'b4e75ef8-3454-4fdc-8af1-61038c856abc' and type == 'event':
         return {
             'id': 'b4e75ef8-3454-4fdc-8af1-61038c856abc',
             'name': 'Rock am Ring 2014',
         }
-    if type == 'place':
+    if id == 'c5c9c210-b7a0-4f6e-937e-02a586c8e14c' and type == 'place':
         return {
             'id': 'c5c9c210-b7a0-4f6e-937e-02a586c8e14c',
             'name': 'University of London Union',

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -1,8 +1,29 @@
+from unittest.mock import MagicMock
 from critiquebrainz.frontend.testing import FrontendTestCase
 import critiquebrainz.db.review as db_review
 from critiquebrainz.db.user import User
 import critiquebrainz.db.users as db_users
 import critiquebrainz.db.license as db_license
+import critiquebrainz.frontend.external.musicbrainz_db.release as mb_release
+from flask import current_app
+
+
+def mock_get_entity_by_id(id, type='release_group'): # pylint: disable=unused-argument
+    if type == 'release_group':
+        return {
+            'id': '6b3cd75d-7453-39f3-86c4-1441f360e121',
+            'title': 'Moderat',
+        }
+    if type == 'event':
+        return {
+            'id': 'b4e75ef8-3454-4fdc-8af1-61038c856abc',
+            'name': 'Rock am Ring 2014',
+        }
+    if type == 'place':
+        return {
+            'id': 'c5c9c210-b7a0-4f6e-937e-02a586c8e14c',
+            'name': 'University of London Union',
+        }
 
 
 class ReviewViewsTestCase(FrontendTestCase):
@@ -20,6 +41,8 @@ class ReviewViewsTestCase(FrontendTestCase):
             full_name="Created so we can fill the form correctly.",
         )
         self.review_text = "Testing! This text should be on the page."
+        mb_release.browse_releases = MagicMock()
+        current_app.jinja_env.filters['entity_details'] = mock_get_entity_by_id
 
     def create_dummy_review(self, is_draft=False):
         review = db_review.create(


### PR DESCRIPTION
Modifed `jinja2` filter for fetching entities by id and added code for retrieving data directly from database for browse review (`/review`) pages.