### PR TITLE
CB-330 Removed duplicate flash messages

### DIFF
--- a/critiquebrainz/frontend/templates/log/action.html
+++ b/critiquebrainz/frontend/templates/log/action.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% if review is defined %}
-  {% set release_group = review.entity_id | entity_details %}
+  {% set release_group = review.entity_id | entity_details(entity_type=review.entity_type) %}
   {% set rg_title = release_group.title | default(_('[Unknown release group]')) %}
   {% set cancel_url = url_for('review.entity', id=review.id) %}
 {% elif user is defined %}

--- a/critiquebrainz/frontend/templates/reports/reports_results.html
+++ b/critiquebrainz/frontend/templates/reports/reports_results.html
@@ -1,5 +1,5 @@
 {% for report in results %}
-  {% set release_group = report.review.entity_id | entity_details %}
+  {% set release_group = report.review.entity_id | entity_details(entity_type=review.entity_type) %}
   <tr>
     <td>{{ report.reported_at | date }}</td>
     <td><a href="{{ url_for('user.info', user_id=report.user.id) }}">{{ report.user.display_name }}</a></td>

--- a/critiquebrainz/frontend/templates/review/report.html
+++ b/critiquebrainz/frontend/templates/review/report.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% set release_group = review.entity_id | entity_details %}
+{% set release_group = review.entity_id | entity_details(entity_type=review.entity_type) %}
 {% set rg_title = release_group.title | default(_('[Unknown release group]')) %}
 
 {% block title %}{{ _('Report %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) }} - CritiqueBrainz{% endblock %}

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -100,7 +100,6 @@ def entity(id, rev=None):
         if not current_user.is_admin():
             raise Forbidden(gettext("Review has been hidden. "
                                     "You need to be an administrator to view it."))
-        flash.warn(gettext("Review has been hidden."))
 
     spotify_mappings = None
     soundcloud_url = None

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -100,6 +100,7 @@ def entity(id, rev=None):
         if not current_user.is_admin():
             raise Forbidden(gettext("Review has been hidden. "
                                     "You need to be an administrator to view it."))
+        flash.warn(gettext("Review has been hidden."))
 
     spotify_mappings = None
     soundcloud_url = None

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -520,7 +520,6 @@ def hide(id):
         review_reports, count = db_spam_report.list_reports(review_id=review["id"])  # pylint: disable=unused-variable
         for report in review_reports:
             db_spam_report.archive(report["user_id"], report["revision_id"])
-        flash.success(gettext("Review has been hidden."))
         return redirect(url_for('.entity', id=review["id"]))
 
     return render_template('log/action.html', review=review, form=form, action=AdminActions.ACTION_HIDE_REVIEW.value)

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -96,11 +96,18 @@ def entity(id, rev=None):
     if review["is_draft"] and not (current_user.is_authenticated and
                                    current_user == review["user"]):
         raise NotFound(gettext("Can't find a review with the specified ID."))
+
     if review["is_hidden"]:
-        if not current_user.is_admin():
+        # show review to admin users with a warning that it is hidden
+        if current_user.is_admin():
+            flash.warn(gettext("Review has been hidden."))
+        elif current_user.is_authenticated and current_user == review["user"]:
+            # show to the author of the review that it was hidden but not the actual review
             raise Forbidden(gettext("Review has been hidden. "
                                     "You need to be an administrator to view it."))
-        flash.warn(gettext("Review has been hidden."))
+        else:
+            # for all other users, return a 404 as if the review didn't exist
+            raise NotFound(gettext("Can't find a review with ID: %(review_id)s!", review_id=id))
 
     spotify_mappings = None
     soundcloud_url = None

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -296,7 +296,7 @@ class ReviewViewsTestCase(FrontendTestCase):
         # check that error is shown to the user if they try to view their hidden reviews
         response = self.client.get("/review/{}".format(review["id"]))
         self.assert403(response)
-        self.assertIn("Review has been hidden.", response)
+        self.assertIn("Review has been hidden.", str(response.data))
 
         self.temporary_login(self.hacker)
         is_user_admin.return_value = True


### PR DESCRIPTION
[CB-330] 'Review has been hidden' message is shown twice when moderator hides a review.