### PR TITLE
CB-438: add rel=nofollow to links in reviews

### DIFF
--- a/critiquebrainz/frontend/views/comment.py
+++ b/critiquebrainz/frontend/views/comment.py
@@ -19,13 +19,13 @@
 from flask import Blueprint, redirect, url_for, render_template, request
 from flask_babel import gettext
 from flask_login import current_user, login_required
-from markdown import markdown
 from werkzeug.exceptions import Unauthorized, NotFound
 
 import critiquebrainz.db.comment as db_comment
 from critiquebrainz.db import exceptions as db_exceptions
 from critiquebrainz.frontend import flash
 from critiquebrainz.frontend.forms.comment import CommentEditForm
+from critiquebrainz.frontend.views import markdown
 from critiquebrainz.frontend.views.review import get_review_or_404
 
 comment_bp = Blueprint('comment', __name__)
@@ -76,7 +76,7 @@ def delete(id):
         flash.success(gettext("Comment has been deleted."))
         return redirect(url_for('review.entity', id=comment["review_id"]))
     if comment:
-        comment["text_html"] = markdown(comment["last_revision"]["text"], safe_mode="escape")
+        comment["text_html"] = markdown.format_markdown_as_safe_html(comment["last_revision"]["text"])
     return render_template('review/delete_comment.html', review=review, comment=comment)
 
 

--- a/critiquebrainz/frontend/views/index.py
+++ b/critiquebrainz/frontend/views/index.py
@@ -1,8 +1,8 @@
 from bs4 import BeautifulSoup
 from flask import Blueprint, render_template
 from flask_babel import format_number
-from markdown import markdown
 
+from critiquebrainz.frontend.views import markdown
 import critiquebrainz.db.review as db_review
 import critiquebrainz.db.users as db_users
 
@@ -16,7 +16,7 @@ def index():
     popular_reviews = db_review.get_popular_reviews_for_index()
     for review in popular_reviews:
         # Preparing text for preview
-        preview = markdown(review['text'], safe_mode="escape")
+        preview = markdown.format_markdown_as_safe_html(review['text'])
         review['preview'] = ''.join(BeautifulSoup(preview, "html.parser").findAll(text=True))
 
     # Recent reviews

--- a/critiquebrainz/frontend/views/markdown.py
+++ b/critiquebrainz/frontend/views/markdown.py
@@ -1,0 +1,10 @@
+from distutils.command.install_egg_info import safe_name
+import bleach
+from markdown import markdown
+
+
+def format_markdown_as_safe_html(md_text):
+    linker = bleach.linkifier.Linker()
+    html = markdown(md_text)
+    safe_html = linker.linkify(html)
+    return safe_html

--- a/critiquebrainz/frontend/views/markdown.py
+++ b/critiquebrainz/frontend/views/markdown.py
@@ -3,8 +3,32 @@ import bleach
 from markdown import markdown
 
 
+def bleach_cb_nofollow(attrs, new=False):
+    """A callback to bleach's Linker which adds rel="nofollow noopener" to all
+    links found in some text.
+    Based on `bleach.callbacks.nofollow`
+    """
+    href_key = (None, "href")
+
+    if href_key not in attrs:
+        return attrs
+
+    if attrs[href_key].startswith("mailto:"):
+        return attrs
+
+    rel_key = (None, "rel")
+    rel_values = [val for val in attrs.get(rel_key, "").split(" ") if val]
+    if "nofollow" not in [rel_val.lower() for rel_val in rel_values]:
+        rel_values.append("nofollow")
+    if "noopener" not in [rel_val.lower() for rel_val in rel_values]:
+        rel_values.append("noopener")
+    attrs[rel_key] = " ".join(rel_values)
+
+    return attrs
+
+
 def format_markdown_as_safe_html(md_text):
-    linker = bleach.linkifier.Linker()
+    linker = bleach.linkifier.Linker(callbacks=[bleach_cb_nofollow])
     html = markdown(md_text)
     safe_html = linker.linkify(html)
     return safe_html

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -5,7 +5,6 @@ from flask import Blueprint, render_template, request, redirect, url_for, jsonif
 from flask_babel import gettext, get_locale, lazy_gettext
 from flask_login import login_required, current_user
 from langdetect import detect
-from markdown import markdown
 from werkzeug.exceptions import Unauthorized, NotFound, Forbidden, BadRequest
 
 import critiquebrainz.db.comment as db_comment
@@ -24,6 +23,7 @@ from critiquebrainz.frontend.forms.log import AdminActionForm
 from critiquebrainz.frontend.forms.review import ReviewCreateForm, ReviewEditForm, ReviewReportForm
 from critiquebrainz.frontend.login import admin_view
 from critiquebrainz.frontend.views import get_avg_rating
+from critiquebrainz.frontend.views import markdown
 from critiquebrainz.utils import side_by_side_diff
 
 review_bp = Blueprint('review', __name__)
@@ -161,7 +161,7 @@ def entity(id, rev=None):
     if revision["text"] is None:
         review["text_html"] = None
     else:
-        review["text_html"] = markdown(revision['text'], safe_mode="escape")
+        review["text_html"] = markdown.format_markdown_as_safe_html(revision['text'])
 
     review["rating"] = revision["rating"]
 
@@ -175,7 +175,7 @@ def entity(id, rev=None):
 
     comments, count = db_comment.list_comments(review_id=id)
     for comment in comments:
-        comment["text_html"] = markdown(comment["last_revision"]["text"], safe_mode="escape")
+        comment["text_html"] = markdown.format_markdown_as_safe_html(comment["last_revision"]["text"])
     comment_form = CommentEditForm(review_id=id)
     return render_template('review/entity/%s.html' % review["entity_type"], review=review,
                            spotify_mappings=spotify_mappings, soundcloud_url=soundcloud_url,

--- a/critiquebrainz/frontend/views/test/test_markdown.py
+++ b/critiquebrainz/frontend/views/test/test_markdown.py
@@ -1,0 +1,17 @@
+from critiquebrainz.frontend.testing import FrontendTestCase
+
+from critiquebrainz.frontend.views import markdown
+
+class MarkdownTestCase(FrontendTestCase):
+
+    def test_link_attrs(self):
+        md = "This is [text with link](https://example.com) and more"
+        html = markdown.format_markdown_as_safe_html(md)
+
+        assert """<a href="https://example.com" rel="nofollow">""" in html
+
+    def test_inline_link_attrs(self):
+        md = "This is a url: https://example.net, and more"
+        html = markdown.format_markdown_as_safe_html(md)
+
+        assert """<a href="https://example.net" rel="nofollow">https://example.net</a>""" in html

--- a/critiquebrainz/frontend/views/test/test_markdown.py
+++ b/critiquebrainz/frontend/views/test/test_markdown.py
@@ -8,10 +8,10 @@ class MarkdownTestCase(FrontendTestCase):
         md = "This is [text with link](https://example.com) and more"
         html = markdown.format_markdown_as_safe_html(md)
 
-        assert """<a href="https://example.com" rel="nofollow">""" in html
+        assert """<a href="https://example.com" rel="nofollow noopener">""" in html
 
     def test_inline_link_attrs(self):
         md = "This is a url: https://example.net, and more"
         html = markdown.format_markdown_as_safe_html(md)
 
-        assert """<a href="https://example.net" rel="nofollow">https://example.net</a>""" in html
+        assert """<a href="https://example.net" rel="nofollow noopener">https://example.net</a>""" in html

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Flask-SQLAlchemy==2.5.1
 Flask-Testing==0.8.1
 Flask-WTF==1.0.1
 Markdown==3.3.6
+bleach==5.0.1
 musicbrainzngs==0.7.1
 pytest==7.1.1
 pytest-cov==3.0.0


### PR DESCRIPTION
Because we allow users to write links in reviews and comments, we should mark them as rel=nofollow so that any spam links that might come through don't negatively affect CB's search ranking

I didn't include [noreferrer](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noreferrer) (or noopener) in this case, I'm not sure if it's strictly necessary as well, any thoughts @amCap1712?