### PR TITLE
CB-282: Spotify mapping tests

### DIFF
--- a/critiquebrainz/frontend/error_handlers.py
+++ b/critiquebrainz/frontend/error_handlers.py
@@ -1,6 +1,11 @@
 # pylint: disable=unused-variable
 from flask import render_template, g
 
+def get_sentry_event_id():
+    try:
+        return g.sentry_event_id
+    except AttributeError:
+        return None
 
 def init_error_handlers(app):
 
@@ -22,8 +27,8 @@ def init_error_handlers(app):
 
     @app.errorhandler(500)
     def internal_server_error(error):
-        return render_template('errors/500.html', error=error, event_id=g.sentry_event_id), 500
+        return render_template('errors/500.html', error=error, event_id=get_sentry_event_id()), 500
 
     @app.errorhandler(503)
     def service_unavailable(error):
-        return render_template('errors/503.html', error=error, event_id=g.sentry_event_id), 503
+        return render_template('errors/503.html', error=error, event_id=get_sentry_event_id()), 503

--- a/critiquebrainz/frontend/error_handlers.py
+++ b/critiquebrainz/frontend/error_handlers.py
@@ -1,11 +1,13 @@
 # pylint: disable=unused-variable
 from flask import render_template, g
 
+
 def get_sentry_event_id():
     try:
         return g.sentry_event_id
     except AttributeError:
         return None
+
 
 def init_error_handlers(app):
 

--- a/critiquebrainz/frontend/error_handlers.py
+++ b/critiquebrainz/frontend/error_handlers.py
@@ -3,6 +3,11 @@ from flask import render_template, g
 
 
 def get_sentry_event_id():
+    """Makes sentry_event_id optional for error handlers
+
+    Returns:
+        sentry_event_id if available else None
+    """
     try:
         return g.sentry_event_id
     except AttributeError:

--- a/critiquebrainz/frontend/templates/macros.html
+++ b/critiquebrainz/frontend/templates/macros.html
@@ -99,7 +99,7 @@
         {{ _('We don\'t have a mapping between this release group and Spotify. Please help us find the right album.') }}
       </span>
       <div style="text-align:center;font-weight:bold;">
-        <a style="font-size:16px;" href="{{ url_for('mapping.spotify', release_group_id=release_group_id) }}" rel="nofollow">
+        <a style="font-size:16px;" href="{{ url_for('mapping.spotify_add', release_group_id=release_group_id) }}" rel="nofollow">
           {{ _('Match this!') }}
         </a>
       </div>

--- a/critiquebrainz/frontend/templates/mapping/list.html
+++ b/critiquebrainz/frontend/templates/mapping/list.html
@@ -17,7 +17,9 @@
      album = '<a href="%s">%s</a>'|safe % (url_for('release_group.entity', id=release_group.id), release_group.title),
      artist = artist|join()) }}
 
-    {% if release_group['first-release-date'] %}
+    {% if release_group['first-release-year'] %}
+      <small>{{ release_group['first-release-year'] }}</small>
+    {% elif release_group['first-release-date'] %}
       <small>{{ release_group['first-release-date'][:4] }}</small>
     {% endif %}
   </h2>

--- a/critiquebrainz/frontend/templates/mapping/list.html
+++ b/critiquebrainz/frontend/templates/mapping/list.html
@@ -66,5 +66,5 @@
         </tbody>
       </table>
   {% endif %}
-  <b><a class="btn btn-primary btn-default" href="{{ url_for('mapping.spotify', release_group_id=release_group.id) }}">{{ _('+ Add new mapping') }}</a></b>
+  <b><a class="btn btn-primary btn-default" href="{{ url_for('mapping.spotify_add', release_group_id=release_group.id) }}">{{ _('+ Add new mapping') }}</a></b>
 {% endblock %}

--- a/critiquebrainz/frontend/templates/mapping/spotify.html
+++ b/critiquebrainz/frontend/templates/mapping/spotify.html
@@ -51,10 +51,10 @@
       <div class="col-md-12">
         <ul class="pager">
           {% if page > 1 %}
-            <li class="previous"><a href="{{ url_for('mapping.spotify', release_group_id=release_group.id, page=page-1) }}">&larr; {{ _('Previous') }}</a></li>
+            <li class="previous"><a href="{{ url_for('mapping.spotify_add', release_group_id=release_group.id, page=page-1) }}">&larr; {{ _('Previous') }}</a></li>
           {% endif %}
           {% if page-1 < count//limit %}
-            <li class="next"><a href="{{ url_for('mapping.spotify', release_group_id=release_group.id, page=page + 1) }}">{{ _('Next') }} &rarr;</a></li>
+            <li class="next"><a href="{{ url_for('mapping.spotify_add', release_group_id=release_group.id, page=page + 1) }}">{{ _('Next') }} &rarr;</a></li>
           {% endif %}
         </ul>
       </div>

--- a/critiquebrainz/frontend/templates/mapping/spotify.html
+++ b/critiquebrainz/frontend/templates/mapping/spotify.html
@@ -7,6 +7,8 @@
 <p class="lead">
   {% if release_group['first-release-date'] %}
     {% set album = '"%s" <span class="text-muted">(%s)</span>'|safe % (release_group.title, release_group['first-release-date'][:4]) %}
+  {% elif release_group['first-release-year']%}
+    {% set album = '"%s" <span class="text-muted">(%s)</span>'|safe % (release_group.title, release_group['first-release-year']) %}
   {% else %}
     {% set album = '"%s"' % release_group.title %}
   {% endif %}

--- a/critiquebrainz/frontend/views/mapping.py
+++ b/critiquebrainz/frontend/views/mapping.py
@@ -175,15 +175,16 @@ def parse_spotify_id(spotify_ref):
       - Spotify URI (spotify:album:6IH6co1QUS7uXoyPDv0rIr)
       - HTTP link (http://open.spotify.com/album/6IH6co1QUS7uXoyPDv0rIr)
     """
-    # Spotify URI
-    if spotify_ref.startswith('spotify:album:'):
-        return spotify_ref[14:]
-
-    # Link to Spotify
-    # TODO(roman): Improve checking there.
-    if spotify_ref.startswith('http://') or spotify_ref.startswith('https://'):
-        if spotify_ref.endswith('/'):
-            spotify_ref = spotify_ref[:-1]
-        return os.path.split(urllib.parse.urlparse(spotify_ref).path)[-1]
-
-    # TODO(roman): Raise exception if failed to parse!
+    try:
+        if spotify_ref.startswith('spotify:album:'):
+            # Spotify URI
+            return spotify_ref[14:]
+        elif spotify_ref.startswith('http://') or spotify_ref.startswith('https://'):
+            # Link to Spotify
+            if spotify_ref.endswith('/'):
+                spotify_ref = spotify_ref[:-1]
+            return os.path.split(urllib.parse.urlparse(spotify_ref).path)[-1]
+    except Exception as err:
+        current_app.logger.error('Error "{}" occurred while parsing Spotify ID!'.format(e))
+        # Raise exception if failed to parse!
+        raise

--- a/critiquebrainz/frontend/views/mapping.py
+++ b/critiquebrainz/frontend/views/mapping.py
@@ -174,6 +174,9 @@ def parse_spotify_id(spotify_ref):
     Supported reference types:
       - Spotify URI (spotify:album:6IH6co1QUS7uXoyPDv0rIr)
       - HTTP link (http://open.spotify.com/album/6IH6co1QUS7uXoyPDv0rIr)
+
+    Returns:
+        parsed spotify id (ex. "6IH6co1QUS7uXoyPDv0rIr") if supported reference types are provided, else None
     """
     try:
         if spotify_ref.startswith('spotify:album:'):
@@ -184,7 +187,9 @@ def parse_spotify_id(spotify_ref):
             if spotify_ref.endswith('/'):
                 spotify_ref = spotify_ref[:-1]
             return os.path.split(urllib.parse.urlparse(spotify_ref).path)[-1]
+        else:
+            return None
     except Exception as err:
-        current_app.logger.error('Error "{}" occurred while parsing Spotify ID!'.format(e))
+        current_app.logger.error('Error "{}" occurred while parsing Spotify ID!'.format(err))
         # Raise exception if failed to parse!
         raise

--- a/critiquebrainz/frontend/views/mapping.py
+++ b/critiquebrainz/frontend/views/mapping.py
@@ -48,7 +48,7 @@ def spotify_list(release_group_id):
 
 
 @mapping_bp.route('/spotify/add')
-def spotify():
+def spotify_add():
     release_group_id = request.args.get('release_group_id')
     if not release_group_id:
         return redirect(url_for('frontend.index'))
@@ -60,7 +60,7 @@ def spotify():
 
     page = int(request.args.get('page', default=1))
     if page < 1:
-        return redirect(url_for('.spotify'))
+        return redirect(url_for('.spotify_add'))
     limit = 16
     offset = (page - 1) * limit
 
@@ -102,18 +102,18 @@ def spotify_confirm():
     spotify_ref = request.args.get('spotify_ref', default=None)
     if not spotify_ref:
         flash.error(gettext("You need to select an album from Spotify!"))
-        return redirect(url_for('.spotify', release_group_id=release_group_id))
+        return redirect(url_for('.spotify_add', release_group_id=release_group_id))
 
     spotify_id = parse_spotify_id(spotify_ref)
     if not spotify_id:
         flash.error(gettext("You need to specify a correct link to this album on Spotify!"))
-        return redirect(url_for('.spotify', release_group_id=release_group_id))
+        return redirect(url_for('.spotify_add', release_group_id=release_group_id))
 
     try:
         album = spotify_api.get_album(spotify_id)
     except ExternalServiceException:
         flash.error(gettext("You need to specify existing album from Spotify!"))
-        return redirect(url_for('.spotify', release_group_id=release_group_id))
+        return redirect(url_for('.spotify_add', release_group_id=release_group_id))
 
     if request.method == 'POST':
         # TODO(roman): Check values that are returned by add_mapping (also take a look at related JS).

--- a/critiquebrainz/frontend/views/mapping.py
+++ b/critiquebrainz/frontend/views/mapping.py
@@ -27,7 +27,6 @@ mapping_bp = Blueprint('mapping', __name__)
 def spotify_list(release_group_id):
     """This view lists all Spotify albums mapped to a specified release group."""
     spotify_mappings = mbspotify.mappings(str(release_group_id))
-
     # Converting Spotify URIs to IDs
     spotify_ids = []
     for mapping in spotify_mappings:
@@ -41,7 +40,7 @@ def spotify_list(release_group_id):
     else:
         spotify_albums = []
     try:
-        release_group = mb_release_group.get_release_group_by_id(release_group_id)
+        release_group = mb_release_group.get_release_group_by_id(str(release_group_id))
     except mb_exceptions.NoDataFoundException:
         raise NotFound("Can't find release group with a specified ID.")
     return render_template('mapping/list.html', spotify_albums=spotify_albums,

--- a/critiquebrainz/frontend/views/test/test_mapping.py
+++ b/critiquebrainz/frontend/views/test/test_mapping.py
@@ -1,6 +1,6 @@
 # critiquebrainz - Repository for Creative Commons licensed reviews
 #
-# Copyright (C) 2018 MetaBrainz Foundation Inc.
+# Copyright (C) 2018 Bimalkant Lauhny.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/critiquebrainz/frontend/views/test/test_mapping.py
+++ b/critiquebrainz/frontend/views/test/test_mapping.py
@@ -1,0 +1,82 @@
+# critiquebrainz - Repository for Creative Commons licensed reviews
+#
+# Copyright (C) 2018 MetaBrainz Foundation Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from unittest.mock import MagicMock
+from critiquebrainz.frontend.testing import FrontendTestCase
+from critiquebrainz.db.user import User
+import critiquebrainz.db.users as db_users
+from critiquebrainz.frontend.external import mbspotify
+import critiquebrainz.frontend.external.spotify as spotify_api
+import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
+import critiquebrainz.frontend.external.musicbrainz_db.release_group as mb_release_group
+
+class SpotifyMappingViewsTestCase(FrontendTestCase):
+
+    def setUp(self):
+        super(SpotifyMappingViewsTestCase, self).setUp()
+        self.user = User(db_users.get_or_create(1, "aef06569-098f-4218-a577-b413944d9493", new_user_data={
+            "display_name": u"Tester",
+        }))
+
+        self.test_spotify_id = "6IH6co1QUS7uXoyPDv0rIr"
+        self.test_release_groups = {
+            'id': '6b3cd75d-7453-39f3-86c4-1441f360e121',
+            'title': 'Test Release Group',
+            'first-release-year': 1970,
+            'artist-credit': [{
+                'name': 'Test Artist'
+            }]
+        }
+        self.test_spotify_response = {
+            '6IH6co1QUS7uXoyPDv0rIr': {
+                'type': 'album',
+                'id': '6IH6co1QUS7uXoyPDv0rIr',
+                'name': 'Test Album',
+                'release_date': '1970-01-01',
+                'external_urls': {
+                    'spotify': 'https://open.spotify.com/album/6IH6co1QUS7uXoyPDv0rIr'
+                },
+                'artists': [{'name': 'Test Artist', }]
+            }
+        }
+
+    def test_false_release_group_mapping_list(self):
+        # test mapping for non-existent release group, should return 404
+        mbspotify.mappings = MagicMock(return_value=[])
+        mb_release_group.get_release_group_by_id = MagicMock(side_effect=mb_exceptions.NoDataFoundException)
+        response = self.client.get("/mapping/6b3cd75d-7453-39f3-86c4-1441f360e121")
+        self.assert404(response, "Can't find release group with a specified ID.")
+
+    def test_release_group_mapping_list(self):
+        # test release group with mappings
+        mbspotify.mappings = MagicMock(return_value=['spotify:album:6IH6co1QUS7uXoyPDv0rIr'])
+        spotify_api.get_multiple_albums = MagicMock(return_value=self.test_spotify_response)
+        mb_release_group.get_release_group_by_id = MagicMock(return_value=self.test_release_group)
+        response = self.client.get("/mapping/6b3cd75d-7453-39f3-86c4-1441f360e121")
+        self.assert200(response)
+        self.assertIn(self.test_spotify_id, str(response.data))
+        self.assertIn("Test Album", str(response.data))
+        self.assertIn("1970-01-01", str(response.data))
+
+    def test_release_group_no_mappings(self):
+        # testing for release group with no mappings
+        mbspotify.mappings = MagicMock(return_value=[])
+        mb_release_group.get_release_group_by_id = MagicMock(return_value=self.test_release_groups)
+        response = self.client.get("/mapping/6b3cd75d-7453-39f3-86c4-1441f360e121")
+        self.assert200(response)
+        self.assertIn("No mappings", str(response.data))


### PR DESCRIPTION
*  Added tests for Spotify mapping frontend
*  Made `sentry_event_id` optional for error handlers
*  Along with parsing release year from `first-release-date`, now Spotify mapping templates will also use `first-release-year`.
*  Changed the name of view function which adds Spotify mappings, from just `spotify` to `spotify_add`.
*  Improved checking while parsing the supplied Spotify URI.
* Other small bugs.