### PR TITLE
CB-252: Make whole row selectable in search results

### DIFF
--- a/critiquebrainz/frontend/templates/search/selector.html
+++ b/critiquebrainz/frontend/templates/search/selector.html
@@ -173,6 +173,11 @@
           alert({{ _("Failed to load more search results!") | tojson }});
         });
       }
+
+      /* function that makes the whole row selectable and onClick will 'check' the respective row's radio button  */
+      $('#results tr').click(function(){
+        $(this).find('input[type=radio]').prop('checked', true);
+      });
     </script>
   {% endblock %}
 {% endif %}


### PR DESCRIPTION
In this patch, the user does not need to check the radio button, by clicking on the row itself the corresponding radio button gets checked.