### PR TITLE
CB-366: Use a git revision of bootstrap-rating-input for jquery compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1236,9 +1236,8 @@
       "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "bootstrap-rating-input": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-rating-input/-/bootstrap-rating-input-0.4.0.tgz",
-      "integrity": "sha1-w59inwBH7TU8hyrlYaVmerX3unQ="
+      "version": "github:javiertoledo/bootstrap-rating-input#0a4ebb7df3c3c1f70165d8c3e138fb8598c49352",
+      "from": "github:javiertoledo/bootstrap-rating-input#0a4ebb7d"
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "bootstrap": "4.3.1",
-    "bootstrap-rating-input": "0.4.0",
+    "bootstrap-rating-input": "javiertoledo/bootstrap-rating-input#0a4ebb7d",
     "jquery": "3.5.1",
     "popper.js": "^1.14.1",
     "leaflet": "1.1.0",


### PR DESCRIPTION
CB-366
The most recently released version of this library doesn't support the most recent jquery, however the latest version on github does. Use this until a new release is made.