### PR TITLE
CB-348: Add votes to dumps

### DIFF
--- a/critiquebrainz/data/dump_manager.py
+++ b/critiquebrainz/data/dump_manager.py
@@ -469,6 +469,7 @@ def importer(archive):
         import_data(os.path.join(temp_dir, 'cbdump', 'review'), 'review')
         import_data(os.path.join(temp_dir, 'cbdump', 'revision'), 'revision')
         import_data(os.path.join(temp_dir, 'cbdump', 'avg_rating'), 'avg_rating')
+        import_data(os.path.join(temp_dir, 'cbdump', 'vote'), 'vote')
 
         shutil.rmtree(temp_dir)  # Cleanup
         print("Done!")

--- a/critiquebrainz/db/vote.py
+++ b/critiquebrainz/db/vote.py
@@ -73,3 +73,14 @@ def delete(user_id, revision_id):
             "user_id": user_id,
             "revision_id": revision_id,
         })
+
+
+def get_count():
+    """Get the total number of votes in CritiqueBrainz.
+    """
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT count(*)
+              FROM vote
+        """))
+        return result.fetchone()[0]

--- a/critiquebrainz/db/vote_test.py
+++ b/critiquebrainz/db/vote_test.py
@@ -61,3 +61,14 @@ class VoteTestCase(DataTestCase):
             "revision_id": self.review["last_revision"]["id"],
             "vote": False,
         })
+
+    def test_get_count(self):
+        self.assertEqual(vote.get_count(), 0)
+        vote.submit(self.user_1.id, self.review["last_revision"]["id"], True)
+        self.assertEqual(vote.get_count(), 1)
+
+    def test_delete(self):
+        vote.submit(self.user_1.id, self.review["last_revision"]["id"], True)
+        self.assertEqual(vote.get_count(), 1)
+        vote.delete(self.user_1.id, self.review["last_revision"]["id"])
+        self.assertEqual(vote.get_count(), 0)


### PR DESCRIPTION
Additions -
* Support for adding `vote` table contents to public dumps
* Support for importing `vote` to db from public dumps