### PR TITLE
CB-277: Update the installation guidelines

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -7,6 +7,9 @@ Setting up the server
 You can set up CritiqueBrainz server using `Docker <https://www.docker.com/>`_. It
 requires minimum amount of configuration.
 
+.. warning::
+  Make sure you have the latest version of Docker.
+
 Configuration
 ^^^^^^^^^^^^^
 
@@ -33,6 +36,9 @@ MusicBrainz account). In the ``Callback URL`` field type::
 
    ``<HOST>`` field should be set to ``localhost`` if you plan to run a local instance of
    CritiqueBrainz for development purposes.
+   For example:- If you are running your local instance of the server on Port Number
+   8000 then ``<HOST>`` should be set
+   to ``localhost:8000``.
 
 After application has been registered, set ``MUSICBRAINZ_CLIENT_ID`` and ``MUSICBRAINZ_CLIENT_SECRET``
 in your ``custom_config.py`` to the values that you see on the MusicBrainz website.
@@ -63,28 +69,44 @@ The ``mbdump-derived.tar.bz2`` archive contains annotations, user tags and searc
 These archives include all the data required for setting up an instance of
 CritiqueBrainz.
 
-You can automatically download the archives (``mbdump.tar.bz2`` and ``mbdump-derived.tar.bz2``) and
-begin the import for the MusicBrainz database::
+One can import the database dump by downloading and importing the data in
+a single command::
 
-   $ docker-compose -f docker/docker-compose.dev.yml run musicbrainz_db
+    $ docker-compose -f docker/docker-compose.dev.yml run musicbrainz_db
 
 .. note::
 
-   An alternative way for setting up the MusicBrainz database is to
-   download the archives manually and then do the import. Archives provided from
-   https://musicbrainz.org can be downloaded from
-   https://musicbrainz.org/doc/MusicBrainz_Database/Download. Note that the
-   environment variable ``DUMPS_DIR`` must be set to the path containing the
-   downloaded archives. Then setup the MusicBrainz database using::
+  One can also manually download the dumps and then import it:-
 
-      $ docker-compose -f docker/docker-compose.dev.yml run -v $DUMPS_DIR:/home/musicbrainz/dumps \
-      -v $PWD/data/mbdata:/var/lib/postgresql/data/pgdata musicbrainz_db
+  i. For this, you have to download the dumps ``mbdump.tar.bz2`` and ``mbdump-derived.tar.bz2``
+     from http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/.
 
-   You can also use the smaller sample dumps available at
-   http://ftp.musicbrainz.org/pub/musicbrainz/data/sample/ to set up the MusicBrainz database.
-   However, note that these dumps are .tar.xz dumps while CritiqueBrainz currently only
-   supports import of .tar.bz2 dumps. So, a decompression of the sample dumps and recompression
-   into .tar.bz2 dumps will be needed.
+     .. warning::
+
+        Make sure to get the latest dumps
+
+  ii. Then the environment variable ``DUMPS_DIR`` must be set to the path of the
+      folders containing the dumps. This can be done by::
+
+        $ export DUMPS_DIR="Path of the folder containing the dumps"
+
+      You can check that the variable ``DUMPS_DIR`` has been succesfully assigned or not by::
+
+        $ echo $DUMPS_DIR
+
+      This must display the path of your folder containing database dumps.
+
+  iii. Then import the database dumps by this command::
+
+        $ docker-compose -f docker/docker-compose.dev.yml run -v $DUMPS_DIR:/home/musicbrainz/dumps \
+        -v $PWD/data/mbdata:/var/lib/postgresql/data/pgdata musicbrainz_db
+
+.. note::
+  You can also use the smaller sample dumps available at http://ftp.musicbrainz.org/pub/musicbrainz/data/sample/
+  to set up the MusicBrainz database. However, note that these dumps are .tar.xz
+  dumps while CritiqueBrainz currently only supports import of .tar.bz2 dumps.
+  So, a decompression of the sample dumps and recompression into .tar.bz2 dumps
+  will be needed.
 
 .. warning::
 


### PR DESCRIPTION
The installation guidelines of CritiqueBrainz were outdated and were very confusing. So its need to be updated. Ticket:- https://tickets.metabrainz.org/browse/CB-277