### PR TITLE
CB-351: Link external reviews imported from MusicBrainz

### DIFF
--- a/critiquebrainz/frontend/templates/event/entity.html
+++ b/critiquebrainz/frontend/templates/event/entity.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from 'macros.html' import show_avg_rating, entity_rate_form with context %}
+{% from 'macros.html' import show_avg_rating, entity_rate_form, show_external_reviews with context %}
 
 {% block title %}{{ event.name }} - CritiqueBrainz{% endblock %}
 
@@ -126,6 +126,13 @@
             {% endfor %}
           </ul>
         {% endfor %}
+      {% endif %}
+
+      {% if external_reviews %}
+        <b>{{ _('External reviews') }}</b>
+        <ul class="list-unstyled external-links">
+          {{ show_external_reviews(external_reviews) }}
+        </ul>
       {% endif %}
 
       <div class="external-links">

--- a/critiquebrainz/frontend/templates/macros.html
+++ b/critiquebrainz/frontend/templates/macros.html
@@ -107,6 +107,16 @@
   </div>
 {%- endmacro %}
 
+{% macro show_external_reviews(reviews) %}
+  {% if reviews %}
+    {% for review in reviews %}
+      <li class="clearfix">
+        <a href="{{ review.url.url }}">{{ review.url.url }}</a>
+      </li>
+    {% endfor %}
+  {% endif %}
+{% endmacro %}
+
 {% macro show_tags(tags) %}
   {% if tags %}
     {% for tag in tags %}

--- a/critiquebrainz/frontend/templates/release_group/entity.html
+++ b/critiquebrainz/frontend/templates/release_group/entity.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from 'macros.html' import cover_art, show_embedded_player, show_tags, show_avg_rating, entity_rate_form with context %}
+{% from 'macros.html' import cover_art, show_embedded_player, show_tags, show_avg_rating, entity_rate_form, show_external_reviews with context %}
 
 {% block title %}
   {{ _('Release group "%(title)s" by %(artist)s', title=release_group.title, artist=release_group['artist-credit-phrase']) }}
@@ -148,6 +148,12 @@
     <p>
       {% if release_group['first-release-date'] %}{{ _('First release in %(year)s', year=release_group['first-release-date'][:4]) }}{% endif %}
     </p>
+    {% if external_reviews %}
+      <b>{{ _('External reviews') }}</b>
+      <ul class="list-unstyled external-links">
+        {{ show_external_reviews(external_reviews) }}
+      </ul>
+    {% endif %}
     {% if release_group['external-urls'] %}
       <b>{{ _('External links') }}</b>
       <ul class="list-unstyled external-links">

--- a/critiquebrainz/frontend/views/event.py
+++ b/critiquebrainz/frontend/views/event.py
@@ -40,6 +40,11 @@ def entity(id):
     except mb_exceptions.NoDataFoundException:
         raise NotFound(gettext("Sorry, we couldn't find an event with that MusicBrainz ID."))
 
+    if 'url-rels' in event:
+        external_reviews = list(filter(lambda rel: rel['type'] == 'review', event['url-rels']))
+    else:
+        external_reviews = []
+
     if 'artist-rels' in event and event['artist-rels']:
         artists_sorted = sorted(event['artist-rels'], key=itemgetter('type'))
         event['artists_grouped'] = groupby(artists_sorted, itemgetter('type'))
@@ -69,5 +74,5 @@ def entity(id):
     avg_rating = get_avg_rating(event['id'], "event")
 
     return render_template('event/entity.html', id=event['id'], event=event, reviews=reviews,
-                           rating_form=rating_form, my_review=my_review, limit=limit, offset=offset,
-                           count=count, avg_rating=avg_rating, current_user=current_user)
+                           rating_form=rating_form, my_review=my_review, external_reviews=external_reviews,
+                           limit=limit, offset=offset, count=count, avg_rating=avg_rating, current_user=current_user)

--- a/critiquebrainz/frontend/views/release_group.py
+++ b/critiquebrainz/frontend/views/release_group.py
@@ -40,6 +40,10 @@ def entity(id):
     except mb_exceptions.NoDataFoundException:
         raise NotFound(gettext("Sorry, we couldn't find a release group with that MusicBrainz ID."))
 
+    if 'url-rels' in release_group:
+        external_reviews = list(filter(lambda rel: rel['type'] == 'review', release_group['url-rels']))
+    else:
+        external_reviews = []
     if 'tag-list' in release_group:
         tags = release_group['tag-list']
     else:
@@ -79,5 +83,5 @@ def entity(id):
 
     return render_template('release_group/entity.html', id=release_group['id'], release_group=release_group, reviews=reviews,
                            release=release, my_review=my_review, spotify_mappings=spotify_mappings, tags=tags,
-                           soundcloud_url=soundcloud_url, limit=limit, offset=offset, count=count, avg_rating=avg_rating,
-                           rating_form=rating_form, current_user=current_user)
+                           soundcloud_url=soundcloud_url, external_reviews=external_reviews, limit=limit, offset=offset,
+                           count=count, avg_rating=avg_rating, rating_form=rating_form, current_user=current_user)


### PR DESCRIPTION
Checks if event or release group have URL relationships of type "review," and displays the links to these reviews. Looking forward to feedback.

https://tickets.metabrainz.org/browse/CB-351