### PR TITLE
Fix invalid cache key for WS list reviews

### DIFF
--- a/critiquebrainz/ws/review/test/views_test.py
+++ b/critiquebrainz/ws/review/test/views_test.py
@@ -295,8 +295,8 @@ class ReviewViewsTestCase(WebServiceTestCase):
         cache_keys = cache.smembers(track_key, namespace="Review")
         self.assertEqual(set(), cache_keys)
 
-        expected_cache_keys = {'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=popularity_sort_order=desc_limit=50_offset=0_language=None_review_type=None',
-                               'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=published_on_sort_order=desc_limit=5_offset=0_language=None_review_type=None'}
+        expected_cache_keys = {'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=popularity_sort_order=desc_entity_type=None_limit=50_offset=0_language=None_review_type=None',
+                               'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=published_on_sort_order=desc_entity_type=None_limit=5_offset=0_language=None_review_type=None'}
 
         # Test cache keys are recorded
         self.client.get('/review/', query_string={'sort': 'rating', 'entity_id': entity_id})

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -384,7 +384,8 @@ def review_list_handler():
     # TODO(roman): Ideally caching logic should live inside the model. Otherwise it
     # becomes hard to track all this stuff.
 
-    cache_key = cache.gen_key('list', f'entity_id={entity_id}', f'user_id={user_id}', f'sort={sort}', f'sort_order={sort_order}', f'limit={limit}', 
+    cache_key = cache.gen_key('list', f'entity_id={entity_id}', f'user_id={user_id}', f'sort={sort}',
+                              f'sort_order={sort_order}', f'entity_type={entity_type}', f'limit={limit}',
                               f'offset={offset}', f'language={language}', f'review_type={review_type}')
     cached_result = cache.get(cache_key, REVIEW_CACHE_NAMESPACE)
 


### PR DESCRIPTION
There are 9 query parameters that can choose the reviews returned by the WS list reviews endpoint. Currently, entity_type is not considered in the cache which often causes wrong responses to be returned when entity type query param is specified.