### PR TITLE
CB-401: entity pages for a non-existent MBID return HTTP 200 and show a detail page.

### DIFF
--- a/critiquebrainz/frontend/external/musicbrainz_db/artist.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/artist.py
@@ -19,7 +19,7 @@ def get_artist_by_id(mbid):
         artist = db.fetch_multiple_artists(
             [mbid],
             includes=['artist-rels', 'url-rels'],
-            unknown_entities_for_missing=True,
+            unknown_entities_for_missing=False,
         ).get(mbid)
         cache.set(key=key, val=artist, time=DEFAULT_CACHE_EXPIRATION)
     return artist_rel.process(artist)

--- a/critiquebrainz/frontend/views/artist.py
+++ b/critiquebrainz/frontend/views/artist.py
@@ -6,9 +6,9 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 import critiquebrainz.db.review as db_review
 import critiquebrainz.frontend.external.musicbrainz_db.artist as mb_artist
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 import critiquebrainz.frontend.external.musicbrainz_db.release_group as mb_release_group
 from critiquebrainz.frontend.views import BROWSE_RELEASE_GROUPS_LIMIT, ARTIST_REVIEWS_LIMIT
+from brainzutils.musicbrainz_db.exceptions import NoDataFoundException
 
 artist_bp = Blueprint('artist', __name__)
 
@@ -22,7 +22,7 @@ def entity(mbid):
     """
     try:
         artist = mb_artist.get_artist_by_id(str(mbid))
-    except mb_exceptions.NoDataFoundException:
+    except NoDataFoundException:
         raise NotFound(gettext("Sorry, we couldn't find an artist with that MusicBrainz ID."))
 
     # Note that some artists might not have a list of members because they are not a band

--- a/critiquebrainz/frontend/views/event.py
+++ b/critiquebrainz/frontend/views/event.py
@@ -26,9 +26,9 @@ from werkzeug.exceptions import NotFound
 
 import critiquebrainz.db.review as db_review
 import critiquebrainz.frontend.external.musicbrainz_db.event as mb_event
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 from critiquebrainz.frontend.forms.rate import RatingEditForm
 from critiquebrainz.frontend.views import get_avg_rating
+from brainzutils.musicbrainz_db.exceptions import NoDataFoundException
 
 event_bp = Blueprint('event', __name__)
 
@@ -38,7 +38,7 @@ def entity(id):
     id = str(id)
     try:
         event = mb_event.get_event_by_id(id)
-    except mb_exceptions.NoDataFoundException:
+    except NoDataFoundException:
         raise NotFound(gettext("Sorry, we couldn't find an event with that MusicBrainz ID."))
 
     if 'url-rels' in event:

--- a/critiquebrainz/frontend/views/label.py
+++ b/critiquebrainz/frontend/views/label.py
@@ -4,10 +4,10 @@ from flask_login import current_user
 from werkzeug.exceptions import NotFound
 
 import critiquebrainz.db.review as db_review
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 import critiquebrainz.frontend.external.musicbrainz_db.label as mb_label
 from critiquebrainz.frontend.forms.rate import RatingEditForm
 from critiquebrainz.frontend.views import get_avg_rating, LABEL_REVIEWS_LIMIT
+from brainzutils.musicbrainz_db.exceptions import NoDataFoundException
 
 label_bp = Blueprint('label', __name__)
 
@@ -17,7 +17,7 @@ def entity(id):
     id = str(id)
     try:
         label = mb_label.get_label_by_id(id)
-    except mb_exceptions.NoDataFoundException:
+    except NoDataFoundException:
         raise NotFound(gettext("Sorry, we couldn't find a label with that MusicBrainz ID."))
 
     label_reviews_limit = LABEL_REVIEWS_LIMIT

--- a/critiquebrainz/frontend/views/mapping.py
+++ b/critiquebrainz/frontend/views/mapping.py
@@ -15,12 +15,12 @@ from flask_babel import gettext
 from flask_login import login_required, current_user
 from werkzeug.exceptions import NotFound, BadRequest, ServiceUnavailable
 
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 import critiquebrainz.frontend.external.musicbrainz_db.release_group as mb_release_group
 import critiquebrainz.frontend.external.spotify as spotify_api
 from critiquebrainz.frontend import flash
 from critiquebrainz.frontend.external import mbspotify
 from critiquebrainz.frontend.external.exceptions import ExternalServiceException
+from brainzutils.musicbrainz_db.exceptions import NoDataFoundException
 
 mapping_bp = Blueprint('mapping', __name__)
 
@@ -43,7 +43,7 @@ def spotify_list(release_group_id):
         spotify_albums = {}
     try:
         release_group = mb_release_group.get_release_group_by_id(str(release_group_id))
-    except mb_exceptions.NoDataFoundException:
+    except NoDataFoundException:
         raise NotFound("Can't find release group with a specified ID.")
     return render_template('mapping/list.html', spotify_albums=spotify_albums,
                            release_group=release_group)
@@ -56,7 +56,7 @@ def spotify_add():
         return redirect(url_for('frontend.index'))
     try:
         release_group = mb_release_group.get_release_group_by_id(release_group_id)
-    except mb_exceptions.NoDataFoundException:
+    except NoDataFoundException:
         flash.error(gettext("Only existing release groups can be mapped to Spotify!"))
         return redirect(url_for('search.index'))
 
@@ -99,7 +99,7 @@ def spotify_confirm():
         raise BadRequest("Didn't provide `release_group_id`!")
     try:
         release_group = mb_release_group.get_release_group_by_id(release_group_id)
-    except mb_exceptions.NoDataFoundException:
+    except NoDataFoundException:
         flash.error(gettext("Only existing release groups can be mapped to Spotify!"))
         return redirect(url_for('search.index'))
 
@@ -155,7 +155,7 @@ def spotify_report():
     # Checking if release group exists
     try:
         release_group = mb_release_group.get_release_group_by_id(release_group_id)
-    except mb_exceptions.NoDataFoundException:
+    except NoDataFoundException:
         raise NotFound("Can't find release group with a specified ID.")
 
     # Checking if release group is mapped to Spotify

--- a/critiquebrainz/frontend/views/place.py
+++ b/critiquebrainz/frontend/views/place.py
@@ -22,10 +22,10 @@ from flask_login import current_user
 from werkzeug.exceptions import NotFound
 
 import critiquebrainz.db.review as db_review
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 import critiquebrainz.frontend.external.musicbrainz_db.place as mb_place
 from critiquebrainz.frontend.forms.rate import RatingEditForm
 from critiquebrainz.frontend.views import get_avg_rating
+from brainzutils.musicbrainz_db.exceptions import NoDataFoundException
 
 place_bp = Blueprint('place', __name__)
 
@@ -35,7 +35,7 @@ def entity(id):
     id = str(id)
     try:
         place = mb_place.get_place_by_id(id)
-    except mb_exceptions.NoDataFoundException:
+    except NoDataFoundException:
         raise NotFound(gettext("Sorry, we couldn't find a place with that MusicBrainz ID."))
 
     if current_user.is_authenticated:

--- a/critiquebrainz/frontend/views/release_group.py
+++ b/critiquebrainz/frontend/views/release_group.py
@@ -22,7 +22,7 @@ from flask_login import current_user
 from werkzeug.exceptions import NotFound
 
 import critiquebrainz.db.review as db_review
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
+from brainzutils.musicbrainz_db.exceptions import NoDataFoundException
 import critiquebrainz.frontend.external.musicbrainz_db.release as mb_release
 import critiquebrainz.frontend.external.musicbrainz_db.release_group as mb_release_group
 from critiquebrainz.frontend.external import mbspotify, soundcloud
@@ -37,7 +37,7 @@ def entity(id):
     id = str(id)
     try:
         release_group = mb_release_group.get_release_group_by_id(id)
-    except mb_exceptions.NoDataFoundException:
+    except NoDataFoundException:
         raise NotFound(gettext("Sorry, we couldn't find a release group with that MusicBrainz ID."))
 
     if 'url-rels' in release_group:

--- a/critiquebrainz/frontend/views/work.py
+++ b/critiquebrainz/frontend/views/work.py
@@ -4,10 +4,10 @@ from flask_login import current_user
 from werkzeug.exceptions import NotFound
 
 import critiquebrainz.db.review as db_review
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 import critiquebrainz.frontend.external.musicbrainz_db.work as mb_work
 from critiquebrainz.frontend.forms.rate import RatingEditForm
 from critiquebrainz.frontend.views import get_avg_rating, WORK_REVIEWS_LIMIT, BROWSE_RECORDING_LIMIT
+from brainzutils.musicbrainz_db.exceptions import NoDataFoundException
 
 work_bp = Blueprint('work', __name__)
 
@@ -17,7 +17,7 @@ def entity(id):
     id = str(id)
     try:
         work = mb_work.get_work_by_id(id)
-    except mb_exceptions.NoDataFoundException:
+    except NoDataFoundException:
         raise NotFound(gettext("Sorry, we couldn't find a work with that MusicBrainz ID."))
 
     work_reviews_limit = WORK_REVIEWS_LIMIT


### PR DESCRIPTION
Fix bug for wrong import of 'NoDataException'.

Changed the value of "unknown-entities_for_missing" from True to False in the "get_artist_by_id" function which passed the appropiate exception when the artist was not found.
The exceptions of this function were caught using "critiquebrainz.frontend.external.musicbrainz_db.exceptions" but it gave the "Internal server error" . We had to use the exceptions from " brainzutils.musicbrainz_db.exceptions" in order to get the "page not found error ".