### PR TITLE
Disable uwsgi request logging

### DIFF
--- a/docker/beta/uwsgi/uwsgi.ini
+++ b/docker/beta/uwsgi/uwsgi.ini
@@ -6,3 +6,4 @@ callable = application
 chdir = /code/
 enable-threads = true
 processes = 20
+disable-logging = true

--- a/docker/prod/uwsgi/uwsgi.ini
+++ b/docker/prod/uwsgi/uwsgi.ini
@@ -6,3 +6,4 @@ callable = application
 chdir = /code/
 enable-threads = true
 processes = 20
+disable-logging = true


### PR DESCRIPTION
This does nothing except fill up tens to hundreds of gigabytes of logs,
and isn't needed.

# Problem

UWSGI logs each request, in the form 
> [pid: 343|app: 0|req: 678/3082] 93.213.240.171 () {38 vars in 637 bytes} [Mon Feb  1 15:42:51 2021] GET /a5a41a8a-9eb8-4d89-b831-c3b3636ee55c/low-level => generated 52243 bytes in 14 msecs (HTTP/1.1 200) 10 headers in 411 bytes (1 switches on core 0)

This fills up docker logs (tens to hundreds of GB), and we don't use any of it

# Solution

Disable uwsgi request logging (yes, the config option is 'disable-logging', but this is only request logging, not generic logging)
