### PR TITLE
Add deploy environment to redis namespace

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -43,6 +43,7 @@ MB_DATABASE_URI = "postgresql://musicbrainz_ro@{{.Address}}:{{.Port}}/musicbrain
 {{with index (service "critiquebrainz-redis") 0}}
 REDIS_HOST = "{{.Address}}"
 REDIS_PORT = {{.Port}}
+REDIS_NAMESPACE = "CB-{{(env "DEPLOY_ENV")}}"
 {{end}}
 {{end}}
 


### PR DESCRIPTION
We want to separate cache items between prod and beta

I tested this manually using `consul-template` in the cb-beta container and it rendered as expected to `REDIS_NAMESPACE = "CB-beta"`