### PR TITLE
CB-374: Entity selection tabs don't change when clicked

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "pre-dev": "webpack --mode development"
   },
   "dependencies": {
-    "bootstrap": "4.3.1",
+    "bootstrap": "^3.4.1",
     "bootstrap-rating-input": "javiertoledo/bootstrap-rating-input#0a4ebb7d",
     "jquery": "3.5.1",
     "popper.js": "^1.14.1",


### PR DESCRIPTION
The current UI components need to rewritten to work correctly with Bootstrap 4. Hence, using Bootstrap 3 till then.