### PR TITLE
GH actions: deploy Docker images from PRs

### DIFF
--- a/.github/workflows/push-dev-image.yml
+++ b/.github/workflows/push-dev-image.yml
@@ -5,6 +5,10 @@ name: Push development image
 on:
   workflow_dispatch:
     inputs:
+      pr:
+        description: 'PR number (if set, ignores above ^)'
+        required: false
+        type: string
       tag:
         description: 'Docker Image Tag (Version)'
         required: true
@@ -15,7 +19,16 @@ jobs:
       runs-on: ubuntu-latest
 
       steps:
-      - uses: actions/checkout@v2
+       # Run only if we are deploying a branch or tag from this repo
+      - uses: actions/checkout@v3
+        # empty strings evaluate to 0
+        if: ${{ github.event.inputs.pr == 0}}
+        
+      # Run only if we are deploying a PR (may be in a forked repo)
+      - uses: actions/checkout@v3
+        if: ${{ github.event.inputs.pr != 0}}
+        with:
+          ref: ${{ format('refs/pull/{0}/head', github.event.inputs.pr) }}
 
       - name: Login to Docker Hub
         run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin


### PR DESCRIPTION
The current Github Actions workflow we use to deploy development Docker images allows us to select a branch or tag from this repo, but not PRs that are created from a forked repo.

With these modifications we can target the ref of the pull request even if it was created from a forked repo.

See also  https://github.com/metabrainz/listenbrainz-server/pull/1928