### PR TITLE
Dockerfile: Install postgresql-client from current base image repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
 # PostgreSQL client
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 ENV PG_MAJOR 12
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-$PG_MAJOR \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
(copied from https://github.com/metabrainz/listenbrainz-server/commit/1ce3af2cacb108b15cf044def385084fafbffe2b)

PostgreSQL doesn't currently support xenial.

1. This approach will eliminate the need to change repository source names every time the base image is updated to a newer version.
2. This approach is mentioned on PostgreSQL docs - https://www.postgresql.org/download/linux/ubuntu/

Output of `cat /etc/apt/sources.list.d/pgdg.list`: `deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 12` which is correct for current base image.