### PR TITLE
Update musicbrainz_id on login

### DIFF
--- a/critiquebrainz/db/users.py
+++ b/critiquebrainz/db/users.py
@@ -214,6 +214,39 @@ def get_or_create(musicbrainz_row_id, musicbrainz_username, new_user_data):
     return user
 
 
+def update_username(user, new_musicbrainz_id: str):
+    """ Update the email field and MusicBrainz ID of the user specified by the lb_id
+
+    Args:
+        user: critiquebrainz user
+        new_musicbrainz_id: MusicBrainz username of a user
+    """
+    # update display name only if the user has not changed it to something else than exising mb username
+    update_display_name = user["musicbrainz_username"] == user["display_name"]
+
+    updates = ["musicbrainz_id = :new_musicbrainz_id"]
+    if update_display_name:
+        updates.append("display_name = :new_musicbrainz_id")
+
+    query = """
+        UPDATE "user"
+           SET {}
+         WHERE id = :cb_id
+    """.format(", ".join(updates))
+
+    with db.engine.connect() as connection:
+        connection.execute(sqlalchemy.text(query), {
+            "cb_id": user["id"],
+            "new_musicbrainz_id": new_musicbrainz_id,
+        })
+
+    user = dict(user)
+    user["musicbrainz_username"] = new_musicbrainz_id
+    if update_display_name:
+        user["display_name"] = new_musicbrainz_id
+    return user
+
+
 def total_count():
     """Returns the total number of users of CritiqueBrainz.
 

--- a/critiquebrainz/frontend/login/provider.py
+++ b/critiquebrainz/frontend/login/provider.py
@@ -80,6 +80,10 @@ class MusicBrainzAuthentication(BaseAuthentication):
             user = db_users.get_or_create(musicbrainz_row_id, musicbrainz_id, new_user_data={
                 'display_name': musicbrainz_id,
             })
+
+            if user["musicbrainz_username"] != musicbrainz_id:
+                user = db_users.update_username(user, musicbrainz_id)
+
             return User(user)
         except KeyError:
             return None

--- a/critiquebrainz/frontend/views/test/test_login.py
+++ b/critiquebrainz/frontend/views/test/test_login.py
@@ -1,3 +1,11 @@
+from urllib.parse import urlparse, parse_qs
+
+import requests_mock
+import sqlalchemy
+from flask import url_for
+
+import critiquebrainz.db.users as db_users
+from critiquebrainz import db
 from critiquebrainz.frontend.testing import FrontendTestCase
 
 
@@ -6,3 +14,72 @@ class LoginViewsTestCase(FrontendTestCase):
     def test_login_page(self):
         response = self.client.get("/login/")
         self.assert200(response)
+
+    @requests_mock.Mocker()
+    def test_login_oauth(self, mock_requests):
+        """ Tests that creating a new user, update MB username and login to CB updates MB username in CB db """
+        row_id = 1111
+
+        mock_requests.post("https://musicbrainz.org/oauth2/token", json={
+          "access_token": "UF7GvG2pl70jTogIwOhD32BhI_aIevPF",
+          "expires_in": 3600,
+          "token_type": "Bearer",
+          "refresh_token": "GjSCBBjp4fnbE0AKo3uFu9qq9K2fFm4u"
+        })
+
+        mock_requests.get("https://musicbrainz.org/oauth2/userinfo", json={
+            "sub": "old-user-name",
+            "metabrainz_user_id": row_id
+        })
+
+        response = self.client.get(url_for("login.musicbrainz"))
+        params = parse_qs(urlparse(response.location).query)
+        response = self.client.get(
+            url_for("login.musicbrainz_post", code="foobar", state=params["state"][0]),
+            follow_redirects=True
+        )
+        self.assert200(response)
+        user = db_users.get_by_mb_row_id(row_id)
+        self.assertEqual(user["musicbrainz_username"], "old-user-name")
+        self.assertEqual(user["display_name"], "old-user-name")
+
+        self.client.get(url_for("login.logout"))
+
+        # change MB username without changing display name, musicbrainz id in database should update
+        mock_requests.get("https://musicbrainz.org/oauth2/userinfo", json={
+            "sub": "new-user-name",
+            "metabrainz_user_id": row_id
+        })
+
+        response = self.client.get(url_for("login.musicbrainz"))
+        params = parse_qs(urlparse(response.location).query)
+        response = self.client.get(
+            url_for("login.musicbrainz_post", code="foobar", state=params["state"][0]),
+            follow_redirects=True
+        )
+        self.assert200(response)
+        user = db_users.get_by_mb_row_id(row_id)
+        self.assertEqual(user["musicbrainz_username"], "new-user-name")
+        self.assertEqual(user["display_name"], "new-user-name")
+
+        self.client.get(url_for("login.logout"))
+
+        # change display name to something else, this time display name should not be updated
+        db_users.update(user["id"], {"display_name": "custom-display-name"})
+
+        # change MB username, musicbrainz id in database should not update because display name is different
+        mock_requests.get("https://musicbrainz.org/oauth2/userinfo", json={
+            "sub": "another-new-user-name",
+            "metabrainz_user_id": row_id
+        })
+
+        response = self.client.get(url_for("login.musicbrainz"))
+        params = parse_qs(urlparse(response.location).query)
+        response = self.client.get(
+            url_for("login.musicbrainz_post", code="foobar", state=params["state"][0]),
+            follow_redirects=True
+        )
+        self.assert200(response)
+        user = db_users.get_by_mb_row_id(row_id)
+        self.assertEqual(user["musicbrainz_username"], "another-new-user-name")
+        self.assertEqual(user["display_name"], "custom-display-name")

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ sqlalchemy-dst==1.0.1
 markupsafe==2.1.1
 itsdangerous==2.1.2
 flask-shell-ipython
+requests-mock==1.9.3


### PR DESCRIPTION
We already do this in LB, implementing the same for CB. However, CB also has a display name field as well. If the display name has been changed to something else than the old musicbrainz id, update it as well otherwise let it remain set to the custom name.