### PR TITLE
Add missing check for moderator CB id

### DIFF
--- a/critiquebrainz/frontend/templates/moderators/moderators.html
+++ b/critiquebrainz/frontend/templates/moderators/moderators.html
@@ -9,7 +9,7 @@
     <ul>
     {% for mod in moderators %}
       <li>
-        {% if mod['critiquebrainz_id'] %}
+        {% if mod['critiquebrainz_id'] is defined and mod['critiquebrainz_id'] %}
           <a href="{{ url_for('user.info', user_id=mod['critiquebrainz_id']) }}">
             {{ mod['musicbrainz_username'] }}
           </a>


### PR DESCRIPTION
AFAIU this situation should only happen if a moderator does not have a CB account. Since, we have StrictDefined mode on we need the is defined check first. Found in local development.