### PR TITLE
CB-326: Hide and Unhide button for moderators on entity review page

### DIFF
--- a/admin/schema_changes/14.sql
+++ b/admin/schema_changes/14.sql
@@ -11,4 +11,3 @@ ALTER TABLE review ADD CONSTRAINT published_on_null_for_drafts_and_not_null_for_
     CHECK ((is_draft = 't' AND published_on IS NULL) OR (is_draft = 'f' AND published_on IS NOT NULL));
 
 COMMIT;
-

--- a/admin/schema_changes/15.sql
+++ b/admin/schema_changes/15.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TYPE action_types ADD VALUE 'unhide_review' AFTER 'hide_review';
+ALTER TYPE action_types ADD VALUE 'unblock_user' AFTER 'block_user';
+
+COMMIT;

--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -1,6 +1,8 @@
 CREATE TYPE action_types AS ENUM (
     'hide_review',
-    'block_user'
+    'unhide_review',
+    'block_user',
+    'unblock_user'
 );
 
 CREATE TYPE entity_types AS ENUM (

--- a/critiquebrainz/db/__init__.py
+++ b/critiquebrainz/db/__init__.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
 
 # This value must be incremented after schema changes on exported tables!
-SCHEMA_VERSION = 14
+SCHEMA_VERSION = 15
 
 VALID_RATING_VALUES = [None, 1, 2, 3, 4, 5]
 REVIEW_RATING_MAX = 5

--- a/critiquebrainz/db/moderation_log.py
+++ b/critiquebrainz/db/moderation_log.py
@@ -14,6 +14,7 @@ class AdminActions(Enum):
     ACTION_HIDE_REVIEW = "hide_review"
     ACTION_UNHIDE_REVIEW = "unhide_review"
     ACTION_BLOCK_USER = "block_user"
+    ACTION_UNBLOCK_USER = "unblock_user"
 
 
 def create(*, admin_id, review_id=None, user_id=None,

--- a/critiquebrainz/db/moderation_log.py
+++ b/critiquebrainz/db/moderation_log.py
@@ -3,12 +3,17 @@ Methods here define logs for various activities that the moderators can take
 via the moderator interface. A new log entry is created for every action.
 """
 from datetime import datetime
+from enum import Enum
 import sqlalchemy
 from critiquebrainz import db
 
 
-ACTION_HIDE_REVIEW = "hide_review"
-ACTION_BLOCK_USER = "block_user"
+class AdminActions(Enum):
+    """ Enum for Admin Actions """
+
+    ACTION_HIDE_REVIEW = "hide_review"
+    ACTION_UNHIDE_REVIEW = "unhide_review"
+    ACTION_BLOCK_USER = "block_user"
 
 
 def create(*, admin_id, review_id=None, user_id=None,
@@ -19,12 +24,12 @@ def create(*, admin_id, review_id=None, user_id=None,
         admin_id (uuid): ID of the admin.
         user_id (uuid): ID of the user blocked.
         review_id (uuid): ID of the review hidden.
-        action (str): str("hide_review", "block_user").
+        action (AdminAction): a member of enum AdminActions.
         reason (str): Reason for blocking a user or hiding a review.
     """
     if not review_id and not user_id:
         raise ValueError("No review ID or user ID specified.")
-    if action != ACTION_BLOCK_USER and action != ACTION_HIDE_REVIEW:
+    if action not in AdminActions:
         raise ValueError("Please specify a valid action.")
     with db.engine.connect() as connection:
         connection.execute(sqlalchemy.text("""
@@ -34,7 +39,7 @@ def create(*, admin_id, review_id=None, user_id=None,
             "admin_id": admin_id,
             "user_id": user_id,
             "review_id": review_id,
-            "action": action,
+            "action": action.value,
             "timestamp": datetime.now(),
             "reason": reason,
         })

--- a/critiquebrainz/db/moderation_log_test.py
+++ b/critiquebrainz/db/moderation_log_test.py
@@ -106,3 +106,16 @@ class ModerationLogTestCase(DataTestCase):
         self.assertEqual(str(logs[0]["admin"]["id"]), self.admin.id)
         self.assertEqual(str(logs[0]["user"]["id"]), self.user.id)
         self.assertEqual(str(logs[0]["action"]), AdminActions.ACTION_BLOCK_USER.value)
+
+        # test logs for unblocking user
+        db_moderation_log.create(
+            admin_id=self.admin.id,
+            reason="User to be unblocked",
+            user_id=self.user.id,
+            action=AdminActions.ACTION_UNBLOCK_USER,
+        )
+        logs, count = db_moderation_log.list_logs(admin_id=self.admin.id)
+        self.assertEqual(count, 4)
+        self.assertEqual(str(logs[0]["admin"]["id"]), self.admin.id)
+        self.assertEqual(str(logs[0]["user"]["id"]), self.user.id)
+        self.assertEqual(str(logs[0]["action"]), AdminActions.ACTION_UNBLOCK_USER.value)

--- a/critiquebrainz/db/moderation_log_test.py
+++ b/critiquebrainz/db/moderation_log_test.py
@@ -1,16 +1,16 @@
 from critiquebrainz.data.testing import DataTestCase
 import critiquebrainz.db.moderation_log as db_moderation_log
-from critiquebrainz.db.moderation_log import ACTION_BLOCK_USER, ACTION_HIDE_REVIEW
+from critiquebrainz.db.moderation_log import AdminActions
 import critiquebrainz.db.users as db_users
 import critiquebrainz.db.license as db_license
 import critiquebrainz.db.review as db_review
 from critiquebrainz.db.user import User
 
 
-class ModerationLogCase(DataTestCase):
+class ModerationLogTestCase(DataTestCase):
 
     def setUp(self):
-        super(ModerationLogCase, self).setUp()
+        super(ModerationLogTestCase, self).setUp()
 
         self.admin = User(db_users.get_or_create(1, "Admin", new_user_data={
             "display_name": "Admin",
@@ -35,32 +35,74 @@ class ModerationLogCase(DataTestCase):
         )
 
     def test_creation(self):
+        # test log creation when no review_id and no user_id is given
+        with self.assertRaises(ValueError) as err:
+            db_moderation_log.create(
+                admin_id=self.admin.id,
+                reason=self.reason,
+                action=AdminActions.ACTION_HIDE_REVIEW,
+            )
+        self.assertEqual(str(err.exception), "No review ID or user ID specified.")
+
+        # test log creation for non existing action
+        with self.assertRaises(ValueError) as err:
+            db_moderation_log.create(
+                admin_id=self.admin.id,
+                reason=self.reason,
+                user_id=self.user.id,
+                action="unknown_action",
+            )
+        self.assertEqual(str(err.exception), "Please specify a valid action.")
+
+        # test sample log creation for blocking user
         db_moderation_log.create(
             admin_id=self.admin.id,
             reason=self.reason,
             user_id=self.user.id,
-            action=ACTION_BLOCK_USER,
+            action=AdminActions.ACTION_BLOCK_USER,
         )
         logs, count = db_moderation_log.list_logs()
         self.assertEqual(count, 1)
         self.assertEqual(str(logs[0]["user"]["id"]), self.user.id)
         self.assertEqual(str(logs[0]["admin"]["id"]), self.admin.id)
+        self.assertEqual(str(logs[0]["action"]), AdminActions.ACTION_BLOCK_USER.value)
 
     def test_list(self):
+        # test logs for hiding review
         db_moderation_log.create(
             admin_id=self.admin.id,
             reason=self.reason,
             review_id=self.review["id"],
-            action=ACTION_HIDE_REVIEW,
+            action=AdminActions.ACTION_HIDE_REVIEW,
         )
         logs, count = db_moderation_log.list_logs(admin_id=self.admin.id)
         self.assertEqual(count, 1)
         self.assertEqual(str(logs[0]["admin"]["id"]), self.admin.id)
+        self.assertEqual(str(logs[0]["review"]["id"]), str(self.review["id"]))
+        self.assertEqual(str(logs[0]["action"]), AdminActions.ACTION_HIDE_REVIEW.value)
+
+        # test logs for unhiding review
+        db_moderation_log.create(
+            admin_id=self.admin.id,
+            reason=self.reason,
+            review_id=self.review["id"],
+            action=AdminActions.ACTION_UNHIDE_REVIEW,
+        )
+        logs, count = db_moderation_log.list_logs(admin_id=self.admin.id)
+        self.assertEqual(count, 2)
+        self.assertEqual(str(logs[0]["admin"]["id"]), self.admin.id)
+        self.assertEqual(str(logs[0]["review"]["id"]), str(self.review["id"]))
+        self.assertEqual(str(logs[0]["action"]), AdminActions.ACTION_UNHIDE_REVIEW.value)
+
+        # test logs for blocking user
         db_moderation_log.create(
             admin_id=self.admin.id,
             reason="User to be blocked",
             user_id=self.user.id,
-            action=ACTION_BLOCK_USER,
+            action=AdminActions.ACTION_BLOCK_USER,
         )
         logs, count = db_moderation_log.list_logs(admin_id=self.admin.id)
-        self.assertEqual(count, 2)
+        self.assertEqual(count, 3)
+        self.assertEqual(str(logs[0]["admin"]["id"]), self.admin.id)
+        self.assertEqual(str(logs[0]["user"]["id"]), self.user.id)
+        self.assertEqual(str(logs[0]["action"]), AdminActions.ACTION_BLOCK_USER.value)

--- a/critiquebrainz/frontend/templates/log/action.html
+++ b/critiquebrainz/frontend/templates/log/action.html
@@ -4,7 +4,11 @@
   {% set release_group = review.entity_id | entity_details %}
   {% set rg_title = release_group.title | default(_('[Unknown release group]')) %}
   {# TODO(dufferzafar): Handle multiple actions for a same entity type #}
-  {% set title = _('Hide %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) %}
+  {% if action == "hide_review" %}
+    {% set title = _('Hide %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) %}
+  {% else %}
+    {% set title = _('Unhide %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) %}
+  {% endif %}
   {% set cancel_url = url_for('review.entity', id=review.id) %}
 {% elif user is defined %}
   {% set title = _('Block %(user)s', user=user.display_name) %}

--- a/critiquebrainz/frontend/templates/log/action.html
+++ b/critiquebrainz/frontend/templates/log/action.html
@@ -3,16 +3,19 @@
 {% if review is defined %}
   {% set release_group = review.entity_id | entity_details %}
   {% set rg_title = release_group.title | default(_('[Unknown release group]')) %}
-  {# TODO(dufferzafar): Handle multiple actions for a same entity type #}
-  {% if action == "hide_review" %}
-    {% set title = _('Hide %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) %}
-  {% else %}
-    {% set title = _('Unhide %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) %}
-  {% endif %}
   {% set cancel_url = url_for('review.entity', id=review.id) %}
 {% elif user is defined %}
-  {% set title = _('Block %(user)s', user=user.display_name) %}
   {% set cancel_url = url_for('user.reviews', user_id=user.id) %}
+{% endif %}
+
+{% if action == "hide_review" %}
+  {% set title = _('Hide %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) %}
+{% elif action == "unhide_review" %}
+  {% set title = _('Unhide %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) %}
+{% elif action == "block_user" %}
+  {% set title = _('Block %(user)s', user=user.display_name) %}
+{% elif action == "unblock_user" %}
+  {% set title = _('Unblock %(user)s', user=user.display_name) %}
 {% endif %}
 
 {% block title %}{{ title }} - CritiqueBrainz{% endblock %}

--- a/critiquebrainz/frontend/templates/log/log_results.html
+++ b/critiquebrainz/frontend/templates/log/log_results.html
@@ -15,17 +15,22 @@
         {{ log.timestamp.strftime('%I:%M %p') }} -
         {% if log.action == "hide_review" %}
           {{
-            _('%(admin)s archived a %(review)s written by %(user)s',
+            _('%(admin)s hid a %(review)s written by %(user)s',
             admin=link_user(log.admin), review=link_review(log.review), user=link_user(log.review.user))
           }}
         {% elif log.action == "unhide_review" %}
           {{
-            _('%(admin)s restored an archived %(review)s written by %(user)s',
+            _('%(admin)s unhid a %(review)s written by %(user)s',
             admin=link_user(log.admin), review=link_review(log.review), user=link_user(log.review.user))
           }}
         {% elif log.action == "block_user" %}
           {{
             _('%(admin)s blocked %(user)s',
+            admin=link_user(log.admin), user=link_user(log.user))
+          }}
+        {% elif log.action == "unblock_user" %}
+          {{
+            _('%(admin)s unblocked %(user)s',
             admin=link_user(log.admin), user=link_user(log.user))
           }}
         {% endif %}

--- a/critiquebrainz/frontend/templates/log/log_results.html
+++ b/critiquebrainz/frontend/templates/log/log_results.html
@@ -18,7 +18,12 @@
             _('%(admin)s archived a %(review)s written by %(user)s',
             admin=link_user(log.admin), review=link_review(log.review), user=link_user(log.review.user))
           }}
-         {% elif log.action == "block_user" %}
+        {% elif log.action == "unhide_review" %}
+          {{
+            _('%(admin)s restored an archived %(review)s written by %(user)s',
+            admin=link_user(log.admin), review=link_review(log.review), user=link_user(log.review.user))
+          }}
+        {% elif log.action == "block_user" %}
           {{
             _('%(admin)s blocked %(user)s',
             admin=link_user(log.admin), user=link_user(log.user))

--- a/critiquebrainz/frontend/templates/review/entity/base.html
+++ b/critiquebrainz/frontend/templates/review/entity/base.html
@@ -45,7 +45,7 @@
         {% endif %}
       {% endif %}
 
-      {% if current_user.is_authenticated and current_user != review.user and current_user.is_admin() %}
+      {% if current_user.is_authenticated and current_user.is_admin() %}
         <hr />
         <div>
           <a href="{{ url_for('review.unhide' if review.is_hidden else 'review.hide', id=review.id) }}"

--- a/critiquebrainz/frontend/templates/review/entity/base.html
+++ b/critiquebrainz/frontend/templates/review/entity/base.html
@@ -47,21 +47,13 @@
 
       {% if current_user.is_authenticated and current_user != review.user and current_user.is_admin() %}
         <hr />
-        {% if review.is_hidden %}
-          <div>
-            <a href="{{ url_for('review.unhide', id=review.id) }}"
-               class="btn btn-warning btn-sm">
-              <span class="glyphicon glyphicon-ok"></span> {{ _('Unhide this review') }}
-            </a>
-          </div>
-        {% else %}
-          <div>
-            <a href="{{ url_for('review.hide', id=review.id) }}"
-               class="btn btn-danger btn-sm">
-              <span class="glyphicon glyphicon-remove"></span> {{ _('Hide this review') }}
-            </a>
-          </div>
-        {% endif %}
+        <div>
+          <a href="{{ url_for('review.unhide' if review.is_hidden else 'review.hide', id=review.id) }}"
+             class="btn {{ 'btn-warning' if review.is_hidden else 'btn-danger'}} btn-sm">
+            <span class="glyphicon {{ 'glyphicon-ok' if review.is_hidden else 'glyphicon-remove' }}"></span>
+            {{ _('Unhide this review' if review.is_hidden else 'Hide this review') }}
+          </a>
+        </div>
       {% endif %}
 
       <hr />

--- a/critiquebrainz/frontend/templates/review/entity/base.html
+++ b/critiquebrainz/frontend/templates/review/entity/base.html
@@ -45,6 +45,25 @@
         {% endif %}
       {% endif %}
 
+      {% if current_user.is_authenticated and current_user != review.user and current_user.is_admin() %}
+        <hr />
+        {% if review.is_hidden %}
+          <div>
+            <a href="{{ url_for('review.unhide', id=review.id) }}"
+               class="btn btn-warning btn-sm">
+              <span class="glyphicon glyphicon-ok"></span> {{ _('Unhide this review') }}
+            </a>
+          </div>
+        {% else %}
+          <div>
+            <a href="{{ url_for('review.hide', id=review.id) }}"
+               class="btn btn-danger btn-sm">
+              <span class="glyphicon glyphicon-remove"></span> {{ _('Hide this review') }}
+            </a>
+          </div>
+        {% endif %}
+      {% endif %}
+
       <hr />
 
       {% if not review.is_draft %}

--- a/critiquebrainz/frontend/templates/user/base.html
+++ b/critiquebrainz/frontend/templates/user/base.html
@@ -14,7 +14,8 @@
           </a>
         {% elif current_user.is_admin() %}
           <a href="{{ url_for('user.unblock' if user.is_blocked else 'user.block', user_id=user.id) }}"
-             class="btn btn-primary pull-right" style="margin-top: 20px;">
+             class="btn {{ 'btn-warning' if user.is_blocked else 'btn-danger'}} pull-right" style="margin-top: 20px;">
+             <span class="glyphicon {{ 'glyphicon-ok' if user.is_blocked else 'glyphicon-remove' }}"></span>
             {{ ('Unblock User' if user.is_blocked else 'Block User') }}
           </a>
         {% endif %}

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -452,11 +452,14 @@ def hide(id):
     return render_template('log/action.html', review=review, form=form, action=ACTION_HIDE_REVIEW)
 
 
-@review_bp.route('/<uuid:id>/unhide', methods=['POST'])
+@review_bp.route('/<uuid:id>/unhide')
 @login_required
 @admin_view
 def unhide(id):
     review = get_review_or_404(id)
+    if not review["is_hidden"]:
+        flash.info(gettext("Review is not hidden."))
+        return redirect(url_for('.entity', id=review["id"]))
     db_review.set_hidden_state(review["id"], is_hidden=False)
     flash.success(gettext("Review is not hidden anymore."))
     return redirect(request.referrer or url_for('user.reviews', user_id=current_user.id))

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -264,7 +264,6 @@ class ReviewViewsTestCase(FrontendTestCase):
             data=dict(reason="Test hiding review."),
             follow_redirects=True,
         )
-
         self.assertIn("Review has been hidden.", str(response.data))
         review = db_review.get_by_id(review["id"])
         self.assertEqual(review["is_hidden"], True)
@@ -275,7 +274,6 @@ class ReviewViewsTestCase(FrontendTestCase):
             data=dict(reason="Test hiding already hidden review."),
             follow_redirects=True,
         )
-
         self.assertIn("Review is already hidden.", str(response.data))
 
         # check that unhide button is visible to admin
@@ -284,11 +282,19 @@ class ReviewViewsTestCase(FrontendTestCase):
         self.assertIn("Unhide this review", str(response.data))
 
         # unhide review
-        response = self.client.get("/review/{}/unhide".format(review["id"]), follow_redirects=True)
-        self.assert200(response)
+        response = self.client.post(
+            "review/{}/unhide".format(review["id"]),
+            data=dict(reason="Test unhiding a hidden review."),
+            follow_redirects=True,
+        )
         self.assertIn("Review is not hidden anymore.", str(response.data))
+        review = db_review.get_by_id(review["id"])
+        self.assertEqual(review["is_hidden"], False)
 
         # unhide a non-hidden review
-        response = self.client.get("/review/{}/unhide".format(review["id"]), follow_redirects=True)
-        self.assert200(response)
+        response = self.client.post(
+            "review/{}/unhide".format(review["id"]),
+            data=dict(reason="Test unhiding an already visible review."),
+            follow_redirects=True,
+        )
         self.assertIn("Review is not hidden.", str(response.data))

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -236,3 +236,59 @@ class ReviewViewsTestCase(FrontendTestCase):
         response = self.client.get("/review/%s" % review["id"])
         self.assert200(response)
         self.assertIn("A great place.", str(response.data))
+
+    def test_hide_unhide(self):
+        # create a review by self.user and check it's not hidden
+        review = self.create_dummy_review()
+        self.assertEqual(review["is_hidden"], False)
+
+        # make self.hacker as current user
+        self.temporary_login(self.hacker)
+
+        # check that hide button is not visible to non-admin user
+        response = self.client.get("/review/{}".format(review["id"]))
+        self.assert200(response)
+        self.assertNotIn("Hide this review", str(response.data))
+
+        # make self.hacker as admin
+        User.is_admin = MagicMock(return_value=True)
+
+        # check that hide button is visible to admin
+        response = self.client.get("/review/{}".format(review["id"]))
+        self.assert200(response)
+        self.assertIn("Hide this review", str(response.data))
+
+        # hide the review
+        response = self.client.post(
+            "review/{}/hide".format(review["id"]),
+            data=dict(reason="Test hiding review."),
+            follow_redirects=True,
+        )
+
+        self.assertIn("Review has been hidden.", str(response.data))
+        review = db_review.get_by_id(review["id"])
+        self.assertEqual(review["is_hidden"], True)
+
+        # hiding already hidden review flashes message
+        response = self.client.post(
+            "review/{}/hide".format(review["id"]),
+            data=dict(reason="Test hiding already hidden review."),
+            follow_redirects=True,
+        )
+
+        self.assertIn("Review is already hidden.", str(response.data))
+
+        # check that unhide button is visible to admin
+        response = self.client.get("/review/{}".format(review["id"]))
+        self.assert200(response)
+        self.assertIn("Unhide this review", str(response.data))
+
+        # unhide review
+        response = self.client.get("/review/{}/unhide".format(review["id"]), follow_redirects=True)
+        self.assert200(response)
+        self.assertIn("Review is not hidden anymore.", str(response.data))
+
+        # unhide a non-hidden review
+        response = self.client.get("/review/{}/unhide".format(review["id"]), follow_redirects=True)
+        self.assert200(response)
+        self.assertIn("Review is not hidden.", str(response.data))

--- a/critiquebrainz/frontend/views/test/test_user.py
+++ b/critiquebrainz/frontend/views/test/test_user.py
@@ -1,22 +1,90 @@
+from unittest.mock import MagicMock
 from critiquebrainz.frontend.testing import FrontendTestCase
-from critiquebrainz.db.user import User
 import critiquebrainz.db.users as db_users
+from critiquebrainz.db.user import User
 
 
 class UserViewsTestCase(FrontendTestCase):
 
-    def test_reviews(self):
-        user = User(db_users.get_or_create(1, "aef06569-098f-4218-a577-b413944d9493", new_user_data={
-            "display_name": "Tester",
+    def setUp(self):
+        super(UserViewsTestCase, self).setUp()
+        self.user = User(db_users.get_or_create(1, "aef06569-098f-4218-a577-b413944d9493", new_user_data={
+            "display_name": u"Tester",
         }))
-        response = self.client.get("/user/%s" % user.id)
+        self.admin = User(db_users.get_or_create(2, "9371e5c7-5995-4471-a5a9-33481f897f9c", new_user_data={
+            "display_name": u"Admin",
+        }))
+
+    def test_reviews(self):
+        # test reviews for user not in db
+        response = self.client.get("/user/{user_id}".format(user_id="random-user-id"))
+        self.assert404(response, "Can't find a user with ID: random-user-id")
+
+        # test reviews for user present in db, but not logged in
+        response = self.client.get("/user/{user_id}".format(user_id=self.user.id))
         self.assert200(response)
         self.assertIn("Tester", str(response.data))
 
     def test_info(self):
-        user = User(db_users.get_or_create(1, "aef06569-098f-4218-a577-b413944d9493", new_user_data={
-            "display_name": "Tester",
-        }))
-        response = self.client.get("/user/%s/info" % user.id)
+        # test info for user not in db
+        response = self.client.get("/user/{user_id}/info".format(user_id="random-user-id"))
+        self.assert404(response, "Can't find a user with ID: random-user-id")
+
+        # test info for user present in db
+        response = self.client.get("/user/{user_id}/info".format(user_id=self.user.id))
         self.assert200(response)
         self.assertIn("Tester", str(response.data))
+
+    def test_block_unblock(self):
+        self.temporary_login(self.admin)
+
+        # test block user when user is not in db
+        response = self.client.get("/user/{user_id}/block".format(user_id="random-user-id"))
+        self.assert404(response, "Can't find a user with ID: random-user-id")
+
+        # only moderator can block a user
+        response = self.client.get("/user/{user_id}/block".format(user_id=self.user.id))
+        self.assert401(response, "You must be an administrator to view this page.")
+
+        # make self.admin as admin
+        User.is_admin = MagicMock(return_value=True)
+
+        # admin blocks tester
+        response = self.client.post(
+            "user/{user_id}/block".format(user_id=self.user.id),
+            data=dict(reason="Test blocking user."),
+            follow_redirects=True,
+        )
+        self.assertIn("This user account has been blocked.", str(response.data))
+        user = db_users.get_by_id(self.user.id)
+        self.assertEqual(user["is_blocked"], True)
+
+        # testing when admin blocks an already blocked user
+        response = self.client.post(
+            "user/{user_id}/block".format(user_id=self.user.id),
+            data=dict(reason="Test blocking already blocker user."),
+            follow_redirects=True,
+        )
+        self.assertIn("This account is already blocked.", str(response.data))
+
+        # test unblock user when user is not in db
+        response = self.client.get("/user/{user_id}/unblock".format(user_id="random-user-id"))
+        self.assert404(response, "Can't find a user with ID: random-user-id")
+
+        # admin unblocks tester
+        response = self.client.post(
+            "user/{user_id}/unblock".format(user_id=self.user.id),
+            data=dict(reason="Test unblocking user."),
+            follow_redirects=True,
+        )
+        self.assertIn("This user account has been unblocked.", str(response.data))
+        user = db_users.get_by_id(self.user.id)
+        self.assertEqual(user["is_blocked"], False)
+
+        # testing when admin unblocks a user that is not blocked
+        response = self.client.post(
+            "user/{user_id}/unblock".format(user_id=self.user.id),
+            data=dict(reason="Test unblocking user that is not blocked."),
+            follow_redirects=True,
+        )
+        self.assertIn("This account is not blocked.", str(response.data))

--- a/critiquebrainz/frontend/views/test/test_user.py
+++ b/critiquebrainz/frontend/views/test/test_user.py
@@ -42,11 +42,7 @@ class UserViewsTestCase(FrontendTestCase):
         response = self.client.get("/user/{user_id}/block".format(user_id="random-user-id"))
         self.assert404(response, "Can't find a user with ID: random-user-id")
 
-        # only moderator can block a user
-        response = self.client.get("/user/{user_id}/block".format(user_id=self.user.id))
-        self.assert401(response, "You must be an administrator to view this page.")
-
-        # make self.admin as admin
+        # make self.admin a moderator
         User.is_admin = MagicMock(return_value=True)
 
         # admin blocks tester


### PR DESCRIPTION
* If a review is not hidden, `Hide this review` button is shown to the moderator. Similarly, if the review is hidden, `Unhide this review` button is shown.
* A user cannot hide or unhide their review even if the user is a moderator. In this case, only some other moderator can take these actions (and is shown hide/unhide button).