### PR TITLE
CB-225: Add Sign in button on error pages

### DIFF
--- a/critiquebrainz/frontend/templates/navbar.html
+++ b/critiquebrainz/frontend/templates/navbar.html
@@ -32,6 +32,10 @@
               </ul>
             </li>
           {% endif %}
+        {% else %}
+          {% if not current_user or current_user.is_anonymous %}
+            <li><a href="{{ url_for('login.index', next=request.url) }}">{{ _('Sign in') }}</a></li>
+          {% endif %}
         {% endif %}
         <li><a href="{{ url_for('review.browse') }}">{{ _('Browse reviews') }}</a></li>
         <li><a href="{{ url_for('review.create') }}">{{ _('Write a review') }}</a></li>


### PR DESCRIPTION
This pull request is the bug fix on error pages. 
It adds the missing sign in button on error pages.
Dropdown menu is purposely not provided as it is mentioned in the comments (https://github.com/metabrainz/critiquebrainz/blob/master/critiquebrainz/frontend/templates/navbar.html#L19) that while loading, user info might fail and page will not render.