### PR TITLE
CB-380: "Write a review" error messages don't give any context

### DIFF
--- a/critiquebrainz/frontend/forms/review.py
+++ b/critiquebrainz/frontend/forms/review.py
@@ -41,7 +41,7 @@ class ReviewEditForm(FlaskForm):
             ('CC BY-SA 3.0', lazy_gettext('Allow commercial use of this review(<a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">CC BY-SA 3.0 license</a>)')),  # noqa: E501
             ('CC BY-NC-SA 3.0', lazy_gettext('Do not allow commercial use of this review, unless approved by MetaBrainz Foundation (<a href="https://creativecommons.org/licenses/by-nc-sa/3.0/" target="_blank">CC BY-NC-SA 3.0 license</a>)')),  # noqa: E501
         ],
-        validators=[validators.DataRequired(message=lazy_gettext("You need to choose a license!"))])
+        validators=[validators.InputRequired(message=lazy_gettext("You need to choose a license"))])
     remember_license = BooleanField(lazy_gettext("Remember this license choice for further preference"))
     language = SelectField(lazy_gettext("You need to accept the license agreement!"), choices=languages)
     rating = IntegerField(lazy_gettext("Rating"), widget=Input(input_type='number'), validators=[validators.Optional()])

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -231,7 +231,7 @@ def create(entity_type=None, entity_id=None):
     review = reviews[0] if count != 0 else None
 
     if review:
-        flash.error(gettext("You have already published a review for this entity!"))
+        flash.error(gettext("You have already published a review for this entity"))
         return redirect(url_for('review.entity', id=review["id"]))
 
     if current_user.is_review_limit_exceeded:


### PR DESCRIPTION
There are two things about the issue in question:-
1) Not a valid choice issue. This occurs because of the default value of the Flask Validator. However, the specific message that should be displayed for the validation failure has an extra Not a Valid Choice message. I checked the WTF forms docs and they [recommend ](https://wtforms.readthedocs.io/en/2.3.x/validators/#wtforms.validators.DataRequired) that `InputRequired` be used unless there is a specific reason to use `DataRequired`. Using, `InputRequired` also fixes the issue.
However, there are other places in the codebase where `DataRequired` is used. Do we want to change those to `InputRequired` as well ?

2) Changing the _exclamation_ to _period_ is simple. But a [livegrep](http://livegrep.metabrainz.org/search/livegrep?q=file%3A.py%20%22%5B%5Cw%5Cs%5D%2B!%22&fold_case=auto&regex=true&context=true&repo%5B%5D=metabrainz%2Fcritiquebrainz) shows _!_ are used at quite a few places. Do we want to change them as well, if yes which ones ?


JIRA: CB-380