### PR TITLE
Add job to build production image if tests pass

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: CritiqueBrainz Tests
+name: CritiqueBrainz CI
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 jobs:
 
   test:
-
+    name: Run test suite
     runs-on: ubuntu-latest
 
     steps:
@@ -27,6 +27,10 @@ jobs:
 
     - uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
+      with:
+        key: critiquebrainz-prod-image-{hash}
+        restore-keys: |
+          critiquebrainz-prod-image-
 
     - name: Run tests
       run: ./test.sh
@@ -36,3 +40,21 @@ jobs:
       if: ${{ always() }}
       with:
         files: reports/tests.xml
+
+  prod:
+      name: Build Production Image
+      runs-on: ubuntu-latest
+      needs: test
+
+      steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+        continue-on-error: true
+
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+
+      - name: Build production image
+        run: docker build --build-arg GIT_COMMIT_SHA=HEAD .


### PR DESCRIPTION
The CritiqueBrainz Deploy Image action was repeatedly failing to build the production image. Adding a job to run build the production image if tests pass. We have found a similar action to be very useful in LB.