### PR TITLE
 Update WTForms

### DIFF
--- a/critiquebrainz/frontend/forms/profile.py
+++ b/critiquebrainz/frontend/forms/profile.py
@@ -1,7 +1,7 @@
 from flask_wtf import FlaskForm
 from flask_babel import lazy_gettext
 from wtforms import StringField, BooleanField, RadioField, validators
-from wtforms.fields.html5 import EmailField
+from wtforms.fields import EmailField
 
 
 class ProfileEditForm(FlaskForm):

--- a/critiquebrainz/frontend/views/review.py
+++ b/critiquebrainz/frontend/views/review.py
@@ -391,10 +391,10 @@ def edit(id):
     # a draft review without changes is allowed.
     if form.state.data == "draft" and review["is_draft"] \
             and form.text.data == review["text"] and form.rating.data == review["rating"]:
-        form.errors["edit"] = ["You must edit either text or rating to update the draft."]
+        form.form_errors.append("You must edit either text or rating to update the draft.")
     elif not review["is_draft"] and form.text.data == review["text"] \
-        and form.rating.data == review["rating"]:
-        form.errors["edit"] = ["You must edit either text or rating to update the review."]
+            and form.rating.data == review["rating"]:
+        form.form_errors.append("You must edit either text or rating to update the review.")
     elif form.validate_on_submit():
         if review["is_draft"]:
             license_choice = form.license_choice.data

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,8 @@ pycountry==1.20
 python-dateutil==2.6.1
 rauth==0.7.3
 transifex-client==0.12.4
-WTForms==2.2.1
+WTForms==3.0.1
+email-validator==1.1.3
 langdetect==1.0.7
 Flask==2.1.2
 Jinja2==3.1.2


### PR DESCRIPTION
This is needed for https://github.com/metabrainz/critiquebrainz/pull/417.

Unselected radio field results in the value of the field being 'None' not None. This is fixed in newer versions. In newer versions, a few imports have changed and email_validators needs to be added a dependency separately to use EmailField.

Newer version of WTForms do not cache form.errors so each call to errors returns a new dict. Form level validation should instead be performed by appending errors to form.form_errors as shown in this commit. https://github.com/wtforms/wtforms/commit/22636b55eda9300b549c8bbaae6f9ae31595d445