### PR TITLE
Change schema version to 8

### DIFF
--- a/critiquebrainz/db/__init__.py
+++ b/critiquebrainz/db/__init__.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
 
 # This value must be incremented after schema changes on exported tables!
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 8
 VALID_RATING_VALUES = [None, 1, 2, 3, 4, 5]
 REVIEW_RATING_MAX = 5
 REVIEW_RATING_MIN = 1


### PR DESCRIPTION
Fixes the SCHEMA_VERSION (of the CB database) to the current version (based on the number of schema changes in the past).