### PR TITLE
Fix bug when trying to write a duplicate review

### DIFF
--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -215,7 +215,9 @@ def create():
         return redirect(url_for('user.reviews', user_id=current_user.id))
 
     # Checking if the user already wrote a review for this entity
-    review = db_review.list_reviews(user_id=current_user.id, entity_id=entity_id)[0]
+    reviews, count = db_review.list_reviews(user_id=current_user.id, entity_id=entity_id)
+    review = reviews[0] if count is not 0 else None
+
     if review:
         flash.error(gettext("You have already published a review for this entity!"))
         return redirect(url_for('review.entity', id=review["id"]))

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -90,6 +90,14 @@ class ReviewViewsTestCase(FrontendTestCase):
         self.assert200(response)
         self.assertIn(self.review_text, str(response.data))
 
+    def test_create_duplicate(self):
+        review = self.create_dummy_review()
+
+        self.temporary_login(self.user)
+        response = self.client.get("/review/write?release_group=%s" % review["entity_id"],
+                                   follow_redirects=True)
+        self.assertIn("You have already published a review for this entity!", str(response.data))
+
     def test_edit(self):
         updated_text = "The text has now been updated"
         data = dict(


### PR DESCRIPTION
I accidently stumbled across this bug and I thought I would fix it, since it was pretty simple. What was happening was that in these lines in `views/review.py`, in the `create` function:

```python
# Checking if the user already wrote a review for this entity
review = db_review.list_reviews(user_id=current_user.id, entity_id=entity_id)[0] # here's the main problem
if review:
    flash.error(gettext("You have already published a review for this entity!"))
    return redirect(url_for('review.entity', id=review["id"]))
```

The first line depends on `db_review.list_reviews` returning a list of reviews straight away. However, `list_reviews` has either since been changed or this line was just a mistake, because `list_reviews` returns a tuple of `(review, count)` (which is weird - returning a list of reviews, you could just get their count using `len(reviews)`, but I won't question it at the moment). What this means is that you end up getting a list in the variable `review`, so when trying to access `review["id"]` - Python complains that list indices can't be strings.

So I fixed it - just plopped another `[0]` when assigning the `review` variable. I've also checked other places in the code, and as far as I can see, this bit of code is (was) the only code depending on `list_reviews` returning a list instead of a tuple.

**EDIT**: Jenkins fails, which is really weird because it fails for the exact opposite reason - it complains "list index out of range" on this changed line. When I test it out in the UI it works as intended on my version.

**EDIT**: Fixed the Jenkins issue. Problem was that if the `review` list is empty (which is most of the time - ironically, _I failed to test the happy path_, which is officially now the stupidest thing I've ever done), Python throws an `IndexError`. So we check whether it's empty beforehand.