### PR TITLE
Remove unused code for Google Analytics and Google+

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -57,5 +57,3 @@ SPOTIFY_CLIENT_SECRET = '''{{template "KEY" "spotify/client_secret"}}'''
 ADMINS = [
     {{template "KEY_ARRAY" "admins"}}
 ]
-
-GOOGLE_ANALYTICS_TRACKING_ID = '''{{template "KEY" "ga_tracking_id"}}'''

--- a/critiquebrainz/frontend/templates/base.html
+++ b/critiquebrainz/frontend/templates/base.html
@@ -16,17 +16,6 @@
       {# This needs to be before body because it's used during cover art loading. #}
       <script src="{{ get_static_path('common.js') }}"></script>
     {% endblock %}
-
-    {% if config.GOOGLE_ANALYTICS_TRACKING_ID %}
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        ga('create', '{{ config.GOOGLE_ANALYTICS_TRACKING_ID }}', 'auto');
-        ga('send', 'pageview');
-      </script>
-    {% endif %}
   </head>
 
   <body>

--- a/critiquebrainz/frontend/templates/sharing.html
+++ b/critiquebrainz/frontend/templates/sharing.html
@@ -23,16 +23,4 @@
     <div class="fb-like" data-layout="button_count" data-action="like" data-show-faces="false" data-share="false"></div>
   </li>
 
-  <!-- Google+ -->
-  <li>
-    <div class="g-plusone" data-size="medium"></div>
-    <script type="text/javascript">
-      (function() {
-        var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
-        po.src = 'https://apis.google.com/js/platform.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
-      })();
-    </script>
-  </li>
-
 </ul>

--- a/custom_config.py.example
+++ b/custom_config.py.example
@@ -50,5 +50,3 @@ ADMINS = []
 #MAIL_FROM_ADDR = "no-reply@critiquebrainz.org"
 
 #DEBUG_TB_TEMPLATE_EDITOR_ENABLED = True
-
-#GOOGLE_ANALYTICS_TRACKING_ID = ""


### PR DESCRIPTION
- Google Analytics has been disabled for a long time (or was never enabled?) using configuration. Disabled here means that the code to render GA wasn't send to the browser. No reason to keep this unused code.

- Google+ was discontinued a few years so removing the sharing button for it. It does not render anything currently anyway.