### PR TITLE
CB-276: Initialize db and create tables in test container before running tests

### DIFF
--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -29,5 +29,6 @@ COPY . /code/
 RUN pybabel compile -d critiquebrainz/frontend/translations
 
 CMD dockerize -wait tcp://db_test:5432 -timeout 60s \
-    py.test --junitxml=/data/test_report.xml \
+    python manage.py init_db --skip-create-db --test-db \
+    && py.test --junitxml=/data/test_report.xml \
             --cov-report xml:/data/coverage.xml

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,5 @@
-﻿import subprocess
+﻿import os
+import subprocess
 from werkzeug.serving import run_simple
 from werkzeug.wsgi import DispatcherMiddleware
 from brainzutils import cache
@@ -85,8 +86,10 @@ def clear_memcached():
 
 @click.option("--skip-create-db", "-s", is_flag=True,
               help="Skip database creation step.")
+@click.option("--test-db", "-t", is_flag=True,
+              help="Initialize the test database.")
 @cli.command()
-def init_db(skip_create_db=False):
+def init_db(skip_create_db=False, test_db=False):
     """Initialize the database.
 
     * Creates the database.
@@ -95,7 +98,14 @@ def init_db(skip_create_db=False):
     """
     click.echo("Initializing the database...")
 
-    db_uri = frontend.create_app().config['SQLALCHEMY_DATABASE_URI']
+    if test_db:
+        db_uri = frontend.create_app(config_path=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            'critiquebrainz', 'test_config.py'
+        )).config['SQLALCHEMY_DATABASE_URI']
+    else:
+        db_uri = frontend.create_app().config['SQLALCHEMY_DATABASE_URI']
+
     if not skip_create_db:
         init_postgres(db_uri)
         create_extension(db_uri)


### PR DESCRIPTION
As decided in discussions [here](https://github.com/metabrainz/critiquebrainz/pull/164#issuecomment-354597289), it is good to create db tables in test container before running tests (and not just rely on pytest's  `setUp()` method .