### PR TITLE
Change container name in Testing

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -135,7 +135,7 @@ Testing
 Alternative way to test the web server is to use a Docker container::
 
    $ docker-compose -f docker/docker-compose.test.yml up -d --build
-   $ docker logs -f critiquebrainz_web_test_1
+   $ docker logs -f docker_critiquebrainz_test_1
 
 Modifying strings
 -----------------

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -134,8 +134,7 @@ Testing
 
 Alternative way to test the web server is to use a Docker container::
 
-   $ docker-compose -f docker/docker-compose.test.yml up -d --build
-   $ docker logs -f docker_critiquebrainz_test_1
+   $ docker-compose -f docker/docker-compose.test.yml up --build
 
 Modifying strings
 -----------------


### PR DESCRIPTION
This pull request is for the bug fix in the documentation.
If the user runs `$ docker logs -f critiquebrainz_web_test_1`, following error occurs:
Error: No such container: critiquebrainz_web_test_1