### PR TITLE
Add index on "user".id::text

### DIFF
--- a/admin/schema_changes/23.sql
+++ b/admin/schema_changes/23.sql
@@ -1,0 +1,3 @@
+BEGIN;
+CREATE INDEX ix_user_id ON "user" USING btree ((id::text));
+COMMIT;

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -3,5 +3,6 @@ BEGIN;
 CREATE INDEX ix_oauth_grant_code ON oauth_grant USING btree (code);
 CREATE INDEX ix_review_entity_id ON review USING btree (entity_id);
 CREATE INDEX ix_revision_review_id ON revision USING btree (review_id);
+CREATE INDEX ix_user_id ON "user" USING btree ((id::text));
 
 COMMIT;


### PR DESCRIPTION
With #403, we perform a check as `"user".id::text = :user_ref`. `:user_ref` can be a username or a uuid, therefore we need to cast "user".id to text so that the comparison succeeds without error in case :user_ref is a username. Casting to text, however disables the use of any uuid indexes we may have on "user".id so add a new index on "user".id::text.

```
critiquebrainz_db=> begin;
BEGIN
critiquebrainz_db=> explain analyze select * from "user" where id::text = 'amCap1712';
                                            QUERY PLAN
---------------------------------------------------------------------------------------------------
 Seq Scan on "user"  (cost=0.00..77.18 rows=13 width=78) (actual time=2.317..2.317 rows=0 loops=1)
   Filter: ((id)::text = 'amCap1712'::text)
   Rows Removed by Filter: 2631
 Planning Time: 0.069 ms
 Execution Time: 2.336 ms
(5 rows)

critiquebrainz_db=> CREATE INDEX ix_user_id ON "user" USING btree ((id::text)); 
CREATE INDEX
critiquebrainz_db=> explain analyze select * from "user" where id::text = 'amCap1712';
                                                      QUERY PLAN
----------------------------------------------------------------------------------------------------------------------
 Index Scan using ix_user_id on "user"  (cost=0.28..12.51 rows=13 width=78) (actual time=0.128..0.128 rows=0 loops=1)
   Index Cond: ((id)::text = 'amCap1712'::text)
 Planning Time: 0.328 ms
 Execution Time: 0.158 ms
(4 rows)

critiquebrainz_db=> rollback;
ROLLBACK
```