### PR TITLE
Fix links for recordings not showing

### DIFF
--- a/critiquebrainz/frontend/templates/work/entity.html
+++ b/critiquebrainz/frontend/templates/work/entity.html
@@ -82,9 +82,9 @@
           {% set recording = rel['recording'] %}
             <tr data-review-id="{{ recording.id }}">
               <td>
-                {# <a href="{{ url_for('recording.entity', id=recording.id) }}"> #}
+                <a href="{{ url_for('recording.entity', id=recording.id) }}">
                   {{ recording.name }}
-                {# </a> #}
+                </a>
               </td>
               <td>{{ rel.type | capitalize }}</td>
               <td>


### PR DESCRIPTION
On the work page, the list of recordings was not showing links. This issue was because the anchor tag was commented out in the template file.