### PR TITLE
Fix error in int argument parsing

### DIFF
--- a/critiquebrainz/ws/parser.py
+++ b/critiquebrainz/ws/parser.py
@@ -53,10 +53,12 @@ class Parser:
         _i = cls.get_key(src, key, optional)
         if _i is None:
             return None
-        if _i.isdigit() is False:
+
+        try:
+            _i = int(_i)
+        except ValueError:
             raise ParserError(key, 'NaN')
 
-        _i = int(_i)
         if max is not None and _i > max:
             raise ParserError(key, 'too large (max=%d)' % max)
         if min is not None and _i < min:


### PR DESCRIPTION
If the input was already an int, it would not have isdigit method and thus raise an error. Hence, doing the check in another way.