### PR TITLE
Show reports for entities other than release groups

### DIFF
--- a/critiquebrainz/db/spam_report.py
+++ b/critiquebrainz/db/spam_report.py
@@ -173,6 +173,7 @@ def list_reports(**kwargs):
                        ON spam_report.revision_id = revision.id)
             ON spam_report.user_id = "user".id
             {}
+      ORDER BY spam_report.reported_at desc
         OFFSET :offset
          LIMIT :limit
     """.format(filterstr))

--- a/critiquebrainz/db/spam_report.py
+++ b/critiquebrainz/db/spam_report.py
@@ -156,6 +156,7 @@ def list_reports(**kwargs):
                review_uuid,
                review_user_id,
                entity_id,
+               entity_type,
                review_user_display_name
           FROM "user"
     INNER JOIN (spam_report
@@ -164,6 +165,7 @@ def list_reports(**kwargs):
                            SELECT review.id as review_uuid,
                                   "user".id as review_user_id,
                                   review.entity_id,
+                                  review.entity_type,
                                   "user".display_name as review_user_display_name
                              FROM review
                        INNER JOIN "user"
@@ -191,6 +193,7 @@ def list_reports(**kwargs):
                     },
                     "id": spam_report["review_uuid"],
                     "entity_id": spam_report.pop("entity_id"),
+                    "entity_type": spam_report.pop("entity_type"),
                     "last_revision": db_revision.get(spam_report.pop("review_uuid"))[0],
                 }
 

--- a/critiquebrainz/frontend/templates/reports/reports_results.html
+++ b/critiquebrainz/frontend/templates/reports/reports_results.html
@@ -1,15 +1,34 @@
+{% macro entity_description(entity, entity_type) %}
+  {% if entity_type == "artist" %}
+    {{ entity['name'] }}
+  {% elif entity_type == "release_group" %}
+    {{ entity['title'] }} by {{ entity['artist-credit-phrase'] }}
+  {% elif entity_type == "event" %}
+    {{ entity['name'] }}
+  {% elif entity_type == "place" %}
+    {{ entity['name'] }}
+  {% elif entity_type == "work" %}
+    {{ entity['name'] }}
+  {% elif entity_type == "label" %}
+    {{ entity['name'] }}
+  {% elif entity_type == "recording" %}
+    {{ entity['name'] }} by {{ entity['artist-credit-phrase'] }}
+  {% else %}
+    [Unknown type]
+  {% endif %}
+{% endmacro %}
+
+
 {% for report in results %}
-  {% set release_group = report.review.entity_id | entity_details(entity_type=review.entity_type) %}
+  {% set entity = report.review.entity_id | entity_details(entity_type=report.review.entity_type) %}
   <tr>
     <td>{{ report.reported_at | date }}</td>
     <td><a href="{{ url_for('user.info', user_id=report.user.id) }}">{{ report.user.display_name }}</a></td>
     <td>{{ report.reason }}</td>
     <td>
       <a href="{{ url_for('review.entity', id=report.review.id) }}">
-        {{ release_group.title | default(_('[Unknown release group]')) }}
-        by
-        {{ release_group['artist-credit-phrase'] | default(_('[Unknown artist]')) }}
-      </a>
+        {{ entity_description(entity, report.review.entity_type) }}
+      </a> ({{report.review.entity_type | title}})
     </td>
     <td><a href="{{ url_for('user.info', user_id=report.review.user.id) }}">{{ report.review.user.display_name }}</a></td>
     <td>

--- a/critiquebrainz/frontend/templates/review/entity/place.html
+++ b/critiquebrainz/frontend/templates/review/entity/place.html
@@ -21,7 +21,7 @@
     {% endif %}
 
     {{ _('%(place)s', place=event_name) }}
-    {% if place['life-span'] and place['life-span']['begin'] %}
+    {% if place['life-span'] is defined and place['life-span']['begin'] is defined %}
       <small>{{ place['life-span']['begin'][:4] }}</small>
     {% endif %}
   </h2>

--- a/critiquebrainz/frontend/templates/review/report.html
+++ b/critiquebrainz/frontend/templates/review/report.html
@@ -1,12 +1,18 @@
 {% extends 'base.html' %}
 
-{% set release_group = review.entity_id | entity_details(entity_type=review.entity_type) %}
-{% set rg_title = release_group.title | default(_('[Unknown release group]')) %}
+{% set entity = review.entity_id | entity_details(entity_type=review.entity_type) %}
+{% if entity.title is defined %}
+  {% set e_title = entity.title %}
+{% elif entity.name is defined %}
+  {% set e_title = entity.name %}
+{% else %}
+  {% set e_title = _('Unknown entity') %}
+{% endif %}
 
-{% block title %}{{ _('Report %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) }} - CritiqueBrainz{% endblock %}
+{% block title %}{{ _('Report %(user)s\'s review of "%(title)s"', title=e_title, user=review.user.display_name) }} - CritiqueBrainz{% endblock %}
 
 {% block content %}
-  <h2>{{ _('Report %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) }}</h2>
+  <h2>{{ _('Report %(user)s\'s review of "%(title)s"', title=e_title, user=review.user.display_name) }}</h2>
   <hr />
 
   {% for field in form.errors %}


### PR DESCRIPTION
There were bugs on the reports page that caused errors when a review of a non-releasegroup entity was reporterd