### PR TITLE
CB-439 (I): Only include text reviews on front page recent reviews

### DIFF
--- a/critiquebrainz/frontend/views/index.py
+++ b/critiquebrainz/frontend/views/index.py
@@ -20,7 +20,7 @@ def index():
         review['preview'] = ''.join(BeautifulSoup(preview, "html.parser").findAll(text=True))
 
     # Recent reviews
-    recent_reviews, _ = db_review.list_reviews(sort='published_on', limit=9)
+    recent_reviews, _ = db_review.list_reviews(sort='published_on', limit=9, review_type='review')
 
     # Statistics
     review_count = format_number(db_review.get_count(is_draft=False))


### PR DESCRIPTION
CB-439

Reviews can be either text, a rating, or both.
In my experience, looking at the recent reviews list on the homepage is annoying if you click through to some new ones and see that they're only ratings.
In order to make the list of reviews more useful, only show ones that have actual text reviews.