### PR TITLE
CB-409: Add name/link for artist reviews in user page

### DIFF
--- a/critiquebrainz/frontend/templates/user/reviews.html
+++ b/critiquebrainz/frontend/templates/user/reviews.html
@@ -60,6 +60,9 @@
                   {% endif %}
                   )
                 {% endif %}
+
+              {%- elif review.entity_type == 'artist' -%}
+                <strong>{{ entity.name | default(_('[Unknown artist]')) }}</strong>
               {%- endif -%}
 
             </a>


### PR DESCRIPTION
### Fix CB-409

This was seemingly just forgotten when artist reviews were added.