### PR TITLE
Only allow http/s protocols in an oauth application's callback URL

### DIFF
--- a/critiquebrainz/frontend/forms/profile_apps.py
+++ b/critiquebrainz/frontend/forms/profile_apps.py
@@ -22,3 +22,7 @@ class ApplicationForm(FlaskForm):
     def validate_redirect_uri(self, field):
         if not field.data.startswith(("http://", "https://")):
             raise validators.ValidationError(lazy_gettext('Authorization callback URL must use http or https'))
+
+    def validate_website(self, field):
+        if not field.data.startswith(("http://", "https://")):
+            raise validators.ValidationError(lazy_gettext('Homepage URL must use http or https'))

--- a/critiquebrainz/frontend/forms/profile_apps.py
+++ b/critiquebrainz/frontend/forms/profile_apps.py
@@ -18,3 +18,7 @@ class ApplicationForm(FlaskForm):
     redirect_uri = StringField(lazy_gettext('Authorization callback URL'), [
         validators.InputRequired(message=lazy_gettext("Authorization callback URL field is empty.")),
         validators.URL(require_tld=False, message=lazy_gettext("Authorization callback URL is invalid."))])
+
+    def validate_redirect_uri(self, field):
+        if not field.data.startswith(("http://", "https://")):
+            raise validators.ValidationError(lazy_gettext('Authorization callback URL must use http or https'))

--- a/critiquebrainz/frontend/views/test/test_profile_apps.py
+++ b/critiquebrainz/frontend/views/test/test_profile_apps.py
@@ -55,6 +55,21 @@ class ProfileApplicationsViewsTestCase(FrontendTestCase):
         self.assertNotIn('You have created an application!', str(response.data))
         self.assertIn('callback URL must use http or https', str(response.data))
 
+    def test_create_invalid_website(self):
+        """Check that an error is returned if the redirect URL isn't an http/s url"""
+        self.temporary_login(self.user)
+        data = {
+            "name": "Another Application",
+            "desc": "Created for Hacking",
+            "website": "javascript://alert(ohno)",
+            "redirect_uri": "http://example.com/redirect",
+        }
+        response = self.client.post('/profile/applications/create', data=data,
+                                    follow_redirects=True)
+        self.assert200(response)
+        self.assertNotIn('You have created an application!', str(response.data))
+        self.assertIn('Homepage URL must use http or https', str(response.data))
+
     def test_edit(self):
         app = self.create_dummy_application()
 

--- a/critiquebrainz/frontend/views/test/test_profile_apps.py
+++ b/critiquebrainz/frontend/views/test/test_profile_apps.py
@@ -14,12 +14,12 @@ class ProfileApplicationsViewsTestCase(FrontendTestCase):
         self.hacker = User(db_users.get_or_create(2, u"9371e5c7-5995-4471-a5a9-33481f897f9c", new_user_data={
             "display_name": u"Hacker!",
         }))
-        self.application = dict(
-            name="Some Application",
-            desc="Created for some purpose",
-            website="http://example.com/",
-            redirect_uri="http://example.com/redirect/",
-        )
+        self.application = {
+            "name": "Some Application",
+            "desc": "Created for some purpose",
+            "website": "http://example.com/",
+            "redirect_uri": "http://example.com/redirect/",
+        }
 
     def create_dummy_application(self):
         db_oauth_client.create(user_id=self.user.id, **self.application)
@@ -35,9 +35,25 @@ class ProfileApplicationsViewsTestCase(FrontendTestCase):
     def test_create(self):
         self.temporary_login(self.user)
         response = self.client.post('/profile/applications/create', data=self.application,
-                                    query_string=self.application, follow_redirects=True)
+                                    follow_redirects=True)
         self.assert200(response)
+        self.assertIn('You have created an application!', str(response.data))
         self.assertIn(self.application['name'], str(response.data))
+
+    def test_create_invalid_redirect(self):
+        """Check that an error is returned if the redirect URL isn't an http/s url"""
+        self.temporary_login(self.user)
+        data = {
+            "name": "Another Application",
+            "desc": "Created for Hacking",
+            "website": "http://example.com/",
+            "redirect_uri": "javascript://alert(ohno)",
+        }
+        response = self.client.post('/profile/applications/create', data=data,
+                                    follow_redirects=True)
+        self.assert200(response)
+        self.assertNotIn('You have created an application!', str(response.data))
+        self.assertIn('callback URL must use http or https', str(response.data))
 
     def test_edit(self):
         app = self.create_dummy_application()


### PR DESCRIPTION
The callback URL is used in an `<a href>` on the oauth permissions page in
the "deny" button, making it possible for someone to craft a URL that
could redirect a user to a malicious page. Prevent this by requring the
callback URL to refer to properly formatted URL.
The homepage url is not checked, but this uses target="_blank", which
causes browsers to block it when opening the link.