### PR TITLE
Disable release-group caching

### DIFF
--- a/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
@@ -7,15 +7,11 @@ from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRA
 
 def get_release_group_by_id(mbid):
     """Get release group using the MusicBrainz ID."""
-    key = cache.gen_key('release-group', mbid)
-    release_group = cache.get(key)
-    if not release_group:
-        release_group = db.fetch_multiple_release_groups(
-            [mbid],
-            includes=['artists', 'releases', 'release-group-rels', 'url-rels', 'tags'],
-            unknown_entities_for_missing=True,
-        )[mbid]
-        cache.set(key=key, val=release_group, time=DEFAULT_CACHE_EXPIRATION)
+    release_group = db.fetch_multiple_release_groups(
+        [mbid],
+        includes=['artists', 'releases', 'release-group-rels', 'url-rels', 'tags'],
+        unknown_entities_for_missing=True,
+    )[mbid]
     return release_group_rel.process(release_group)
 
 


### PR DESCRIPTION
Release group caching is creating load problems. Disable it for now to diagnose issues.