### PR TITLE
CB-437: Add entity metadata to review get endpoints

### DIFF
--- a/critiquebrainz/ws/review/test/views_test.py
+++ b/critiquebrainz/ws/review/test/views_test.py
@@ -295,8 +295,8 @@ class ReviewViewsTestCase(WebServiceTestCase):
         cache_keys = cache.smembers(track_key, namespace="Review")
         self.assertEqual(set(), cache_keys)
 
-        expected_cache_keys = {'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=popularity_sort_order=desc_entity_type=None_limit=50_offset=0_language=None_review_type=None',
-                               'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=published_on_sort_order=desc_entity_type=None_limit=5_offset=0_language=None_review_type=None'}
+        expected_cache_keys = {'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=popularity_sort_order=desc_entity_type=None_limit=50_offset=0_language=None_review_type=None_include_metadata=None',
+                               'list_entity_id=90878b63-f639-3c8b-aefb-190bdf3d1790_user_id=None_sort=published_on_sort_order=desc_entity_type=None_limit=5_offset=0_language=None_review_type=None_include_metadata=None'}
 
         # Test cache keys are recorded
         self.client.get('/review/', query_string={'sort': 'rating', 'entity_id': entity_id})

--- a/critiquebrainz/ws/review/test/views_test.py
+++ b/critiquebrainz/ws/review/test/views_test.py
@@ -341,4 +341,4 @@ class ReviewViewsTestCase(WebServiceTestCase):
 
         self.assertEqual(resp.json["reviews"][0]["artist"]["name"], 'Linkin Park')
         self.assertEqual(resp.json["reviews"][0]["artist"]["type"], 'Group')
-        self.assertEqual(resp.json["avg_rating"], 4.5)
+        self.assertEqual(resp.json["average_rating"], 4.5)

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -2,7 +2,7 @@ import logging
 
 from brainzutils import cache
 from flask import Blueprint, jsonify
-from critiquebrainz.frontend.external.musicbrainz_db import mbstore
+from critiquebrainz.frontend.external import mbstore
 import critiquebrainz.db.avg_rating as db_avg_rating
 import critiquebrainz.db.review as db_review
 from critiquebrainz.db import (

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -3,7 +3,7 @@ import logging
 from brainzutils import cache
 from flask import Blueprint, jsonify
 from critiquebrainz.frontend.external import mbstore
-import critiquebrainz.db.avg_rating as db_avg_rating
+from critiquebrainz.frontend.views import get_avg_rating
 import critiquebrainz.db.review as db_review
 from critiquebrainz.db import (
     vote as db_vote,
@@ -435,7 +435,9 @@ def review_list_handler():
                 entity_type = reviews[0]["entity_type"] if reviews  else None
             
             if entity_type:
-                avg_rating = db_avg_rating.get(entity_id, entity_type)['rating']
+                avg_rating = get_avg_rating(entity_id, entity_type)
+                if avg_rating:
+                    avg_rating = avg_rating['rating']
             else:
                 avg_rating = None
                 include_avg_rating = False

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -397,7 +397,7 @@ def review_list_handler():
 
     cache_key = cache.gen_key('list', f'entity_id={entity_id}', f'user_id={user_id}', f'sort={sort}',
                               f'sort_order={sort_order}', f'entity_type={entity_type}', f'limit={limit}',
-                              f'offset={offset}', f'language={language}', f'review_type={review_type}')
+                              f'offset={offset}', f'language={language}', f'review_type={review_type}', f'include_metadata={include_metadata}')
     cached_result = cache.get(cache_key, REVIEW_CACHE_NAMESPACE)
 
     if cached_result:

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -398,7 +398,7 @@ def review_list_handler():
                               f'offset={offset}', f'language={language}', f'review_type={review_type}')
     cached_result = cache.get(cache_key, REVIEW_CACHE_NAMESPACE)
 
-    if False:
+    if cached_result:
         reviews = cached_result['reviews']
         count = cached_result['count']
         avg_rating = cached_result['avg_rating']

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -350,6 +350,8 @@ def review_list_handler():
     :query review_type: ``review`` or ``rating``. If set, only return reviews which have a text review, or a rating **(optional)**
     :query include_metadata: ``true`` or ``false``. Include metadata of the entity **(optional)**
 
+    **NOTE:** If entity_id is provided, then additional top-level item "average_rating" which is the average of all ratings for this entity is also included.
+
     :resheader Content-Type: *application/json*
     """
     # TODO: This checking is added to keep old clients working and needs to be removed.
@@ -458,10 +460,11 @@ def review_list_handler():
                    expirein=REVIEW_CACHE_TIMEOUT,
                    namespace=REVIEW_CACHE_NAMESPACE)
 
+
+    result = {"limit": limit, "offset": offset, "count": count, "reviews": reviews} 
     if include_avg_rating:
-        return jsonify(limit=limit, offset=offset, count=count, reviews=reviews, avg_rating=avg_rating)
-    
-    return jsonify(limit=limit, offset=offset, count=count, reviews=reviews)
+        result["average_rating"] = avg_rating 
+    return jsonify(**result)
 
 
 # don't need to add OPTIONS here because its already added


### PR DESCRIPTION
* Return average ratings for entity if the entity_id is given
* Add parameter to include the metadata for the entities