### PR TITLE
CB-429: API: Default sort by published_on desc if no sort params provided

### DIFF
--- a/critiquebrainz/ws/review/test/views_test.py
+++ b/critiquebrainz/ws/review/test/views_test.py
@@ -295,8 +295,8 @@ class ReviewViewsTestCase(WebServiceTestCase):
         cache_keys = cache.smembers(track_key, namespace="Review")
         self.assertEqual(set(), cache_keys)
 
-        expected_cache_keys = {'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=popularity_sort_order=None_limit=50_offset=0_language=None_review_type=None',
-                               'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=None_sort_order=None_limit=5_offset=0_language=None_review_type=None'}
+        expected_cache_keys = {'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=popularity_sort_order=desc_limit=50_offset=0_language=None_review_type=None',
+                               'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=published_on_sort_order=desc_limit=5_offset=0_language=None_review_type=None'}
 
         # Test cache keys are recorded
         self.client.get('/review/', query_string={'sort': 'rating', 'entity_id': entity_id})

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -341,8 +341,8 @@ def review_list_handler():
     :query entity_id: UUID of an entity to retrieve reviews for **(optional)**
     :query entity_type: One of the supported reviewable entities. :data:`critiquebrainz.db.review.ENTITY_TYPES` **(optional)**
     :query user_id: user's UUID **(optional)**
-    :query sort: ``popularity`` or ``published_on`` **(optional)**
-    :query sort_order: ``asc`` or ``desc`` **(optional)**
+    :query sort: ``popularity`` or ``published_on`` **(optional)**. Defaults to ``published_on``
+    :query sort_order: ``asc`` or ``desc`` **(optional)**. Defaults to ``desc``
     :query limit: results limit, min is 0, max is 50, default is 50 **(optional)**
     :query offset: result offset, default is 0 **(optional)**
     :query language: language code (ISO 639-1) **(optional)**
@@ -369,6 +369,11 @@ def review_list_handler():
         sort = 'published_on'
     if sort == 'rating':
         sort = 'popularity'
+
+    if not sort:
+        sort = 'published_on'
+    if not sort_order:
+        sort_order = 'desc'
 
     limit = Parser.int('uri', 'limit', min=1, max=50, optional=True) or 50
     offset = Parser.int('uri', 'offset', optional=True) or 0


### PR DESCRIPTION
By default the reviews list endpoint had no sort, which meant that we weren't sending any `ORDER BY` clause to the database. Update to always include a default sort if it's not set.