### PR TITLE
Gracefully handle errors due to invalid oauth codes

### DIFF
--- a/critiquebrainz/frontend/views/login.py
+++ b/critiquebrainz/frontend/views/login.py
@@ -26,10 +26,14 @@ def musicbrainz():
 def musicbrainz_post():
     """Callback endpoint."""
     if mb_auth.validate_post_login():
-        login_user(mb_auth.get_user())
-        next = session.get('next')
-        if next:
-            return redirect(next)
+        user = mb_auth.get_user()
+        if user:
+            login_user(user)
+            next = session.get('next')
+            if next:
+                return redirect(next)
+        else:
+            flash.error(gettext("Login failed."))
     else:
         flash.error(gettext("Login failed."))
     return redirect(url_for('frontend.index'))


### PR DESCRIPTION
Identified in https://sentry.metabrainz.org/metabrainz/listenbrainz/issues/145812/?environment=production&referrer=alert_email

Although it doesn't happen in a normal successful oauth flow, there are some cases where a manually constructed URL with an invalid code parameter could cause an uncaught exception.

Handle the situation where:

* the auth code isn't valid on the musicbrainz end, therefore returning an error message
* the response from musicbrainz isn't valid json
