### PR TITLE
CB-242: Incorrect gravatars are shown on /moderators

### DIFF
--- a/critiquebrainz/frontend/views/moderators.py
+++ b/critiquebrainz/frontend/views/moderators.py
@@ -18,7 +18,7 @@ def mods_list():
         mods.append({
             'critiquebrainz_id': mod_data["id"],
             'musicbrainz_username': mod_data["musicbrainz_username"],
-            'avatar_url': gravatar_url(mod_data["musicbrainz_username"]),
+            'avatar_url': mod_data["avatar_url"],
         })
     for mod_username in mod_usernames:  # The rest
         mods.append({


### PR DESCRIPTION
Earlier, gravatar_url() was generating a new hash at the time of creating the dictionary of moderators is which was creating the error. Now, in this PR instead of generating the new hash, it has been replaced with existing generated avatar_url which is fixed for the user. 

P.S. - The change is not tested as I didn't have a working dev environment with a database to test my changes. So I don't know whether this is a proper fix for the bug or not. :) 