### PR TITLE
Fix invalid use of entity_details filter

### DIFF
--- a/critiquebrainz/frontend/templates/log/action.html
+++ b/critiquebrainz/frontend/templates/log/action.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% if review is defined %}
-  {% set release_group = review.entity_id | entity_details %}
+  {% set release_group = review.entity_id | entity_details(entity_type=review.entity_type) %}
   {% set rg_title = release_group.title | default(_('[Unknown release group]')) %}
   {% set cancel_url = url_for('review.entity', id=review.id) %}
 {% elif user is defined %}

--- a/critiquebrainz/frontend/templates/reports/reports_results.html
+++ b/critiquebrainz/frontend/templates/reports/reports_results.html
@@ -1,5 +1,5 @@
 {% for report in results %}
-  {% set release_group = report.review.entity_id | entity_details %}
+  {% set release_group = report.review.entity_id | entity_details(entity_type=review.entity_type) %}
   <tr>
     <td>{{ report.reported_at | date }}</td>
     <td><a href="{{ url_for('user.info', user_id=report.user.id) }}">{{ report.user.display_name }}</a></td>

--- a/critiquebrainz/frontend/templates/review/report.html
+++ b/critiquebrainz/frontend/templates/review/report.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% set release_group = review.entity_id | entity_details %}
+{% set release_group = review.entity_id | entity_details(entity_type=review.entity_type) %}
 {% set rg_title = release_group.title | default(_('[Unknown release group]')) %}
 
 {% block title %}{{ _('Report %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) }} - CritiqueBrainz{% endblock %}


### PR DESCRIPTION
At some places, the entity_details filter is missing the entity_type parameter which causes the template to error. encountered while trying to hide a review.