### PR TITLE
[CB-420]: Fix comment input

### DIFF
--- a/critiquebrainz/frontend/forms/comment.py
+++ b/critiquebrainz/frontend/forms/comment.py
@@ -2,14 +2,14 @@ from flask_wtf import FlaskForm
 from flask_babel import lazy_gettext
 from wtforms import TextAreaField, StringField
 from wtforms.widgets import HiddenInput
-from wtforms.validators import InputRequired
+from wtforms.validators import Length
 
 
 class CommentEditForm(FlaskForm):
     state = StringField(widget=HiddenInput(), default='publish')
     text = TextAreaField(
         lazy_gettext("Add a comment..."),
-        validators=[InputRequired(message=lazy_gettext("Comment must not be empty!"))]
+        validators=[Length(min= 1, message=lazy_gettext("Comment must not be empty!"))]
     )
     review_id = StringField(widget=HiddenInput())
 


### PR DESCRIPTION
CB-420 surfaced that currently validation of comment input isn't working.
In short, we generate a hidden input textarea with the `required` attribute.
The textarea being both hidden and required causes some issues with native browser validation hints.

By using the Length validator instead of InputRequired, we conserve the intended mechanism without the textarea having a `required` prop.
Trying to post a comment with no content results in the expected error message:
![image](https://user-images.githubusercontent.com/6179856/156637214-d656cb62-35fc-4c7e-b765-4320f91f2c80.png)
