### PR TITLE
CB-360: Make labels on album image always appear above the cover art

### DIFF
--- a/critiquebrainz/frontend/static/styles/main.less
+++ b/critiquebrainz/frontend/static/styles/main.less
@@ -279,6 +279,7 @@ ul.sharing {
     }
 
     img {
+      z-index: 0;
       display: block;
       margin-left: auto;
       margin-right: auto;
@@ -294,10 +295,12 @@ ul.sharing {
       font-weight: bold;
       font-size: small;
       color: #fff;
+      z-index: 2;
     }
 
     .caption {
       .release-group-title {
+        z-index: 2;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
I just changed the z-index of the 2 badges that show above the cover art. I think this is how it was supposed to work, but previously it was just luck that the items showed above the cover art due to their implicit z-index based on the code layout