### PR TITLE
Fix some incorrect url_for definitions

### DIFF
--- a/critiquebrainz/frontend/templates/review/entity/work.html
+++ b/critiquebrainz/frontend/templates/review/entity/work.html
@@ -17,7 +17,7 @@
 
     {{ _('%(work)s', work=work_name) }}
 
-    {% if work['life-span'] %}
+    {% if work['life-span'] is defined %}
       <small>{{ work['life-span']['begin'][:4] }}</small>
     {% endif %}
   </h2>

--- a/critiquebrainz/frontend/views/artist.py
+++ b/critiquebrainz/frontend/views/artist.py
@@ -65,7 +65,7 @@ def entity(id):
         raise BadRequest("Invalid page number!")
     
     if page < 1:
-        return redirect(url_for('.reviews'))
+        return redirect(url_for('artist.entity', id=id))
     release_groups_offset = (page - 1) * BROWSE_RELEASE_GROUPS_LIMIT
     release_groups, release_group_count = mb_release_group.browse_release_groups(
         artist_id=artist['mbid'],

--- a/critiquebrainz/frontend/views/work.py
+++ b/critiquebrainz/frontend/views/work.py
@@ -47,7 +47,7 @@ def entity(id):
         raise BadRequest("Invalid page number!")
     
     if page < 1:
-        return redirect(url_for('.reviews'))
+        return redirect(url_for('work.entity', id=id))
 
     recording_rels = work['recording-rels']
     recording_count = len(recording_rels)


### PR DESCRIPTION
Found due to errors reported in sentry (the urls were accessed by bots, so likely not a huge issue)