### PR TITLE
CB-376: Breaking change in API (created => published_on)

### DIFF
--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -349,10 +349,14 @@ def review_list_handler():
         entity_type = Parser.string('uri', 'entity_type', valid_values=ENTITY_TYPES, optional=True)
 
     user_id = Parser.uuid('uri', 'user_id', optional=True)
-    # TODO: "rating" sort value is deprecated and needs to be removed.
-    sort = Parser.string('uri', 'sort', valid_values=['popularity', 'published_on', 'rating'], optional=True)
+    sort = Parser.string('uri', 'sort', valid_values=['popularity', 'published_on', 'rating', 'created'], optional=True)
+
+    # "rating" and "created" sort values are deprecated and but allowed here for backward compatibility
+    if sort == 'created':
+        sort = 'published_on'
     if sort == 'rating':
         sort = 'popularity'
+
     limit = Parser.int('uri', 'limit', min=1, max=50, optional=True) or 50
     offset = Parser.int('uri', 'offset', optional=True) or 0
     language = Parser.string('uri', 'language', min=2, max=3, optional=True)

--- a/critiquebrainz/ws/review/views_test.py
+++ b/critiquebrainz/ws/review/views_test.py
@@ -41,6 +41,23 @@ class ReviewViewsTestCase(WebServiceTestCase):
     def create_dummy_review(self):
         return db_review.create(**self.review)
 
+    def test_review_sort(self):
+        response = self.client.get('/review/', query_string={'sort': 'rating'})
+        self.assert200(response)
+
+        response = self.client.get('/review/', query_string={'sort': 'published_on'})
+        self.assert200(response)
+
+        response = self.client.get('/review/', query_string={'sort': 'popularity'})
+        self.assert200(response)
+
+        response = self.client.get('/review/', query_string={'sort': 'created'})
+        self.assert200(response)
+
+        response = self.client.get('/review/', query_string={'sort': 'hello'})
+        self.assert400(response)
+        self.assertEquals(response.json['description'], 'Parameter `sort`: is not valid')
+
     def test_review_count(self):
         resp = self.client.get('/review/').json
         self.assertEqual(resp['count'], 0)


### PR DESCRIPTION
Check for the created parameter and map it to to published_on for backward compatibility.

JIRA: CB-376