### PR TITLE
CB-280: Fix Spotify mapping page suggestions

### DIFF
--- a/critiquebrainz/frontend/external/spotify.py
+++ b/critiquebrainz/frontend/external/spotify.py
@@ -60,6 +60,9 @@ def get_multiple_albums(spotify_ids: List[str]) -> List[dict]:
         List of album objects from Spotify. More info about this type of objects
         is available at https://developer.spotify.com/web-api/object-model/#album-object.
     """
+    if not spotify_ids:
+        return []
+    spotify_ids = list(spotify_ids)
     cache_namespace = "spotify_albums"
     albums = cache.get_many(spotify_ids, cache_namespace)
 

--- a/critiquebrainz/frontend/external/spotify_test.py
+++ b/critiquebrainz/frontend/external/spotify_test.py
@@ -12,6 +12,18 @@ class FakeSpotifyResponse:
 
     @classmethod
     def fromSpotifyIds(cls, spotify_ids):
+        """Returns a response similar to Spotify Web API fetching multiple albums.
+
+        Args:
+            spotify_ids (list): List of Spotify IDs of the albums.
+
+        Returns:
+            Dictionary with the key: 'albums' and list of albums as value with the structure
+            {
+                'id': str (spotify_id),
+                'data': str,
+            }
+        """
         response = []
         for spotify_id in spotify_ids:
             response.append({'id': spotify_id, 'data': spotify._BASE_URL + spotify_id})

--- a/critiquebrainz/frontend/external/spotify_test.py
+++ b/critiquebrainz/frontend/external/spotify_test.py
@@ -1,3 +1,4 @@
+from brainzutils import cache
 from critiquebrainz.frontend.testing import FrontendTestCase
 from critiquebrainz.frontend.external import spotify
 
@@ -8,6 +9,13 @@ class FakeSpotifyResponse:
 
     def json(self):
         return dict(url=self.url)
+
+    @classmethod
+    def fromSpotifyIds(cls, spotify_ids):
+        response = []
+        for spotify_id in spotify_ids:
+            response.append({'id': spotify_id, 'data': spotify._BASE_URL + spotify_id})
+        return dict(albums=response)
 
 
 class SpotifyTestCase(FrontendTestCase):
@@ -26,3 +34,25 @@ class SpotifyTestCase(FrontendTestCase):
         self.assertDictEqual(
             spotify.get_album('random-spotify-id'),
             dict(url="https://api.spotify.com/v1/albums/random-spotify-id"))
+
+    def test_get_multiple_albums(self):
+        spotify_ids = ['0Y7qkJVZ06tS2GUCDptzyW']
+        if cache.get_many(spotify_ids, 'spotify_albums'):
+            cache.delete_many(spotify_ids, 'spotify_albums')
+
+        spotify._get = lambda query: FakeSpotifyResponse.fromSpotifyIds(spotify_ids)
+        albums = spotify.get_multiple_albums(spotify_ids)
+        self.assertDictEqual(albums[spotify_ids[0]], {
+            'id': spotify_ids[0],
+            'data': spotify._BASE_URL + spotify_ids[0],
+        })
+
+        albums = cache.get_many(spotify_ids, 'spotify_albums')
+        self.assertListEqual(list(albums.keys()), spotify_ids)
+
+        # test if cached result is returned properly
+        albums = spotify.get_multiple_albums(spotify_ids)
+        self.assertDictEqual(albums[spotify_ids[0]], {
+            'id': spotify_ids[0],
+            'data': spotify._BASE_URL + spotify_ids[0],
+        })


### PR DESCRIPTION
Fix missing suggestions after caching and added a test for checking cached spotify results. Since the same list object was passed to the function `get_multiple_albums` (in `spotify.py`), `album_ids` were deleted from the original object and cached results showed no suggestions instead.