### PR TITLE
Add basic .readthedocs.yaml and update deps versions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
+sphinx:
+   configuration: docs/conf.py
+
+formats: all
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==1.5.6
+Sphinx==5.0.2
 Pygments==2.7.4
-sphinxcontrib-httpdomain==1.5.0
+sphinxcontrib-httpdomain==1.8.0
 -r ../requirements.txt


### PR DESCRIPTION
Use same python version as prod in building docs. Also, update dependency versions.

https://readthedocs.org/projects/critiquebrainz/builds/17529003/