### PR TITLE
CB-271: Automatically detect the language of reviews

### DIFF
--- a/critiquebrainz/frontend/templates/review/modify/base.html
+++ b/critiquebrainz/frontend/templates/review/modify/base.html
@@ -58,7 +58,10 @@
   <script src="{{ get_static_path('wysiwyg-editor.js') }}"></script>
   <script>
     $(document).ready(function() {
-      new SimpleMDE({ element: $('#review-content')[0] });
+      reviewContentEditor = new SimpleMDE({
+        element: $('#review-content')[0],
+        spellChecker: false
+      });
 
       // Show warning when leaving review editor without saving changes
       var beingSaved = false;
@@ -70,6 +73,31 @@
         var confirmationMessage = "Your review has not been saved.";
         (e || window.event).returnValue = confirmationMessage;     // Gecko and Trident
         return confirmationMessage;                                // Gecko and WebKit
+      });
+
+      oldReviewLength = reviewContentEditor.value().length
+      languageSelector = $('#review-language')[0]
+      // Detect the language of the review on change
+      // codemirror is the underlying editor behind SimpleMDE.
+      reviewContentEditor.codemirror.on("change", function() {
+        const MIN_DIFFERENCE = 10
+
+        var currentReviewContent = reviewContentEditor.value()
+        var currentReviewLength = currentReviewContent.length
+        if(currentReviewLength == 0) { return; }
+
+        // Don't call too often.
+        var difference = Math.abs(currentReviewLength - oldReviewLength)
+        if(difference < MIN_DIFFERENCE) { return; }
+        oldReviewLength = currentReviewLength
+
+        $.ajax({
+          type: "POST",
+          url: "{{ url_for('review.get_language') }}",
+          data: {text: currentReviewContent},
+          success: function(data) { $(languageSelector).val(data) },
+          error: function() { console.error("Getting language failed"); } // Ignore any failure, won't do any harm
+        })
       });
 
       $("#btn-publish").click(function(){

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -19,6 +19,7 @@ import critiquebrainz.db.spam_report as db_spam_report
 import critiquebrainz.db.review as db_review
 import critiquebrainz.db.moderation_log as db_moderation_log
 from critiquebrainz.frontend.external.musicbrainz_db.entities import get_multiple_entities, get_entity_by_id
+from langdetect import detect
 
 
 review_bp = Blueprint('review', __name__)
@@ -307,6 +308,13 @@ def edit(id):
         return render_template('review/modify/edit.html', form=form, review=review, entity_type=review["entity_type"],
                                entity=entity, spotify_mappings=spotify_mappings, soundcloud_url=soundcloud_url)
     return render_template('review/modify/edit.html', form=form, review=review, entity_type=review["entity_type"])
+
+
+@review_bp.route('/write/get_language', methods=['POST'])
+@login_required
+def get_language():
+    """Return the most likely language of the text."""
+    return detect(request.form['text'])
 
 
 @review_bp.route('/<uuid:id>/delete', methods=['GET', 'POST'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ requests==2.18.3
 SQLAlchemy==1.1.13
 transifex-client==0.12.4
 WTForms==2.1
+langdetect==1.0.7


### PR DESCRIPTION
[Jira ticket.](https://tickets.metabrainz.org/browse/CB-271)

Using the `langdetect` library. It supports all of the languages that CB has in its languages menu on the navbar, plus many more. `langdetect` is already well tested, so I didn't really add any tests for this feature. But if needed I can.