### PR TITLE
Add documentation for disabling SELinux

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
       file: ./common.yml
       service: db
     volumes:
-      - ../data/pgdata:/var/lib/postgresql/data/pgdata
+      - ../data/pgdata:/var/lib/postgresql/data/pgdata:z
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
     ports:
@@ -27,8 +27,8 @@ services:
       context: ..
       dockerfile: ./docker/Dockerfile.dev
     volumes:
-      - ../:/code
-      - ../data/app:/data
+      - ../:/code:z
+      - ../data/app:/data:z
     ports:
       - "80:80"
     depends_on:
@@ -43,7 +43,7 @@ services:
   musicbrainz_db:
     image: metabrainz/musicbrainz-test-database:schema-change-2017-q2
     volumes:
-      - ../data/mbdata:/var/lib/postgresql/data/pgdata
+      - ../data/mbdata:/var/lib/postgresql/data/pgdata:z
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
       MB_IMPORT_DUMPS: "true"

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -63,10 +63,6 @@ The ``mbdump-derived.tar.bz2`` archive contains annotations, user tags and searc
 These archives include all the data required for setting up an instance of
 CritiqueBrainz.
 
-Note that if you have SELinux enabled on your OS, you must perform one of the following steps:
-   Set SELinux to disabled mode. Run $setenforce 0 and try again.
-   If you do not wish to disable SELinux append a :Z to the volume declaration so that Docker will fix the SELinux context of the volume directory
-
 You can automatically download the archives (``mbdump.tar.bz2`` and ``mbdump-derived.tar.bz2``) and
 begin the import for the MusicBrainz database::
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -63,6 +63,10 @@ The ``mbdump-derived.tar.bz2`` archive contains annotations, user tags and searc
 These archives include all the data required for setting up an instance of
 CritiqueBrainz.
 
+Note that if you have SELinux enabled on your OS, you must perform one of the following steps:
+   Set SELinux to disabled mode. Run $setenforce 0 and try again.
+   If you do not wish to disable SELinux append a :Z to the volume declaration so that Docker will fix the SELinux context of the volume directory
+
 You can automatically download the archives (``mbdump.tar.bz2`` and ``mbdump-derived.tar.bz2``) and
 begin the import for the MusicBrainz database::
 


### PR DESCRIPTION
Improvement in the documentation
For the users that have enabled SELinux on their OS (inbuilt in some OS):
If they run `$ docker-compose -f docker/docker-compose.dev.yml run musicbrainz_db`, following error might occur:
python3: can't open file 'manage.py': [Errno 13] Permission denied
If they further run `$ docker-compose -f docker/docker-compose.dev.yml run critiquebrainz python3 \
manage.py init_db --skip-create-db` following error might occur: 
chown: cannot read directory ‘/var/lib/postgresql/data/pgdata’: Permission denied