### PR TITLE
Update docker-compose port configuration

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,5 +1,5 @@
 # Docker Compose file for development
-version: "2"
+version: "3.4"
 
 volumes:
   cb_home:
@@ -17,7 +17,7 @@ services:
       - ../data/pgdata:/var/lib/postgresql/data/pgdata:z
       - ./pg_custom:/docker-entrypoint-initdb.d/
     ports:
-      - "15432:5432"
+      - "127.0.0.1:15432:5432"
 
   critiquebrainz:
     build:
@@ -31,13 +31,13 @@ services:
       FLASK_APP: critiquebrainz.frontend
       FLASK_ENV: development
     ports:
-      - "80:80"
+      - "8200:8200"
     depends_on:
       - db
       - critiquebrainz_redis
       - musicbrainz_db
       - static_builder
-    command: python3 manage.py runserver -h 0.0.0.0 -p 80 -d
+    command: python3 manage.py runserver -h 0.0.0.0 -p 8200 -d
 
   critiquebrainz_redis:
     image: redis:4.0-alpine
@@ -51,7 +51,7 @@ services:
       MB_IMPORT_DUMPS: "true"
       POSTGRES_HOST_AUTH_METHOD: "trust"
     ports:
-      - "5430:5432"
+      - "127.0.0.1:25432:5432"
 
   static_builder:
     build:

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -30,15 +30,13 @@ These values can be obtained from MusicBrainz after you register a new instance 
 CritiqueBrainz at https://musicbrainz.org/account/applications/register (you'll need a
 MusicBrainz account). In the ``Callback URL`` field type::
 
-   http://<HOST>/login/musicbrainz/post
+   http://localhost:8200/login/musicbrainz/post
 
 .. note::
 
-   ``<HOST>`` field should be set to ``localhost`` if you plan to run a local instance of
-   CritiqueBrainz for development purposes.
-   For example:- If you are running your local instance of the server on Port Number
-   8000 then ``<HOST>`` should be set
-   to ``localhost:8000``.
+   By default, CritiqueBrainz will be available at http://localhost:8200. If you change the
+   port or host that it is running on, you should set the Callback URL to the host that you
+   configure.
 
 After application has been registered, set ``MUSICBRAINZ_CLIENT_ID`` and ``MUSICBRAINZ_CLIENT_SECRET``
 in your ``custom_config.py`` to the values that you see on the MusicBrainz website.


### PR DESCRIPTION
Bind postgres ports to 127.0.0.1 so that they're not exposed to the world if the host has a public IP address: https://github.com/metabrainz/guidelines/blob/f04bafbd3b081b24f6271b546ada47d84586e800/Docker.md#publishing-ports
Use port 8200, [close to ListenBrainz' 8100](https://github.com/metabrainz/listenbrainz-server/pull/1781), and not overlapping with 80, which may be used by different services on the same host