### PR TITLE
CB-305: Allow users to edit comments

### DIFF
--- a/critiquebrainz/frontend/static/styles/main.less
+++ b/critiquebrainz/frontend/static/styles/main.less
@@ -418,6 +418,11 @@ a#edit-review { margin-top: 20px; }
       }
     }
   }
+
+  // comments
+  .comment-header {
+    margin: 15px auto;
+  }
 }
 
 

--- a/critiquebrainz/frontend/templates/review/entity/base.html
+++ b/critiquebrainz/frontend/templates/review/entity/base.html
@@ -149,44 +149,7 @@
         </div>
       {% endif %}
 
-      {% if comments %}
-        <hr/>
-        <h3> Comments ({{ comment_count }})</h3>
-        <div id="comment-list">
-          {% for comment in comments %}
-            <div id="{{ comment.id }}">
-              <hr/>
-              <p>
-                {{ comment_credit(comment, user_picture_size=24) }}
-                {% if current_user.is_authenticated and current_user == comment.user %}
-                  <a href="{{ url_for('comment.delete', id=comment.id) }}"
-                     class="btn btn-danger btn-xs"
-                     title="{{ _('Delete your comment') }}">
-                      <span class="glyphicon glyphicon-trash"></span>
-                  </a>
-                {% endif %}
-                <span style="float:right;">
-                  <small><em class="text-muted"> {{comment.created | date}} </em></small>
-                </span>
-              </p>
-              <p> {{ comment.text_html|safe }} </p>
-            </div>
-          {% endfor %}
-        </div>
-      {% endif %}
-
-      {% if current_user.is_authenticated %}
-        <hr/>
-        <form method="POST" class="form-horizontal" role="form" action="{{ url_for('comment.create') }}">
-          <div class="form-group">
-            {{ comment_form.hidden_tag() }}
-            {{ comment_form.text(id="comment-text") }}
-          </div>
-          <div class="form-group">
-            <button type="submit" class="btn btn-primary">{{ _('Add comment') }}</button>
-          </div>
-        </form>
-      {% endif %}
+      <div id="comments-section">{% include 'review/entity/comments.html' %}</div>
 
      </div>
   </div>
@@ -196,14 +159,4 @@
 {% block scripts %}
   {{ super() }}
   <script src="{{ get_static_path('rating.js') }}"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css"/>
-  <script src="{{ get_static_path('wysiwyg-editor.js') }}"></script>
-  <script>
-    $(document).ready(function() {
-      reviewContentEditor = new SimpleMDE({
-        element: $('#comment-text')[0],
-        spellChecker: false
-      });
-    });
-  </script>
 {% endblock %}

--- a/critiquebrainz/frontend/templates/review/entity/base.html
+++ b/critiquebrainz/frontend/templates/review/entity/base.html
@@ -149,7 +149,11 @@
         </div>
       {% endif %}
 
-      <div id="comments-section">{% include 'review/entity/comments.html' %}</div>
+      <hr/>
+      <div id="comments-section">
+        <h3> Comments ({{ comment_count }})</h3>
+        {% include 'review/entity/comments.html' %}
+      </div>
 
      </div>
   </div>

--- a/critiquebrainz/frontend/templates/review/entity/comments.html
+++ b/critiquebrainz/frontend/templates/review/entity/comments.html
@@ -1,0 +1,94 @@
+{% if comments %}
+  <hr/>
+  <h3> Comments ({{ comment_count }})</h3>
+  <div id="comment-list">
+    {% for comment in comments %}
+      <hr/>
+      <div id="{{ comment.id }}" class="comment-container">
+        <div class="comment-header">
+          {{ comment_credit(comment, user_picture_size=24) }}
+          {% if current_user.is_authenticated and current_user == comment.user %}
+            <a href="{{ url_for('comment.delete', id=comment.id) }}"
+               class="btn btn-danger btn-xs"
+               title="{{ _('Delete this comment') }}">
+                <span class="glyphicon glyphicon-trash"></span>
+            </a>
+            <button class="comment-edit-button btn btn-primary btn-xs"
+                    title="{{ _('Edit this comment') }}">
+              <span class="glyphicon glyphicon-edit"></span>  
+            </button>
+          {% endif %}
+          <span style="float:right;">
+            <small><em class="text-muted"> {{comment.created | date}} </em></small>
+          </span>
+        </div>
+        <div class="comment-content">
+          <div class="comment-content-html">
+            {{ comment.text_html|safe }}
+          </div>
+          <p class="comment-content-mark" style="display: none;">{{ comment.last_revision.text }}</p>
+        </div>
+        <div class="comment-edit-form" style="display: none;">
+          <form method="POST" class="form-horizontal" role="form" action="{{ url_for('comment.edit', id=comment.id) }}">
+            <div class="form-group">
+              {{ comment_form.hidden_tag() }}
+              {{ comment_form.text(class="comment-text") }}
+            </div>
+            <div class="form-group">
+              <button type="submit" class="btn btn-primary">{{ _('Update comment') }}</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+{% endif %}
+
+{% if current_user.is_authenticated %}
+  <hr/>
+  <div id="comment-add-form">
+    <form method="POST" class="form-horizontal" role="form" action="{{ url_for('comment.create') }}">
+      <div class="form-group">
+        {{ comment_form.hidden_tag() }}
+        {{ comment_form.text(class="comment-text") }}
+      </div>
+      <div class="form-group">
+        <button type="submit" class="btn btn-primary">{{ _('Add comment') }}</button>
+      </div>
+    </form>
+  </div>
+{% endif %}
+
+
+{% block scripts %}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css"/>
+  <script src="{{ get_static_path('wysiwyg-editor.js') }}"></script>
+  <script>
+    $(document).ready(function() {
+      simplemde = {};
+      simplemde["commentAddForm"] = new SimpleMDE({
+        element: $("#comment-add-form").find(".comment-text")[0],
+        spellChecker: false
+      });
+
+      $(".comment-edit-button").click(function() {
+
+        let commentDiv = $(this).closest(".comment-container"),
+            commentEditForm = commentDiv.find(".comment-edit-form"),
+            commentText = commentEditForm.find(".comment-text")[0],
+            commentContentDiv = commentDiv.find(".comment-content"),
+            commentContentText = commentContentDiv.find(".comment-content-mark").text(),
+            commentDivId = commentDiv.attr("id");
+        commentEditForm.toggle();
+        commentContentDiv.toggle();
+        if (!simplemde[commentDivId]) {
+          simplemde[commentDivId] = new SimpleMDE({
+            element: commentText,
+            spellChecker: false
+          });
+        }
+        simplemde[commentDivId].value(commentContentText);
+      });
+    });
+  </script>
+{% endblock %}

--- a/critiquebrainz/frontend/templates/review/entity/comments.html
+++ b/critiquebrainz/frontend/templates/review/entity/comments.html
@@ -1,6 +1,4 @@
 {% if comments %}
-  <hr/>
-  <h3> Comments ({{ comment_count }})</h3>
   <div id="comment-list">
     {% for comment in comments %}
       <hr/>

--- a/critiquebrainz/frontend/templates/review/entity/comments.html
+++ b/critiquebrainz/frontend/templates/review/entity/comments.html
@@ -28,17 +28,6 @@
           </div>
           <p class="comment-content-mark" style="display: none;">{{ comment.last_revision.text }}</p>
         </div>
-        <div class="comment-edit-form" style="display: none;">
-          <form method="POST" class="form-horizontal" role="form" action="{{ url_for('comment.edit', id=comment.id) }}">
-            <div class="form-group">
-              {{ comment_form.hidden_tag() }}
-              {{ comment_form.text(class="comment-text") }}
-            </div>
-            <div class="form-group">
-              <button type="submit" class="btn btn-primary">{{ _('Update comment') }}</button>
-            </div>
-          </form>
-        </div>
       </div>
     {% endfor %}
   </div>
@@ -65,29 +54,52 @@
   <script src="{{ get_static_path('wysiwyg-editor.js') }}"></script>
   <script>
     $(document).ready(function() {
-      simplemde = {};
-      simplemde["commentAddForm"] = new SimpleMDE({
+      commentMdes = {};
+      commentMdes["commentAddForm"] = new SimpleMDE({
         element: $("#comment-add-form").find(".comment-text")[0],
         spellChecker: false
       });
 
       $(".comment-edit-button").click(function() {
-
         let commentDiv = $(this).closest(".comment-container"),
-            commentEditForm = commentDiv.find(".comment-edit-form"),
-            commentText = commentEditForm.find(".comment-text")[0],
-            commentContentDiv = commentDiv.find(".comment-content"),
-            commentContentText = commentContentDiv.find(".comment-content-mark").text(),
             commentDivId = commentDiv.attr("id");
-        commentEditForm.toggle();
+
+        let commentUpdateForm = commentDiv.find(".comment-update-form");
+        if (commentUpdateForm.length === 0) {
+            // update button is clicked first time for this comment,
+            // define new commentUpdateForm, and append it to comment div
+            let commentUpdateFormHtml = $(`
+              <div class="comment-update-form" style="display: none;">
+                <form method="POST" class="form-horizontal" role="form" action="{{ url_for('comment.edit', id='commentDivId') }}">
+                  <div class="form-group">
+                    {{ comment_form.hidden_tag() }}
+                    {{ comment_form.text(class="comment-text") }}
+                  </div>
+                  <div class="form-group">
+                    <button type="submit" class="btn btn-primary">{{ _('Update comment') }}</button>
+                  </div>
+                </form>
+              </div>
+            `.replace('commentDivId', commentDivId));
+            commentDiv.append(commentUpdateFormHtml);
+            commentUpdateForm = commentDiv.find(".comment-update-form");
+        }
+        commentUpdateForm.toggle();
+        let commentText = commentUpdateForm.find(".comment-text")[0],
+            commentContentDiv = commentDiv.find(".comment-content"),
+            commentContentText = commentContentDiv.find(".comment-content-mark").text();
+
+        // hide/show old comment text
         commentContentDiv.toggle();
-        if (!simplemde[commentDivId]) {
-          simplemde[commentDivId] = new SimpleMDE({
+
+        if (!commentMdes[commentDivId]) {
+          // if no simplemde object is created for this comment, create it
+          commentMdes[commentDivId] = new SimpleMDE({
             element: commentText,
             spellChecker: false
           });
         }
-        simplemde[commentDivId].value(commentContentText);
+        commentMdes[commentDivId].value(commentContentText);
       });
     });
   </script>

--- a/critiquebrainz/frontend/templates/review/entity/comments.html
+++ b/critiquebrainz/frontend/templates/review/entity/comments.html
@@ -67,6 +67,7 @@
             // update button is clicked first time for this comment,
             // define new commentUpdateForm, and append it to comment div
             let commentUpdateFormHtml = $(`
+              <br>
               <div class="comment-update-form" style="display: none;">
                 <form method="POST" class="form-horizontal" role="form" action="{{ url_for('comment.edit', id='commentDivId') }}">
                   <div class="form-group">

--- a/critiquebrainz/frontend/views/comment.py
+++ b/critiquebrainz/frontend/views/comment.py
@@ -84,8 +84,6 @@ def delete(id):
 @login_required
 def edit(id):
     comment = get_comment_or_404(id)
-    # if comment exists, review must exist
-    review = get_review_or_404(comment["review_id"])
     if comment["user"] != current_user:
         raise Unauthorized(gettext("Only the author can edit this comment."))
     if current_user.is_blocked:

--- a/critiquebrainz/frontend/views/comment.py
+++ b/critiquebrainz/frontend/views/comment.py
@@ -78,3 +78,31 @@ def delete(id):
     if comment:
         comment["text_html"] = markdown(comment["last_revision"]["text"], safe_mode="escape")
     return render_template('review/delete_comment.html', review=review, comment=comment)
+
+
+@comment_bp.route('/<uuid:id>/edit', methods=['POST'])
+@login_required
+def edit(id):
+    comment = get_comment_or_404(id)
+    # if comment exists, review must exist
+    review = get_review_or_404(comment["review_id"])
+    if comment["user"] != current_user:
+        raise Unauthorized(gettext("Only the author can edit this comment."))
+    if current_user.is_blocked:
+        flash.error(gettext("You are not allowed to edit comments because your "
+                            "account has been blocked by a moderator."))
+        return redirect(url_for('review.entity', id=comment["review_id"]))
+    form = CommentEditForm()
+    if form.validate_on_submit():
+        if form.text.data != comment["last_revision"]["text"]:
+            db_comment.update(
+                comment_id=comment["id"],
+                text=form.text.data
+            )
+            flash.success(gettext("Comment has been updated."))
+        else:
+            flash.error(gettext("You must change some content of the comment to update it!"))
+    elif not form.text.data:
+        # comment must have some text
+        flash.error(gettext("Comment must not be empty!"))
+    return redirect(url_for('review.entity', id=comment["review_id"]))


### PR DESCRIPTION
Changes/additions summary:
* Separate template for comments
* Added JavaScript for dynamically displaying comment edit form when a user clicks on the comment edit button.
* Added `comment.edit` view