### PR TITLE
CB-401, CB-408: Return 404 for entities that don't exist in the MB database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM metabrainz/python:3.8-20210115
 
+ENV PYTHONUNBUFFERED 1
+
 # remove expired let's encrypt certificate and install new ones
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \

--- a/critiquebrainz/data/testing.py
+++ b/critiquebrainz/data/testing.py
@@ -9,9 +9,7 @@ from critiquebrainz.frontend import create_app
 class DataTestCase(TestCase):
 
     def create_app(self):
-        app = create_app()
-        app.config['WTF_CSRF_ENABLED'] = False
-        app.config['TESTING'] = True
+        app = create_app(config_path=os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'test_config.py'))
         return app
 
     def setUp(self):

--- a/critiquebrainz/db/revision.py
+++ b/critiquebrainz/db/revision.py
@@ -152,11 +152,11 @@ def get_revision_number(review_id, revision_id):
             "review_id": review_id,
             "revision_id": revision_id,
         })
-        rev_num = result.fetchone()[0]
+        rev_num = result.fetchone()
         if not rev_num:
             raise db_exceptions.NoDataFoundException("Can't find the revision with id={} for specified review.".
                                                      format(revision_id))
-    return rev_num
+    return rev_num[0]
 
 
 def create(connection, review_id, text=None, rating=None):

--- a/critiquebrainz/db/test/revision_test.py
+++ b/critiquebrainz/db/test/revision_test.py
@@ -5,6 +5,7 @@ import critiquebrainz.db.review as db_review
 import critiquebrainz.db.users as db_users
 from critiquebrainz.data.testing import DataTestCase
 from critiquebrainz.db import revision, vote
+from critiquebrainz.db import exceptions
 from critiquebrainz.db.user import User
 
 
@@ -104,3 +105,7 @@ class RevisionTestCase(DataTestCase):
         self.review = db_review.get_by_id(self.review["id"])
         rev_num = revision.get_revision_number(self.review["id"], self.review["last_revision"]["id"])
         self.assertEqual(rev_num, 2)
+
+        # A revision number that doesn't exist
+        with self.assertRaises(exceptions.NoDataFoundException):
+            revision.get_revision_number(self.review["id"], self.review["last_revision"]["id"] + 5)

--- a/critiquebrainz/frontend/external/musicbrainz_db/artist.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/artist.py
@@ -7,6 +7,10 @@ from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRA
 from critiquebrainz.frontend.external.relationships import artist as artist_rel
 
 
+def artist_is_unknown(artist):
+    return artist == serialize.serialize_artists(unknown_entities.unknown_artist)
+
+
 def get_artist_by_id(mbid):
     """Get artist with MusicBrainz ID.
 
@@ -23,7 +27,7 @@ def get_artist_by_id(mbid):
             includes=['artist-rels', 'url-rels'],
             unknown_entities_for_missing=True,
         )
-        if artist == serialize.serialize_artists(unknown_entities.unknown_artist):
+        if artist_is_unknown(artist):
             return None
         cache.set(key=key, val=artist, time=DEFAULT_CACHE_EXPIRATION)
     return artist_rel.process(artist)

--- a/critiquebrainz/frontend/external/musicbrainz_db/artist.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/artist.py
@@ -1,5 +1,7 @@
 from brainzutils import cache
 from brainzutils.musicbrainz_db import artist as db
+from brainzutils.musicbrainz_db import serialize
+from brainzutils.musicbrainz_db import unknown_entities
 
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 from critiquebrainz.frontend.external.relationships import artist as artist_rel
@@ -21,5 +23,7 @@ def get_artist_by_id(mbid):
             includes=['artist-rels', 'url-rels'],
             unknown_entities_for_missing=True,
         )
+        if artist == serialize.serialize_artists(unknown_entities.unknown_artist):
+            return None
         cache.set(key=key, val=artist, time=DEFAULT_CACHE_EXPIRATION)
     return artist_rel.process(artist)

--- a/critiquebrainz/frontend/external/musicbrainz_db/event.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/event.py
@@ -6,6 +6,10 @@ from brainzutils.musicbrainz_db import unknown_entities
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 
 
+def event_is_unknown(event):
+    return event == serialize.serialize_events(unknown_entities.unknown_event)
+
+
 def get_event_by_id(mbid):
     """Get event with the MusicBrainz ID.
 
@@ -22,7 +26,7 @@ def get_event_by_id(mbid):
             includes=['artist-rels', 'place-rels', 'series-rels', 'url-rels', 'release-group-rels'],
             unknown_entities_for_missing=True,
         )
-        if event == serialize.serialize_events(unknown_entities.unknown_event):
+        if event_is_unknown(event):
             return None
         cache.set(key=key, val=event, time=DEFAULT_CACHE_EXPIRATION)
     return event

--- a/critiquebrainz/frontend/external/musicbrainz_db/event.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/event.py
@@ -1,5 +1,7 @@
 from brainzutils import cache
 from brainzutils.musicbrainz_db import event as db
+from brainzutils.musicbrainz_db import serialize
+from brainzutils.musicbrainz_db import unknown_entities
 
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 
@@ -20,5 +22,7 @@ def get_event_by_id(mbid):
             includes=['artist-rels', 'place-rels', 'series-rels', 'url-rels', 'release-group-rels'],
             unknown_entities_for_missing=True,
         )
+        if event == serialize.serialize_events(unknown_entities.unknown_event):
+            return None
         cache.set(key=key, val=event, time=DEFAULT_CACHE_EXPIRATION)
     return event

--- a/critiquebrainz/frontend/external/musicbrainz_db/label.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/label.py
@@ -7,6 +7,10 @@ from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRA
 from critiquebrainz.frontend.external.relationships import label as label_rel
 
 
+def label_is_unknown(label):
+    return label['name'] == unknown_entities.unknown_label.name
+
+
 def get_label_by_id(mbid):
     """Get label with MusicBrainz ID.
 
@@ -23,7 +27,7 @@ def get_label_by_id(mbid):
             includes=['artist-rels', 'url-rels'],
             unknown_entities_for_missing=True
         )
-        if label['name'] == unknown_entities.unknown_label.name:
+        if label_is_unknown(label):
             return None
         cache.set(key=key, val=label, time=DEFAULT_CACHE_EXPIRATION)
     return label_rel.process(label)

--- a/critiquebrainz/frontend/external/musicbrainz_db/label.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/label.py
@@ -1,5 +1,7 @@
 from brainzutils import cache
 from brainzutils.musicbrainz_db import label as db
+from brainzutils.musicbrainz_db import serialize
+from brainzutils.musicbrainz_db import unknown_entities
 
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 from critiquebrainz.frontend.external.relationships import label as label_rel
@@ -21,5 +23,7 @@ def get_label_by_id(mbid):
             includes=['artist-rels', 'url-rels'],
             unknown_entities_for_missing=True
         )
+        if label['name'] == unknown_entities.unknown_label.name:
+            return None
         cache.set(key=key, val=label, time=DEFAULT_CACHE_EXPIRATION)
     return label_rel.process(label)

--- a/critiquebrainz/frontend/external/musicbrainz_db/place.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/place.py
@@ -7,6 +7,10 @@ from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRA
 from critiquebrainz.frontend.external.relationships import place as place_rel
 
 
+def place_is_unknown(place):
+    return place['name'] == unknown_entities.unknown_place.name
+
+
 def get_place_by_id(mbid):
     """Get place with the MusicBrainz ID.
 
@@ -23,7 +27,7 @@ def get_place_by_id(mbid):
             includes=['artist-rels', 'place-rels', 'release-group-rels', 'url-rels'],
             unknown_entities_for_missing=True,
         )
-        if place['name'] == unknown_entities.unknown_place.name:
+        if place_is_unknown(place):
             return None
         cache.set(key=key, val=place, time=DEFAULT_CACHE_EXPIRATION)
     return place_rel.process(place)

--- a/critiquebrainz/frontend/external/musicbrainz_db/place.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/place.py
@@ -1,5 +1,7 @@
 from brainzutils import cache
 from brainzutils.musicbrainz_db import place as db
+from brainzutils.musicbrainz_db import serialize
+from brainzutils.musicbrainz_db import unknown_entities
 
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 from critiquebrainz.frontend.external.relationships import place as place_rel
@@ -21,5 +23,7 @@ def get_place_by_id(mbid):
             includes=['artist-rels', 'place-rels', 'release-group-rels', 'url-rels'],
             unknown_entities_for_missing=True,
         )
+        if place['name'] == unknown_entities.unknown_place.name:
+            return None
         cache.set(key=key, val=place, time=DEFAULT_CACHE_EXPIRATION)
     return place_rel.process(place)

--- a/critiquebrainz/frontend/external/musicbrainz_db/recording.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/recording.py
@@ -1,5 +1,7 @@
 from brainzutils import cache
 from brainzutils.musicbrainz_db import recording as db
+from brainzutils.musicbrainz_db import serialize
+from brainzutils.musicbrainz_db import unknown_entities
 
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 
@@ -18,6 +20,9 @@ def get_recording_by_id(mbid):
         recording = db.get_recording_by_mbid(
             mbid,
             includes=['artists', 'work-rels', 'url-rels'],
+            unknown_entities_for_missing=True,
         )
+        if recording['name'] == unknown_entities.unknown_recording.name:
+            return None
         cache.set(key=key, val=recording, time=DEFAULT_CACHE_EXPIRATION)
     return recording

--- a/critiquebrainz/frontend/external/musicbrainz_db/recording.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/recording.py
@@ -6,6 +6,10 @@ from brainzutils.musicbrainz_db import unknown_entities
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 
 
+def recording_is_unknown(recording):
+    return recording['name'] == unknown_entities.unknown_recording.name
+
+
 def get_recording_by_id(mbid):
     """Get recording with MusicBrainz ID.
 
@@ -22,7 +26,7 @@ def get_recording_by_id(mbid):
             includes=['artists', 'work-rels', 'url-rels'],
             unknown_entities_for_missing=True,
         )
-        if recording['name'] == unknown_entities.unknown_recording.name:
+        if recording_is_unknown(recording):
             return None
         cache.set(key=key, val=recording, time=DEFAULT_CACHE_EXPIRATION)
     return recording

--- a/critiquebrainz/frontend/external/musicbrainz_db/release.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/release.py
@@ -6,6 +6,10 @@ from brainzutils.musicbrainz_db import unknown_entities
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 
 
+def release_is_unknown(release):
+    return release == serialize.serialize_releases(unknown_entities.unknown_release)
+
+
 def get_release_by_id(mbid):
     """Get release with MusicBrainz ID.
 
@@ -22,7 +26,7 @@ def get_release_by_id(mbid):
             includes=['media', 'release-groups'],
             unknown_entities_for_missing=True,
         )
-        if release == serialize.serialize_releases(unknown_entities.unknown_release):
+        if release_is_unknown(release):
             return None
         cache.set(key=key, val=release, time=DEFAULT_CACHE_EXPIRATION)
     return release

--- a/critiquebrainz/frontend/external/musicbrainz_db/release.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/release.py
@@ -1,5 +1,7 @@
 from brainzutils import cache
 from brainzutils.musicbrainz_db import release as db
+from brainzutils.musicbrainz_db import serialize
+from brainzutils.musicbrainz_db import unknown_entities
 
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 
@@ -20,5 +22,7 @@ def get_release_by_id(mbid):
             includes=['media', 'release-groups'],
             unknown_entities_for_missing=True,
         )
+        if release == serialize.serialize_releases(unknown_entities.unknown_release):
+            return None
         cache.set(key=key, val=release, time=DEFAULT_CACHE_EXPIRATION)
     return release

--- a/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
@@ -7,6 +7,10 @@ import critiquebrainz.frontend.external.relationships.release_group as release_g
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 
 
+def release_group_is_unknown(release_group):
+    return release_group['title'] == unknown_entities.unknown_release_group.name
+
+
 def get_release_group_by_id(mbid):
     """Get release group using the MusicBrainz ID."""
     key = cache.gen_key('release-group', mbid)
@@ -17,7 +21,7 @@ def get_release_group_by_id(mbid):
             includes=['artists', 'releases', 'release-group-rels', 'url-rels', 'tags'],
             unknown_entities_for_missing=True,
         )
-        if release_group['title'] == unknown_entities.unknown_release_group.name:
+        if release_group_is_unknown(release_group):
             return None
         cache.set(key=key, val=release_group, time=DEFAULT_CACHE_EXPIRATION)
     return release_group_rel.process(release_group)

--- a/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/release_group.py
@@ -1,5 +1,8 @@
 from brainzutils import cache
 from brainzutils.musicbrainz_db import release_group as db
+from brainzutils.musicbrainz_db import serialize
+from brainzutils.musicbrainz_db import unknown_entities
+
 import critiquebrainz.frontend.external.relationships.release_group as release_group_rel
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 
@@ -14,6 +17,8 @@ def get_release_group_by_id(mbid):
             includes=['artists', 'releases', 'release-group-rels', 'url-rels', 'tags'],
             unknown_entities_for_missing=True,
         )
+        if release_group['title'] == unknown_entities.unknown_release_group.name:
+            return None
         cache.set(key=key, val=release_group, time=DEFAULT_CACHE_EXPIRATION)
     return release_group_rel.process(release_group)
 

--- a/critiquebrainz/frontend/external/musicbrainz_db/test/test_cache.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/test/test_cache.py
@@ -181,7 +181,7 @@ class CacheTestCase(DataTestCase):
 
         # Test that first time data is fetched database is queried
         cache_get.assert_called_with(expected_key)
-        recording_fetch.assert_called_with(mbid, includes=['artists', 'work-rels', 'url-rels'])
+        recording_fetch.assert_called_with(mbid, includes=['artists', 'work-rels', 'url-rels'], unknown_entities_for_missing=True)
         cache_set.assert_called_with(key=expected_key, val=recording, time=DEFAULT_CACHE_EXPIRATION)
 
         cache_get.return_value = recording
@@ -295,7 +295,7 @@ class CacheTestCase(DataTestCase):
 
         # Test that first time data is fetched database is queried
         cache_get.assert_called_with(expected_key)
-        work_fetch.assert_called_with(mbid, includes=['artist-rels', 'recording-rels'])
+        work_fetch.assert_called_with(mbid, includes=['artist-rels', 'recording-rels'], unknown_entities_for_missing=True)
         cache_set.assert_called_with(key=expected_key, val=work, time=DEFAULT_CACHE_EXPIRATION)
 
         cache_get.return_value = work

--- a/critiquebrainz/frontend/external/musicbrainz_db/work.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/work.py
@@ -1,5 +1,7 @@
 from brainzutils import cache
 from brainzutils.musicbrainz_db import work as db
+from brainzutils.musicbrainz_db import serialize
+from brainzutils.musicbrainz_db import unknown_entities
 
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 
@@ -18,6 +20,9 @@ def get_work_by_id(mbid):
         work = db.get_work_by_id(
             mbid,
             includes=['artist-rels', 'recording-rels'],
+            unknown_entities_for_missing=True,
         )
+        if work == serialize.serialize_works(unknown_entities.unknown_work):
+            return None
         cache.set(key=key, val=work, time=DEFAULT_CACHE_EXPIRATION)
     return work

--- a/critiquebrainz/frontend/external/musicbrainz_db/work.py
+++ b/critiquebrainz/frontend/external/musicbrainz_db/work.py
@@ -6,6 +6,10 @@ from brainzutils.musicbrainz_db import unknown_entities
 from critiquebrainz.frontend.external.musicbrainz_db import DEFAULT_CACHE_EXPIRATION
 
 
+def work_is_unknown(work):
+    return work == serialize.serialize_works(unknown_entities.unknown_work)
+
+
 def get_work_by_id(mbid):
     """Get work with MusicBrainz ID.
 
@@ -22,7 +26,7 @@ def get_work_by_id(mbid):
             includes=['artist-rels', 'recording-rels'],
             unknown_entities_for_missing=True,
         )
-        if work == serialize.serialize_works(unknown_entities.unknown_work):
+        if work_is_unknown(work):
             return None
         cache.set(key=key, val=work, time=DEFAULT_CACHE_EXPIRATION)
     return work

--- a/critiquebrainz/frontend/templates/review/entity/artist.html
+++ b/critiquebrainz/frontend/templates/review/entity/artist.html
@@ -1,6 +1,6 @@
 {% extends 'review/entity/base.html' %}
 
-{% set artist = review.entity_id | entity_details(type='artist') %}
+{% set artist = entity %}
 
 {% block title %}
   {% set artist_name = artist.name | default(_('[Unknown artist]')) %}

--- a/critiquebrainz/frontend/templates/review/entity/event.html
+++ b/critiquebrainz/frontend/templates/review/entity/event.html
@@ -1,6 +1,6 @@
 {% extends 'review/entity/base.html' %}
 
-{% set event = review.entity_id | entity_details(type='event') %}
+{% set event = entity %}
 
 {% block title %}
   {% set event_title = event.name | default(_('[Unknown event]')) %}

--- a/critiquebrainz/frontend/templates/review/entity/label.html
+++ b/critiquebrainz/frontend/templates/review/entity/label.html
@@ -1,6 +1,6 @@
 {% extends 'review/entity/base.html' %}
 
-{% set label = review.entity_id | entity_details(type='label') %}
+{% set label = entity %}
 
 {% block title %}
   {% set label_title = label.name | default(_('[Unknown label]')) %}

--- a/critiquebrainz/frontend/templates/review/entity/place.html
+++ b/critiquebrainz/frontend/templates/review/entity/place.html
@@ -5,7 +5,7 @@
   <script src="{{ get_static_path('leaflet.js') }}"></script>
 {% endblock %}
 
-{% set place = review.entity_id | entity_details(type='place') %}
+{% set place = entity %}
 
 {% block title %}
   {% set place_title = place.name | default(_('[Unknown place]')) %}

--- a/critiquebrainz/frontend/templates/review/entity/recording.html
+++ b/critiquebrainz/frontend/templates/review/entity/recording.html
@@ -1,6 +1,6 @@
 {% extends 'review/entity/base.html' %}
 
-{% set recording = review.entity_id | entity_details(type='recording') %}
+{% set recording = entity %}
 
 {% block title %}
   {% set recording_title = recording.name | default(_('[Unknown recording]')) %}

--- a/critiquebrainz/frontend/templates/review/entity/release_group.html
+++ b/critiquebrainz/frontend/templates/review/entity/release_group.html
@@ -1,7 +1,7 @@
 {% extends 'review/entity/base.html' %}
 {% from 'macros.html' import cover_art, show_embedded_player with context %}
 
-{% set release_group = review.entity_id | entity_details %}
+{% set release_group = entity %}
 
 {% block title %}
   {% set release_group_title = release_group.title | default(_('[Unknown release group]')) %}

--- a/critiquebrainz/frontend/templates/review/entity/work.html
+++ b/critiquebrainz/frontend/templates/review/entity/work.html
@@ -1,6 +1,6 @@
 {% extends 'review/entity/base.html' %}
 
-{% set work = review.entity_id | entity_details(type='work') %}
+{% set work = entity %}
 
 {% block title %}
   {% set work_title = work.name | default(_('[Unknown work]')) %}

--- a/critiquebrainz/frontend/templates/user/reviews.html
+++ b/critiquebrainz/frontend/templates/user/reviews.html
@@ -24,7 +24,7 @@
       </thead>
       <tbody>
       {% for review in reviews %}
-        {% set entity = review.entity_id | entity_details(type=review.entity_type) %}
+        {% set entity = entities[review.entity_id | string] %}
         <tr data-review-id="{{ review.id }}">
           <td class="title">
             <a href="{{ url_for('review.entity', id=review.id) }}">

--- a/critiquebrainz/frontend/testing.py
+++ b/critiquebrainz/frontend/testing.py
@@ -9,9 +9,7 @@ from critiquebrainz.frontend import create_app
 class FrontendTestCase(TestCase):
 
     def create_app(self):
-        app = create_app()
-        app.config['WTF_CSRF_ENABLED'] = False
-        app.config['TESTING'] = True
+        app = create_app(config_path=os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'test_config.py'))
         return app
 
     def setUp(self):

--- a/critiquebrainz/frontend/views/artist.py
+++ b/critiquebrainz/frontend/views/artist.py
@@ -7,7 +7,6 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 import critiquebrainz.db.review as db_review
 import critiquebrainz.frontend.external.musicbrainz_db.artist as mb_artist
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 import critiquebrainz.frontend.external.musicbrainz_db.release_group as mb_release_group
 from critiquebrainz.frontend.views import get_avg_rating, BROWSE_RELEASE_GROUPS_LIMIT, ARTIST_REVIEWS_LIMIT
 from critiquebrainz.frontend.forms.rate import RatingEditForm
@@ -22,9 +21,8 @@ def entity(id):
     Displays release groups (split up into several sections depending on their
     type), artist information (type, members/member of, external links).
     """
-    try:
-        artist = mb_artist.get_artist_by_id(str(id))
-    except mb_exceptions.NoDataFoundException:
+    artist = mb_artist.get_artist_by_id(str(id))
+    if artist is None:
         raise NotFound(gettext("Sorry, we couldn't find an artist with that MusicBrainz ID."))
 
     # Note that some artists might not have a list of members because they are not a band

--- a/critiquebrainz/frontend/views/event.py
+++ b/critiquebrainz/frontend/views/event.py
@@ -26,7 +26,6 @@ from werkzeug.exceptions import NotFound
 
 import critiquebrainz.db.review as db_review
 import critiquebrainz.frontend.external.musicbrainz_db.event as mb_event
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 from critiquebrainz.frontend.forms.rate import RatingEditForm
 from critiquebrainz.frontend.views import get_avg_rating
 
@@ -36,9 +35,8 @@ event_bp = Blueprint('event', __name__)
 @event_bp.route('/<uuid:id>')
 def entity(id):
     id = str(id)
-    try:
-        event = mb_event.get_event_by_id(id)
-    except mb_exceptions.NoDataFoundException:
+    event = mb_event.get_event_by_id(id)
+    if event is None:
         raise NotFound(gettext("Sorry, we couldn't find an event with that MusicBrainz ID."))
 
     if 'url-rels' in event:

--- a/critiquebrainz/frontend/views/label.py
+++ b/critiquebrainz/frontend/views/label.py
@@ -4,7 +4,6 @@ from flask_login import current_user
 from werkzeug.exceptions import NotFound
 
 import critiquebrainz.db.review as db_review
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 import critiquebrainz.frontend.external.musicbrainz_db.label as mb_label
 from critiquebrainz.frontend.forms.rate import RatingEditForm
 from critiquebrainz.frontend.views import get_avg_rating, LABEL_REVIEWS_LIMIT
@@ -15,9 +14,8 @@ label_bp = Blueprint('label', __name__)
 @label_bp.route('/<uuid:id>')
 def entity(id):
     id = str(id)
-    try:
-        label = mb_label.get_label_by_id(id)
-    except mb_exceptions.NoDataFoundException:
+    label = mb_label.get_label_by_id(id)
+    if label is None:
         raise NotFound(gettext("Sorry, we couldn't find a label with that MusicBrainz ID."))
 
     label_reviews_limit = LABEL_REVIEWS_LIMIT

--- a/critiquebrainz/frontend/views/place.py
+++ b/critiquebrainz/frontend/views/place.py
@@ -22,7 +22,6 @@ from flask_login import current_user
 from werkzeug.exceptions import NotFound
 
 import critiquebrainz.db.review as db_review
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 import critiquebrainz.frontend.external.musicbrainz_db.place as mb_place
 from critiquebrainz.frontend.forms.rate import RatingEditForm
 from critiquebrainz.frontend.views import get_avg_rating
@@ -33,9 +32,8 @@ place_bp = Blueprint('place', __name__)
 @place_bp.route('/<uuid:id>')
 def entity(id):
     id = str(id)
-    try:
-        place = mb_place.get_place_by_id(id)
-    except mb_exceptions.NoDataFoundException:
+    place = mb_place.get_place_by_id(id)
+    if place is None:
         raise NotFound(gettext("Sorry, we couldn't find a place with that MusicBrainz ID."))
 
     if current_user.is_authenticated:

--- a/critiquebrainz/frontend/views/recording.py
+++ b/critiquebrainz/frontend/views/recording.py
@@ -4,7 +4,6 @@ from werkzeug.exceptions import NotFound
 from flask_babel import gettext
 import critiquebrainz.db.review as db_review
 import critiquebrainz.frontend.external.musicbrainz_db.recording as mb_recording
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 from critiquebrainz.frontend.forms.rate import RatingEditForm
 from critiquebrainz.frontend.views import get_avg_rating, RECORDING_REVIEWS_LIMIT
 
@@ -15,9 +14,8 @@ recording_bp = Blueprint('recording', __name__)
 @recording_bp.route('/<uuid:id>')
 def entity(id):
     id = str(id)
-    try:
-        recording = mb_recording.get_recording_by_id(id)
-    except mb_exceptions.NoDataFoundException:
+    recording = mb_recording.get_recording_by_id(id)
+    if recording is None:
         raise NotFound(gettext("Sorry, we couldn't find a recording with that MusicBrainz ID."))
 
     if 'url-rels' in recording:

--- a/critiquebrainz/frontend/views/release_group.py
+++ b/critiquebrainz/frontend/views/release_group.py
@@ -22,7 +22,6 @@ from flask_login import current_user
 from werkzeug.exceptions import NotFound
 
 import critiquebrainz.db.review as db_review
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 import critiquebrainz.frontend.external.musicbrainz_db.release as mb_release
 import critiquebrainz.frontend.external.musicbrainz_db.release_group as mb_release_group
 from critiquebrainz.frontend.external import mbspotify, soundcloud
@@ -35,9 +34,8 @@ release_group_bp = Blueprint('release_group', __name__)
 @release_group_bp.route('/<uuid:id>')
 def entity(id):
     id = str(id)
-    try:
-        release_group = mb_release_group.get_release_group_by_id(id)
-    except mb_exceptions.NoDataFoundException:
+    release_group = mb_release_group.get_release_group_by_id(id)
+    if release_group is None:
         raise NotFound(gettext("Sorry, we couldn't find a release group with that MusicBrainz ID."))
 
     if 'url-rels' in release_group:

--- a/critiquebrainz/frontend/views/test/test_artist.py
+++ b/critiquebrainz/frontend/views/test/test_artist.py
@@ -36,14 +36,10 @@ class ArtistViewsTestCase(FrontendTestCase):
         ))
 
     @mock.patch('critiquebrainz.frontend.external.musicbrainz_db.release_group.browse_release_groups')
-    @mock.patch('critiquebrainz.frontend.external.musicbrainz_db.artist.get_artist_by_id')
-    def test_artist_page(self, get_artist_by_id, browse_release_groups):
-        get_artist_by_id.return_value = {
-            'id': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
-            'name': 'Linkin Park',
-            'sort-name': 'Linkin Park',
-        }
+    def test_artist_page(self, browse_release_groups):
+        # Release groups in the sample database don't have all possible rg types, so mock it
         browse_release_groups.side_effect = return_release_groups
+
         # Basic artist page should be available.
         response = self.client.get('/artist/f59c5520-5f46-4d2c-b2c4-822eabf53419')
         self.assert200(response)
@@ -71,3 +67,8 @@ class ArtistViewsTestCase(FrontendTestCase):
         # Other releases tab
         response = self.client.get('/artist/f59c5520-5f46-4d2c-b2c4-822eabf53419?release_type=other')
         self.assert200(response)
+
+    def test_artist_page_not_found(self):
+        # No such mbid returns an error.
+        response = self.client.get('/artist/f59c5520-5f46-4d2c-b2c4-822eabf59999')
+        self.assert404(response)

--- a/critiquebrainz/frontend/views/test/test_comment.py
+++ b/critiquebrainz/frontend/views/test/test_comment.py
@@ -26,14 +26,6 @@ from critiquebrainz.db.user import User
 from critiquebrainz.frontend.testing import FrontendTestCase
 
 
-def mock_get_entity_by_id(id, type='release_group'):
-    # pylint: disable=unused-argument
-    return {
-        'id': 'e7aad618-fa86-3983-9e77-405e21796eca',
-        'title': 'Test Entity',
-    }
-
-
 class CommentViewsTestCase(FrontendTestCase):
 
     def setUp(self):
@@ -50,14 +42,13 @@ class CommentViewsTestCase(FrontendTestCase):
         )
         self.review = db_review.create(
             user_id=self.reviewer.id,
-            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_id="90878b63-f639-3c8b-aefb-190bdf3d1790",
             entity_type="release_group",
             text="Test Review.",
             rating=5,
             is_draft=False,
             license_id=self.license["id"],
         )
-        current_app.jinja_env.filters["entity_details"] = mock_get_entity_by_id
 
     def create_dummy_comment(self):
         return db_comment.create(

--- a/critiquebrainz/frontend/views/test/test_event.py
+++ b/critiquebrainz/frontend/views/test/test_event.py
@@ -1,0 +1,11 @@
+from critiquebrainz.frontend.testing import FrontendTestCase
+
+class EventViewsTestCase(FrontendTestCase):
+
+    def test_event_page(self):
+        response = self.client.get('/event/fe39727a-3d21-4066-9345-3970cbd6cca4')
+        self.assert200(response)
+        self.assertIn('Nine Inch Nails at Arena Riga', str(response.data))
+
+        response = self.client.get('/event/fe39727a-3d21-4066-9345-3970cbd66666')
+        self.assert404(response)

--- a/critiquebrainz/frontend/views/test/test_label.py
+++ b/critiquebrainz/frontend/views/test/test_label.py
@@ -1,0 +1,11 @@
+from critiquebrainz.frontend.testing import FrontendTestCase
+
+class LabelViewsTestCase(FrontendTestCase):
+
+    def test_label_page(self):
+        response = self.client.get('/label/615fa478-3901-42b8-80bc-bf58b1ff0e03')
+        self.assert200(response)
+        self.assertIn('Naxos', str(response.data))
+
+        response = self.client.get('/label/615fa478-3901-42b8-80bc-bf58b1ff0000')
+        self.assert404(response)

--- a/critiquebrainz/frontend/views/test/test_place.py
+++ b/critiquebrainz/frontend/views/test/test_place.py
@@ -1,0 +1,11 @@
+from critiquebrainz.frontend.testing import FrontendTestCase
+
+class PlaceViewsTestCase(FrontendTestCase):
+
+    def test_place_page(self):
+        response = self.client.get('/place/bea135c0-a32e-49be-85fd-9234c73fa0a8')
+        self.assert200(response)
+        self.assertIn('Berliner Philharmonie', str(response.data))
+
+        response = self.client.get('/place/bea135c0-a32e-49be-85fd-9234c73fdddd')
+        self.assert404(response)

--- a/critiquebrainz/frontend/views/test/test_rate.py
+++ b/critiquebrainz/frontend/views/test/test_rate.py
@@ -39,7 +39,7 @@ class RateViewsTestCase(FrontendTestCase):
 
     def test_rate(self):
         self.temporary_login(self.reviewer)
-        entity_id = 'e7aad618-fa86-3983-9e77-405e21796eca'
+        entity_id = '9162580e-5df4-32de-80cc-f45a8d8a9b1d'
         # Test for first time rating (no review exists)
         payload = {
             'entity_id': entity_id,

--- a/critiquebrainz/frontend/views/test/test_recording.py
+++ b/critiquebrainz/frontend/views/test/test_recording.py
@@ -12,24 +12,6 @@ class RecordingViewsTestCase(FrontendTestCase):
 
     def setUp(self):
         super(RecordingViewsTestCase, self).setUp()
-        mb_recording.get_recording_by_id = MagicMock()
-        mb_recording.get_recording_by_id.return_value = {
-            'id': '442ddce2-ffa1-4865-81d2-b42c40fec7c5',
-            'name': 'Dream Come True',
-            'length': 229.0,
-            'artists': [
-                {
-                    'id': '164f0d73-1234-4e2c-8743-d77bf2191051',
-                    'name': 'Kanye West',
-                    'join_phrase': ' feat. '
-                },
-                {
-                    'id': '75a72702-a5ef-4513-bca5-c5b944903546',
-                    'name': 'John Legend'
-                }
-            ],
-            'artist-credit-phrase': 'Kanye West feat. John Legend'
-        }
         self.user = User(db_users.get_or_create(1, "Tester", new_user_data={"display_name": "test user"}))
         self.license = db_license.create(id='Test', full_name='Test License')
 
@@ -43,8 +25,13 @@ class RecordingViewsTestCase(FrontendTestCase):
             license_id=self.license['id'],
             language='en',
         )
-        response = self.client.get('/recording/8ef859e3-feb2-4dd1-93da-22b91280d768')
+        response = self.client.get('/recording/442ddce2-ffa1-4865-81d2-b42c40fec7c5')
         self.assert200(response)
         self.assertIn('Dream Come True', str(response.data))
         # Test if there is a review from test user
         self.assertIn('test user', str(response.data))
+
+    def test_recording_page_not_found(self):
+        # No such mbid returns an error.
+        response = self.client.get('/recording/442ddce2-ffa1-4865-81d2-b42c40feffff')
+        self.assert404(response)

--- a/critiquebrainz/frontend/views/test/test_release_group.py
+++ b/critiquebrainz/frontend/views/test/test_release_group.py
@@ -19,24 +19,23 @@ class ReleaseGroupViewsTestCase(FrontendTestCase):
             full_name='Test License',
         )
 
-    @mock.patch('critiquebrainz.frontend.external.musicbrainz_db.release_group.get_release_group_by_id')
-    def test_release_group_page(self, get_release_group_by_id):
-        get_release_group_by_id.return_value = {
-            'id': '8ef859e3-feb2-4dd1-93da-22b91280d768',
-            'title': 'Collision Course',
-            'first-release-year': 2004,
-        }
+    def test_release_group_page(self):
         db_review.create(
             user_id=self.user.id,
-            entity_id='8ef859e3-feb2-4dd1-93da-22b91280d768',
+            entity_id='1eff4a06-056e-4dc7-91c4-0cbc5878f3c3',
             entity_type='release_group',
             text='This is a test review',
             is_draft=False,
             license_id=self.license['id'],
             language='en',
         )
-        response = self.client.get('/release-group/8ef859e3-feb2-4dd1-93da-22b91280d768')
+        response = self.client.get('/release-group/1eff4a06-056e-4dc7-91c4-0cbc5878f3c3')
         self.assert200(response)
-        self.assertIn('Collision Course', str(response.data))
+        self.assertIn('Strobe Light', str(response.data))
         # Test if there is a review from test user
         self.assertIn('test user', str(response.data))
+
+    def test_releasegroup_page_not_found(self):
+        # No such mbid returns an error.
+        response = self.client.get('/release-group/1eff4a06-056e-4dc7-91c4-0cbc58780000')
+        self.assert404(response)

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -218,7 +218,7 @@ class ReviewViewsTestCase(FrontendTestCase):
 
     def test_event_review_pages(self):
         review = db_review.create(
-            entity_id="b4e75ef8-3454-4fdc-8af1-61038c856abc",
+            entity_id="026015da-11cc-4dcb-bdce-760f852c46cd",
             entity_type="event",
             user_id=self.user.id,
             text="A great event, enjoyed it.",

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -11,24 +11,6 @@ from critiquebrainz.db.user import User
 from critiquebrainz.frontend.testing import FrontendTestCase
 
 
-def mock_get_entity_by_id(id, type='release_group'):
-    if id == '6b3cd75d-7453-39f3-86c4-1441f360e121' and type == 'release_group':
-        return {
-            'id': '6b3cd75d-7453-39f3-86c4-1441f360e121',
-            'title': 'Moderat',
-        }
-    if id == 'b4e75ef8-3454-4fdc-8af1-61038c856abc' and type == 'event':
-        return {
-            'id': 'b4e75ef8-3454-4fdc-8af1-61038c856abc',
-            'name': 'Rock am Ring 2014',
-        }
-    if id == 'c5c9c210-b7a0-4f6e-937e-02a586c8e14c' and type == 'place':
-        return {
-            'id': 'c5c9c210-b7a0-4f6e-937e-02a586c8e14c',
-            'name': 'University of London Union',
-        }
-
-
 class ReviewViewsTestCase(FrontendTestCase):
 
     def setUp(self):
@@ -45,11 +27,10 @@ class ReviewViewsTestCase(FrontendTestCase):
         )
         self.review_text = "Testing! This text should be on the page."
         self.review_rating = 3
-        current_app.jinja_env.filters['entity_details'] = mock_get_entity_by_id
 
     def create_dummy_review(self, is_draft=False, is_hidden=False):
         review = db_review.create(
-            entity_id="6b3cd75d-7453-39f3-86c4-1441f360e121",
+            entity_id="0cef1de0-6ff1-38e1-80cb-ff11ee2c69e2",
             entity_type="release_group",
             user_id=self.user.id,
             text=self.review_text,
@@ -120,7 +101,7 @@ class ReviewViewsTestCase(FrontendTestCase):
     # pylint: disable=unused-variable
     def test_create(self):
         data = dict(
-            entity_id='6b3cd75d-7453-39f3-86c4-1441f360e121',
+            entity_id='0cef1de0-6ff1-38e1-80cb-ff11ee2c69e2',
             entity_type='release_group',
             state='draft',
             text=self.review_text,
@@ -150,7 +131,7 @@ class ReviewViewsTestCase(FrontendTestCase):
                                    follow_redirects=True)
         self.assert400(response, "You can't write reviews about this type of entity.")
 
-        data = dict(release_group='6b3cd75d-7453-39f3-86c4-1441f360e121')
+        data = dict(release_group='0cef1de0-6ff1-38e1-80cb-ff11ee2c69e2')
         response = self.client.get("/review/write/", query_string=data)
         redirect_url = urlparse(response.location)
         self.assertEqual(redirect_url.path, url_for("review.create", entity_type="release_group",
@@ -167,7 +148,7 @@ class ReviewViewsTestCase(FrontendTestCase):
     def test_edit(self):
         updated_text = "The text has now been updated"
         data = dict(
-            release_group="6b3cd75d-7453-39f3-86c4-1441f360e121",
+            release_group="0cef1de0-6ff1-38e1-80cb-ff11ee2c69e2",
             state='publish',
             text=updated_text,
             license_choice=self.license["id"],

--- a/critiquebrainz/frontend/views/test/test_work.py
+++ b/critiquebrainz/frontend/views/test/test_work.py
@@ -1,0 +1,12 @@
+from critiquebrainz.frontend.testing import FrontendTestCase
+
+
+class WorkViewsTestCase(FrontendTestCase):
+
+    def test_work_page(self):
+        response = self.client.get('/work/239389e0-305f-34fc-9147-d5c40332d112')
+        self.assert200(response)
+        self.assertIn('Piano Trio in A minor', str(response.data))
+
+        response = self.client.get('/work/239389e0-305f-34fc-9147-d5c403324444')
+        self.assert404(response)

--- a/critiquebrainz/frontend/views/work.py
+++ b/critiquebrainz/frontend/views/work.py
@@ -4,7 +4,6 @@ from flask_login import current_user
 from werkzeug.exceptions import NotFound
 
 import critiquebrainz.db.review as db_review
-import critiquebrainz.frontend.external.musicbrainz_db.exceptions as mb_exceptions
 import critiquebrainz.frontend.external.musicbrainz_db.work as mb_work
 from critiquebrainz.frontend.forms.rate import RatingEditForm
 from critiquebrainz.frontend.views import get_avg_rating, WORK_REVIEWS_LIMIT, BROWSE_RECORDING_LIMIT
@@ -15,9 +14,8 @@ work_bp = Blueprint('work', __name__)
 @work_bp.route('/<uuid:id>')
 def entity(id):
     id = str(id)
-    try:
-        work = mb_work.get_work_by_id(id)
-    except mb_exceptions.NoDataFoundException:
+    work = mb_work.get_work_by_id(id)
+    if work is None:
         raise NotFound(gettext("Sorry, we couldn't find a work with that MusicBrainz ID."))
 
     work_reviews_limit = WORK_REVIEWS_LIMIT

--- a/critiquebrainz/ws/review/test/views_test.py
+++ b/critiquebrainz/ws/review/test/views_test.py
@@ -22,7 +22,7 @@ class ReviewViewsTestCase(WebServiceTestCase):
             full_name="Created so we can fill the form correctly.",
         )
         self.review = dict(
-            entity_id="6b3cd75d-7453-39f3-86c4-1441f360e121",
+            entity_id="90878b63-f639-3c8b-aefb-190bdf3d1790",
             entity_type='release_group',
             user_id=self.user.id,
             text="Testing! This text should be on the page.",

--- a/critiquebrainz/ws/testing.py
+++ b/critiquebrainz/ws/testing.py
@@ -12,9 +12,7 @@ from critiquebrainz.ws.oauth import oauth
 class WebServiceTestCase(TestCase):
 
     def create_app(self):
-        app = create_app()
-        app.config['WTF_CSRF_ENABLED'] = False
-        app.config['TESTING'] = True
+        app = create_app(config_path=os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'test_config.py'))
         oauth.init_app(app)
         return app
 

--- a/default_config.py
+++ b/default_config.py
@@ -8,7 +8,7 @@ SQLALCHEMY_DATABASE_URI = "postgresql://critiquebrainz:critiquebrainz@db:5432/cr
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 # MusicBrainz Database
-MB_DATABASE_URI = "postgresql://musicbrainz:musicbrainz@musicbrainz_db:5432/musicbrainz_test"
+MB_DATABASE_URI = "postgresql://musicbrainz:musicbrainz@musicbrainz_db:5432/musicbrainz_db"
 
 # Redis
 REDIS_HOST = "critiquebrainz_redis"

--- a/develop.sh
+++ b/develop.sh
@@ -46,6 +46,9 @@ elif [[ "$1" == "psql" ]]; then
 elif [[ "$1" == "test" ]]; then shift
     echo "Running docker-compose test..."
     invoke_docker_compose_test "$@"
+elif [[ "$1" == "redis" ]]; then shift
+    echo "Running redis-cli..."
+    invoke_docker_compose run --rm critiquebrainz_redis redis-cli -h critiquebrainz_redis
 else
     echo "Running docker-compose with the given command..."
     invoke_docker_compose "$@"

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM metabrainz/python:3.8-20210115
 
+ENV PYTHONUNBUFFERED 1
+
 # remove expired let's encrypt certificate and install new ones
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -13,9 +13,8 @@ services:
       - ./pg_custom:/docker-entrypoint-initdb.d/
 
   musicbrainz_db:
-    image: metabrainz/musicbrainz-test-database:beta
+    image: metabrainz/brainzutils-mb-sample-database:schema-25-2021-04-04.0
     environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
       POSTGRES_HOST_AUTH_METHOD: trust
 
   critiquebrainz_redis:

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,5 @@ requests==2.23.0
 SQLAlchemy==1.3.16
 mbdata==25.0.4
 sqlalchemy-dst==1.0.1
+markupsafe==2.0.1
+itsdangerous==2.0.1

--- a/test_config.py
+++ b/test_config.py
@@ -1,0 +1,9 @@
+# Testing configuration
+
+DEBUG = False
+SECRET_KEY = "test"
+WTF_CSRF_ENABLED = False
+TESTING = True
+
+# MusicBrainz Database
+MB_DATABASE_URI = "postgresql://musicbrainz@musicbrainz_db:5432/musicbrainz_db"


### PR DESCRIPTION
This is a prerequisite to upgrading to BU 2.0 - we removed the concept of "unknown entities", and so had to make a decision about how to present these in CB.

Based on discussion in CB-401 and CB-408, we decided to explicitly return 404 on all entity pages that don't exist, and also on review pages for entities that don't exist.

In a future PR, we'll add an admin interface to see these items, and add the ability to change the entity id that the review is targeting, or delete the review.

In https://github.com/metabrainz/critiquebrainz/commit/754f5a71c62d22ddc960d94293349f6cf5a650ed I reverted a change that removed the test config file, because I realised that the test db name is different in tests and development.
Because create_app actually connects to the database in the config file, it's not possible to create the app and then change the config value and then connect to the database. Easier to revert the change.

I switched from using the metabrainz/musicbrainz-test-database:beta postgres image to metabrainz/brainzutils-mb-sample-database:schema-25-2021-04-04.0. This is much faster to start up (I was waiting ~10-15 seconds for the initial setup and schema creation every time I ran tests, now it's basically instant), and now the database has real musicbrainz data in it. This means that we were able to get rid of a bunch of mocks, which have always been a bit flaky for us. This involved changing a few entity mbids in tests to ones which were in the database.

Also fixed a bug in get_revision_number that showed up during testing, and pinned some dependency versions.