### PR TITLE
Pin package versions and upgrade brainzutils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,15 @@ rauth==0.7.3
 transifex-client==0.12.4
 WTForms==2.2.1
 langdetect==1.0.7
+Flask==1.1.2
+Jinja2==2.11.2
+werkzeug==1.0.1
+Flask-DebugToolbar==0.11.0
+Flask-UUID==0.2
+raven[flask]==6.10.0
+redis==3.5.3
+msgpack-python==0.5.6
+requests==2.23.0
+SQLAlchemy==1.3.16
+mbdata==25.0.4
+sqlalchemy-dst==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ git+https://github.com/metabrainz/brainzutils-python.git@v1.14.0
 beautifulsoup4==4.8.0
 coverage==4.4.1
 click==6.7
-Flask-Babel==0.11.2
+Flask-Babel==2.0.0
 Flask-Login==0.4.0
 Flask-SQLAlchemy==2.4.0
 Flask-Testing==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask-Babel==2.0.0
 Flask-Login==0.4.0
 Flask-SQLAlchemy==2.4.0
 Flask-Testing==0.6.2
-Flask-WTF==0.14.2
+Flask-WTF==0.14.3
 Markdown==3.1.1
 musicbrainzngs==0.6
 pytest==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/metabrainz/brainzutils-python.git@v1.14.0
+git+https://github.com/metabrainz/brainzutils-python.git@v1.16.0
 beautifulsoup4==4.8.0
 coverage==4.4.1
 click==6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ click==6.7
 Flask-Babel==2.0.0
 Flask-Login==0.4.0
 Flask-SQLAlchemy==2.4.0
-Flask-Testing==0.6.2
+Flask-Testing==0.8.0
 Flask-WTF==0.14.3
 Markdown==3.1.1
 musicbrainzngs==0.6


### PR DESCRIPTION
Once metabrainz/brainzutils-python#45 is merged, BU will use open ended versions. To make sure we use desired versions, pin the versions in downstream projects.

The BU PR must be merged before this PR and the requirements.txt must be updated to use the new release of BU.