### PR TITLE
Fix AttributeError when Medium has no format

### DIFF
--- a/critiquebrainz/frontend/external/musicbrainz_db/serialize.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/serialize.py
@@ -150,8 +150,9 @@ def to_dict_medium(medium, includes=None):
         'name': medium.name,
         'track_count': medium.track_count,
         'position': medium.position,
-        'format': medium.format.name,
     }
+    if medium.format:
+        data['format'] = medium.format.name
 
     if 'tracks' in includes and includes['tracks']:
         data['track-list'] = [to_dict_track(track) for track in includes['tracks']]


### PR DESCRIPTION
Fixes this `AttributeError` when medium format is `None`.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/werkzeug/wsgi.py", line 660, in __call__
    return app(environ, start_response)
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1997, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1985, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1540, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/code/critiquebrainz/frontend/views/release_group.py", line 28, in entity
    release = mb_release.get_release_by_id(release_group['release-list'][0]['id'])
  File "/code/critiquebrainz/frontend/external/musicbrainz_db/release.py", line 23, in get_release_by_id
    release = _get_release_by_id(mbid)
  File "/code/critiquebrainz/frontend/external/musicbrainz_db/release.py", line 31, in _get_release_by_id
    includes=['media', 'release-groups'],
  File "/code/critiquebrainz/frontend/external/musicbrainz_db/release.py", line 82, in fetch_multiple_releases
    releases = {str(mbid): to_dict_releases(releases[mbid], includes_data[releases[mbid].id]) for mbid in mbids}
  File "/code/critiquebrainz/frontend/external/musicbrainz_db/release.py", line 82, in <dictcomp>
    releases = {str(mbid): to_dict_releases(releases[mbid], includes_data[releases[mbid].id]) for mbid in mbids}
  File "/code/critiquebrainz/frontend/external/musicbrainz_db/serialize.py", line 193, in to_dict_releases
    for medium in includes['media']]
  File "/code/critiquebrainz/frontend/external/musicbrainz_db/serialize.py", line 193, in <listcomp>
    for medium in includes['media']]
  File "/code/critiquebrainz/frontend/external/musicbrainz_db/serialize.py", line 153, in to_dict_medium
    'format': medium.format.name,
AttributeError: 'NoneType' object has no attribute 'name'

```