### PR TITLE
Fix ignoring some files when building Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,33 +1,33 @@
-.git
+/.git
 
 # Docker configuration
 
 # Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
+**/__pycache__/
+**/*.py[cod]
 
 # Virtual environment
-env
-venv
+/env
+/venv
 /build
 
 # Node
-node_modules
+/node_modules
 
 # Logs
-*.log
-pip-log.txt
-pip-delete-this-directory.txt
+**/*.log
+**/pip-log.txt
+**/pip-delete-this-directory.txt
 
 # Application data
-data
+/data
 
 # Configuration
-consul_config.py
-custom_config.py
+/consul_config.py
+/custom_config.py
 
 # Test results
-htmlcov
-.coverage
+**/htmlcov
+**/.coverage
 
-.transifexrc
+**/.transifexrc

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,12 +7,12 @@
 **/*.py[cod]
 
 # Virtual environment
-/env
-/venv
-/build
+/env/
+/venv/
+/build/
 
 # Node
-/node_modules
+/node_modules/
 
 # Logs
 **/*.log
@@ -20,14 +20,14 @@
 **/pip-delete-this-directory.txt
 
 # Application data
-/data
+/data/
 
 # Configuration
 /consul_config.py
 /custom_config.py
 
 # Test results
-**/htmlcov
+**/htmlcov/
 **/.coverage
 
 **/.transifexrc

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-/.git
+/.git*
 
 # Docker configuration
 
@@ -7,9 +7,9 @@
 **/*.py[cod]
 
 # Virtual environment
-/env/
-/venv/
-/build/
+/env*/
+/venv*/
+/build*/
 
 # Node
 /node_modules/


### PR DESCRIPTION
# Problem

Patterns in the `.dockerignore` file are incorrectly following `.gitignore` format.
The main difference is that root directory `/` is implicit in `.dockerignore` format.
See https://docs.docker.com/engine/reference/builder/#dockerignore-file for reference.

This leads to not ignoring a bunch of files when building Docker images.
It can make Docker images to be larger than necessary or to contain unintended data.

# Solution

* Do not rely on defaults which are different from `.gitignore` syntax by explicitly prepending with `/` to match from the root directory only (default) or with `**/` to match from any subdirectory (and from the root directory too).
* Append an ending `/` to specify when ignoring directories
* Extend some patterns to match more actual and potential files: `.gitattributes`, `venv-py39`…

That pull request follows commit https://github.com/metabrainz/sir/commit/c03d56865917d9fddec54dd7a432268c04afa5ff whihc addresses the same issue in SIR, and pull request https://github.com/metabrainz/listenbrainz-server/pull/1224.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

* Rebuild, check it still works for all build targets, and compare images size.
* Possibly add more patterns to ignore more files. (I just fixed and extended existing patterns, I did not add any new pattern.)