### PR TITLE
Miscellaneous Bug Fixes 

### DIFF
--- a/critiquebrainz/frontend/__init__.py
+++ b/critiquebrainz/frontend/__init__.py
@@ -3,6 +3,7 @@ import os
 import sys
 from time import sleep
 
+import pycountry
 from brainzutils.flask import CustomFlask
 from flask import send_from_directory
 
@@ -119,14 +120,14 @@ def create_app(debug=None, config_path=None):
     app.jinja_env.add_extension('jinja2.ext.do')
     from critiquebrainz.utils import reformat_date, reformat_datetime, track_length, track_length_ms, parameterize
     from critiquebrainz.frontend.external.musicbrainz_db.entities import get_entity_by_id
+    from critiquebrainz.frontend.forms.utils import get_language_name
     app.jinja_env.filters['date'] = reformat_date
     app.jinja_env.filters['datetime'] = reformat_datetime
     app.jinja_env.filters['track_length'] = track_length
     app.jinja_env.filters['track_length_ms'] = track_length_ms
     app.jinja_env.filters['parameterize'] = parameterize
     app.jinja_env.filters['entity_details'] = get_entity_by_id
-    from flask_babel import Locale, get_locale
-    app.jinja_env.filters['language_name'] = lambda language_code: Locale(language_code).get_language_name(get_locale())
+    app.jinja_env.filters['language_name'] = get_language_name
     app.context_processor(lambda: dict(get_static_path=static_manager.get_static_path))
 
     # Blueprints

--- a/critiquebrainz/frontend/forms/review.py
+++ b/critiquebrainz/frontend/forms/review.py
@@ -3,9 +3,8 @@ from flask_babel import lazy_gettext, Locale
 from wtforms import TextAreaField, RadioField, SelectField, BooleanField, StringField, validators, IntegerField
 from wtforms.validators import ValidationError
 from wtforms.widgets import HiddenInput, Input
-from babel.core import UnknownLocaleError
-import pycountry
 from critiquebrainz.db.review import supported_languages
+from critiquebrainz.frontend.forms.utils import get_language_name
 
 MIN_REVIEW_LENGTH = 25
 MAX_REVIEW_LENGTH = 100000
@@ -23,10 +22,7 @@ class StateAndLength(validators.Length):
 # Loading supported languages
 languages = []
 for language_code in supported_languages:
-    try:
-        languages.append((language_code, Locale(language_code).language_name))
-    except UnknownLocaleError:
-        languages.append((language_code, pycountry.languages.get(iso639_1_code=language_code).name))
+    languages.append((language_code, get_language_name(language_code)))
 
 
 class ReviewEditForm(FlaskForm):

--- a/critiquebrainz/frontend/forms/utils.py
+++ b/critiquebrainz/frontend/forms/utils.py
@@ -1,0 +1,9 @@
+import pycountry
+from babel.core import UnknownLocaleError, Locale
+
+
+def get_language_name(language_code):
+    try:
+        return Locale(language_code).language_name
+    except UnknownLocaleError:
+        return pycountry.languages.get(iso639_1_code=language_code).name

--- a/critiquebrainz/frontend/templates/search/selector_results.html
+++ b/critiquebrainz/frontend/templates/search/selector_results.html
@@ -67,7 +67,7 @@
 {% elif type=="work" %}
   <tr>
     <td>
-      {# <a href="{{ url_for('work.entity', id=result.id) }}" target="_blank">{{ result['name'] }}</a> #}
+       <a href="{{ url_for('work.entity', id=result.id) }}" target="_blank">{{ result['title'] }}</a>
     </td>
     <td>
       {% if result['artist-relation-list'] %}


### PR DESCRIPTION
1) Bugfix for showing work title in search results
2) Due to some reason, the language selector for writing a review was using pycountry as a fallback if babel could not resolve the Locale. However, while displaying the language name on the view review page only babel was being used. pycountry is not added as a fallback in this case as well. This fixes CB-393.