### PR TITLE
CB-419: Refactor entity ratings form

### DIFF
--- a/critiquebrainz/frontend/templates/recording/entity.html
+++ b/critiquebrainz/frontend/templates/recording/entity.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% from 'macros.html' import show_avg_rating, entity_rate_form, show_external_reviews with context %}
+{% from 'common.html' import rating_script with context %}
 
 {% block title %}
   {{ _('Recording "%(name)s" by %(artist)s', name=recording.name, artist=recording['artist-credit-phrase']) }}
@@ -119,16 +120,5 @@
 {% endblock %}
 
 {% block scripts %}
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css"/>
-  <script>
-    $(document).ready(function() {
-      $("#ratestars").click(function(e){
-        // only submit rating form when user clicks on <i></i> tag (see generated HTML for rating stars on this page)
-        if (e.target.tagName === 'I') {
-          $("#rating-form").submit();
-        }
-      });
-    });
-  </script>
-  <script src="{{ get_static_path('rating.js') }}"></script>
+    {{ rating_script }}
 {% endblock %}


### PR DESCRIPTION
A single common element can replace the rating script on all the pages. The commit https://github.com/metabrainz/critiquebrainz/commit/8f8f1e13eec2ca1999f47935925847a6d98c9c73 replaced all the rating script to a common element but missed out the script on the recording page.