### PR TITLE
Update search results view

### DIFF
--- a/critiquebrainz/frontend/static/styles/main.less
+++ b/critiquebrainz/frontend/static/styles/main.less
@@ -102,6 +102,11 @@ ul.sharing {
   margin-top: 4px;
 }
 
+// Search page
+#search-results thead tr th:first-child {
+  width: 50%;
+}
+
 // Review listings
 .cover-art-container {
   position: relative;

--- a/critiquebrainz/frontend/templates/event/entity.html
+++ b/critiquebrainz/frontend/templates/event/entity.html
@@ -30,7 +30,7 @@
 
   {% if event['place-rels'] is defined %}
     {% set place = event['place-rels'][0]['place'] %}
-    {% if place['coordinates'] %}
+    {% if place['coordinates'] is defined %}
       {% set lat = place['coordinates']['latitude'] | float %}
       {% set long = place['coordinates']['longitude'] | float %}
     {% endif %}

--- a/critiquebrainz/frontend/templates/review/entity/event.html
+++ b/critiquebrainz/frontend/templates/review/entity/event.html
@@ -25,7 +25,7 @@
 
 {% if event['place-relation-list'] is defined %}
   {% set place = event['place-relation-list'][0]['place'] %}
-  {% if place['coordinates'] %}
+  {% if place['coordinates'] is defined %}
     {% set lat = place['coordinates']['latitude'] | float %}
     {% set long = place['coordinates']['longitude'] | float %}
     {% set sidebar_visible = True %}

--- a/critiquebrainz/frontend/templates/review/entity/place.html
+++ b/critiquebrainz/frontend/templates/review/entity/place.html
@@ -27,7 +27,7 @@
   </h2>
 {% endblock %}
 
-{% if place['coordinates'] %}
+{% if place['coordinates'] is defined %}
   {% set lat = place['coordinates']['latitude'] | float %}
   {% set long = place['coordinates']['longitude'] | float %}
   {% set sidebar_visible = True %}

--- a/critiquebrainz/frontend/templates/search/index.html
+++ b/critiquebrainz/frontend/templates/search/index.html
@@ -46,7 +46,7 @@
     <p class="lead" style="text-align: center;">{{ _('No results found') }}</p>
   {% else %}
 
-    <table class="table table-hover">
+    <table id="search-results" class="table table-hover">
       <thead>
       {% if type == "artist" %}
         <tr>

--- a/critiquebrainz/frontend/templates/search/results.html
+++ b/critiquebrainz/frontend/templates/search/results.html
@@ -5,7 +5,7 @@
     <tr>
       <td>
         <a href="{{ url_for('artist.entity', id=result.id) }}">{{ result['name'] }}</a>
-        {% if result['disambiguation'] is defined %}<span class="text-muted">({{ result['disambiguation'] }})</span>{% endif %}
+        {% if result['disambiguation'] is defined %}<small class="text-muted">({{ result['disambiguation'] }})</small>{% endif %}
       </td>
       <td>{{ result['sort-name'] is defined and result['sort-name'] }}</td>
       <td>{{ result['type'] is defined and result['type'] or '-' }}</td>
@@ -17,7 +17,7 @@
     <tr>
       <td>
         <a href="{{ url_for('release_group.entity', id=result.id) }}">{{ result['title'] }}</a>
-        {% if result['disambiguation'] is defined %}<span class="text-muted">({{ result['disambiguation'] }})</span>{% endif %}
+        {% if result['disambiguation'] is defined %}<small class="text-muted">({{ result['disambiguation'] }})</small>{% endif %}
       </td>
       <td>{{ display_artist_credit(result) }}</td>
       <td>{{ result['primary-type'] is defined and result['primary-type'] or '-' }}</td>
@@ -28,13 +28,13 @@
     <tr>
       <td>
         <a href="{{ url_for('event.entity', id=result.id) }}">{{ result['name'] }}</a>
-        {% if result['life-span'] is defined %}<span class="text-muted">({{ result['life-span']['begin'] }}
-          {% if result['life-span']['end'] is defined %} - {{ result['life-span']['end'] }}{% endif %})</span>{% endif %}
+        {% if result['life-span'] is defined %}<small class="text-muted">({{ result['life-span']['begin'] }}
+          {% if result['life-span']['end'] is defined %} - {{ result['life-span']['end'] }}{% endif %})</small>{% endif %}
       </td>
       <td>{{ display_artist_credit(result) }}</td>
       <td>
         {% if result['place-relation-list'] is defined %}
-          {{ result['place-relation-list'][0]['place']['name'] or '-' }}
+        <a href="{{ url_for('place.entity', id=result['place-relation-list'][0]['place']['id']) }}">{{ result['place-relation-list'][0]['place']['name'] }}</a>
         {% else %}
           -
         {% endif %}
@@ -46,9 +46,10 @@
     <tr>
       <td>
         <a href="{{ url_for('place.entity', id=result.id) }}">{{ result['name'] }}</a>
+        {% if result['disambiguation'] is defined %}<small class="text-muted">({{ result['disambiguation'] }})</small>{% endif %}
       </td>
       <td>
-        {{ result['type'] or '-' }}
+        {{ result['type'] is defined and result['type'] or '-' }}
       </td>
       <td>
         {% if result['area'] is defined %}
@@ -64,6 +65,7 @@
     <tr>
       <td>
         <a href="{{ url_for('work.entity', id=result.id) }}">{{ result['title'] }}</a>
+        {% if result['disambiguation'] is defined %}<small class="text-muted">({{ result['disambiguation'] }})</small>{% endif %}
       </td>
       <td>{{ display_artist_credit(result) }}</td>
       <td>
@@ -79,6 +81,7 @@
     <tr>
       <td>
         <a href="{{ url_for('label.entity', id=result.id) }}">{{ result['name'] }}</a>
+        {% if result['disambiguation'] is defined %}<small class="text-muted">({{ result['disambiguation'] }})</small>{% endif %}
       </td>
       <td>
         {{ result['type'] is defined and result['type'] or '-' }}
@@ -93,6 +96,7 @@
     <tr>
       <td>
         <a href="{{ url_for('recording.entity', id=result.id) }}">{{ result['title'] }}</a>
+        {% if result['disambiguation'] is defined %}<small class="text-muted">({{ result['disambiguation'] }})</small>{% endif %}
       </td>
       <td>
         {% if result['length'] is defined %}


### PR DESCRIPTION
* Always show a disambiguation if it exists, and make it `<small>`
* Always make the first column of search results 50% wide. Search results are 4 or 5 columns wide, the other fields fit in the other 50%
* Add a link to the Place on the search results for an event
* Fix some checks for undefined data in templates


Before
<img width="1177" alt="Screen Shot 2022-05-26 at 5 14 29 PM" src="https://user-images.githubusercontent.com/19217/170518319-3a2668dd-159d-40f7-a65f-e5a857390b08.png">

After
<img width="1166" alt="Screen Shot 2022-05-26 at 5 14 49 PM" src="https://user-images.githubusercontent.com/19217/170518350-97f90e84-ce02-4df0-bbbb-de01d1c874e5.png">

@MonkeyDo tagging you for css check - I decided to just add a new class for it instead of repeating a `style` attribute, we don't have any react or embedded css, so just adding it to a section in the main less file.