### PR TITLE
CB-382: You can sometimes create a review without a revision

### DIFF
--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -240,7 +240,7 @@ def update(review_id, *, drafted, text=None, rating=None, license_id=None, langu
         updated_info["review_id"] = review_id
         with db.engine.connect() as connection:
             connection.execute(query, updated_info)
-            db_revision.create(review_id, text, rating, sql_connection=connection)
+            db_revision.create(connection, review_id, text, rating)
     cache.invalidate_namespace(REVIEW_CACHE_NAMESPACE)
 
 
@@ -319,7 +319,7 @@ def create(*, entity_id, entity_type, user_id, is_draft, text=None, rating=None,
             "published_on": published_on,
         })
         review_id = result.fetchone()[0]
-        db_revision.create(review_id, text, rating, sql_connection=connection)
+        db_revision.create(connection, review_id, text, rating)
         cache.invalidate_namespace(REVIEW_CACHE_NAMESPACE)
     return get_by_id(review_id)
 

--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -240,8 +240,7 @@ def update(review_id, *, drafted, text=None, rating=None, license_id=None, langu
         updated_info["review_id"] = review_id
         with db.engine.connect() as connection:
             connection.execute(query, updated_info)
-
-    db_revision.create(review_id, text, rating)
+            db_revision.create(review_id, text, rating, sql_connection=connection)
     cache.invalidate_namespace(REVIEW_CACHE_NAMESPACE)
 
 
@@ -320,8 +319,7 @@ def create(*, entity_id, entity_type, user_id, is_draft, text=None, rating=None,
             "published_on": published_on,
         })
         review_id = result.fetchone()[0]
-        # TODO(roman): It would be better to create review and revision in one transaction
-        db_revision.create(review_id, text, rating)
+        db_revision.create(review_id, text, rating, sql_connection=connection)
         cache.invalidate_namespace(REVIEW_CACHE_NAMESPACE)
     return get_by_id(review_id)
 

--- a/critiquebrainz/db/revision.py
+++ b/critiquebrainz/db/revision.py
@@ -157,13 +157,14 @@ def get_revision_number(review_id, revision_id):
     return rev_num
 
 
-def create(review_id, text=None, rating=None):
+def create(review_id, text=None, rating=None, sql_connection=None):
     """Creates a new revision for the given review.
 
     Args:
         review_id (uuid): ID of the review.
         text (str): Updated/New text part of the review.
         rating (int): Updated/New rating part of the review
+        sql_connection: connection to database to update/create the review
     """
     if text is None and rating is None:
         raise db_exceptions.BadDataException("Text part and rating part of a revision can not be None simultaneously")
@@ -172,16 +173,21 @@ def create(review_id, text=None, rating=None):
     # Convert ratings to values on a scale 0-100
     rating = RATING_SCALE_0_100.get(rating)
 
-    with db.engine.connect() as connection:
-        connection.execute(sqlalchemy.text("""
-            INSERT INTO revision(review_id, timestamp, text, rating)
-                 VALUES (:review_id, :timestamp, :text, :rating)
-        """), {
-            "review_id": review_id,
-            "timestamp": datetime.now(),
-            "text": text,
-            "rating": rating,
-        })
+    sql_query = sqlalchemy.text(
+        """INSERT INTO revision(review_id, timestamp, text, rating) 
+        VALUES (:review_id, :timestamp, :text, :rating)""")
+    value_dict = {
+        "review_id": review_id,
+        "timestamp": datetime.now(),
+        "text": text,
+        "rating": rating,
+    }
+
+    if sql_connection:
+        sql_connection.execute(sql_query, value_dict)
+    else:
+        with db.engine.connect() as connection:
+            connection.execute(sql_query, value_dict)
 
     # Update average rating if rating part of the review has changed
     review = db_review.get_by_id(review_id)

--- a/critiquebrainz/db/revision.py
+++ b/critiquebrainz/db/revision.py
@@ -157,14 +157,14 @@ def get_revision_number(review_id, revision_id):
     return rev_num
 
 
-def create(review_id, text=None, rating=None, sql_connection=None):
+def create(sql_connection, review_id, text=None, rating=None):
     """Creates a new revision for the given review.
 
     Args:
+        sql_connection: connection to database to update/create the review
         review_id (uuid): ID of the review.
         text (str): Updated/New text part of the review.
         rating (int): Updated/New rating part of the review
-        sql_connection: connection to database to update/create the review
     """
     if text is None and rating is None:
         raise db_exceptions.BadDataException("Text part and rating part of a revision can not be None simultaneously")
@@ -183,11 +183,7 @@ def create(review_id, text=None, rating=None, sql_connection=None):
         "rating": rating,
     }
 
-    if sql_connection:
-        sql_connection.execute(sql_query, value_dict)
-    else:
-        with db.engine.connect() as connection:
-            connection.execute(sql_query, value_dict)
+    sql_connection.execute(sql_query, value_dict)
 
     # Update average rating if rating part of the review has changed
     review = db_review.get_by_id(review_id)


### PR DESCRIPTION
It might be possible that there may be other uses or potential use case
for creating a revision in a separate transaction. Hence, added the
connection as an optional parameter. To enforce the creation in the
same transaction we can make the parameter mandatory.

JIRA: CB-382