### PR TITLE
Replace blueprint name for edition group

### DIFF
--- a/critiquebrainz/frontend/__init__.py
+++ b/critiquebrainz/frontend/__init__.py
@@ -153,7 +153,7 @@ def create_app(debug=None, config_path=None):
     from critiquebrainz.frontend.views.work import work_bp
     from critiquebrainz.frontend.views.recording import recording_bp
     from critiquebrainz.frontend.views.event import event_bp
-    from critiquebrainz.frontend.views.bb_edition_group import edition_group_bp
+    from critiquebrainz.frontend.views.bb_edition_group import bb_edition_group_bp
     from critiquebrainz.frontend.views.mapping import mapping_bp
     from critiquebrainz.frontend.views.user import user_bp
     from critiquebrainz.frontend.views.profile import profile_bp
@@ -179,7 +179,7 @@ def create_app(debug=None, config_path=None):
     app.register_blueprint(recording_bp, url_prefix='/recording')
     app.register_blueprint(event_bp, url_prefix='/event')
     app.register_blueprint(place_bp, url_prefix='/place')
-    app.register_blueprint(edition_group_bp, url_prefix='/edition-group')
+    app.register_blueprint(bb_edition_group_bp, url_prefix='/edition-group')
     app.register_blueprint(mapping_bp, url_prefix='/mapping')
     app.register_blueprint(user_bp, url_prefix='/user')
     app.register_blueprint(profile_bp, url_prefix='/profile')

--- a/critiquebrainz/frontend/views/bb_edition_group.py
+++ b/critiquebrainz/frontend/views/bb_edition_group.py
@@ -8,10 +8,10 @@ from critiquebrainz.frontend.forms.rate import RatingEditForm
 from critiquebrainz.frontend.views import get_avg_rating, EDITION_GROUP_REVIEWS_LIMIT
 
 
-edition_group_bp = Blueprint('edition_group', __name__)
+bb_edition_group_bp = Blueprint('bb_edition_group', __name__)
 
 
-@edition_group_bp.route('/<uuid:id>')
+@bb_edition_group_bp.route('/<uuid:id>')
 def entity(id):
     id = str(id)
     edition_group = bb_edition_group.get_edition_group_by_bbid(id)


### PR DESCRIPTION
This PR fixes the broken link to the entity page for edition group.