### PR TITLE
CB-394: Do not allow CC BY-NC-SA license for future reviews

### DIFF
--- a/admin/schema_changes/24.sql
+++ b/admin/schema_changes/24.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+INSERT INTO license (id, full_name, info_url)
+     VALUES ('CC BY-SA 4.0',
+             'Creative Commons Attribution-ShareAlike 4.0 International',
+             'https://creativecommons.org/licenses/by-sa/4.0/');
+
+COMMIT;

--- a/admin/schema_changes/24.sql
+++ b/admin/schema_changes/24.sql
@@ -5,4 +5,7 @@ INSERT INTO license (id, full_name, info_url)
              'Creative Commons Attribution-ShareAlike 4.0 International',
              'https://creativecommons.org/licenses/by-sa/4.0/');
 
+UPDATE "user" 
+   SET license_choice = NULL;
+
 COMMIT;

--- a/critiquebrainz/data/fixtures.py
+++ b/critiquebrainz/data/fixtures.py
@@ -34,6 +34,11 @@ class LicenseData:
         full_name="Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported",
         info_url="https://creativecommons.org/licenses/by-nc-sa/3.0/",
     )
+    cc_by_sa_4 = dict(
+        id="CC BY-SA 4.0",
+        full_name="Creative Commons Attribution-ShareAlike 4.0 International",
+        info_url="https://creativecommons.org/licenses/by-sa/4.0/",
+    )
 
 
 # Include all objects into this tuple.

--- a/critiquebrainz/data/licenses/cc-by-sa-40.txt
+++ b/critiquebrainz/data/licenses/cc-by-sa-40.txt
@@ -1,0 +1,427 @@
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+     including for purposes of Section 3(b); and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -18,7 +18,7 @@ from critiquebrainz.db import (exceptions as db_exceptions,
 from critiquebrainz.db.user import User
 
 REVIEW_CACHE_NAMESPACE = "Review"
-DEFAULT_LICENSE_ID = "CC BY-SA 3.0"
+DEFAULT_LICENSE_ID = "CC BY-SA 4.0"
 DEFAULT_LANG = "en"
 
 #: list of allowed entity_type's for writing/querying a review

--- a/critiquebrainz/db/user.py
+++ b/critiquebrainz/db/user.py
@@ -17,7 +17,6 @@ class User(AdminMixin):
         self.musicbrainz_username = user.get('musicbrainz_username')
         self.user_ref = user.get('user_ref')
         self.is_blocked = user.get('is_blocked', False)
-        self.license_choice = user.get('license_choice', None)
         self.musicbrainz_row_id = user.get('musicbrainz_row_id', None)
     
     @property
@@ -120,7 +119,8 @@ class User(AdminMixin):
         if confidential is True:
             response.update(dict(
                 email=self.email,
-                license_choice=self.license_choice,
+                musicbrainz_username=self.musicbrainz_username,
+                user_ref=self.user_ref,
             ))
 
         if 'user_type' in includes:

--- a/critiquebrainz/frontend/forms/profile.py
+++ b/critiquebrainz/frontend/forms/profile.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from flask_babel import lazy_gettext
-from wtforms import StringField, BooleanField, RadioField, validators
+from wtforms import StringField, validators
 from wtforms.fields import EmailField
 
 
@@ -12,7 +12,3 @@ class ProfileEditForm(FlaskForm):
     email = EmailField(lazy_gettext("Email"), [
         validators.Optional(strip_whitespace=False),
         validators.Email(message=lazy_gettext("Email field is not a valid email address."))])
-    license_choice = RadioField(lazy_gettext("Preferred License Choice"), choices=[
-        ('CC BY-SA 3.0', lazy_gettext('Allow commercial use of my reviews (<a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">CC BY-SA 3.0 license</a>)')),  # noqa: E501
-        ('CC BY-NC-SA 3.0', lazy_gettext('Do not allow commercial use of my reviews, unless approved by MetaBrainz Foundation (<a href="https://creativecommons.org/licenses/by-nc-sa/3.0/" target="_blank">CC BY-NC-SA 3.0 license</a>)')),  # noqa: E501
-    ])

--- a/critiquebrainz/frontend/forms/review.py
+++ b/critiquebrainz/frontend/forms/review.py
@@ -32,18 +32,11 @@ class ReviewEditForm(FlaskForm):
         StateAndLength(min=MIN_REVIEW_LENGTH, max=MAX_REVIEW_LENGTH,
                        message=lazy_gettext("Text length needs to be between %(min)d and %(max)d characters.",
                                             min=MIN_REVIEW_LENGTH, max=MAX_REVIEW_LENGTH))])
-    license_choice = RadioField(
-        choices=[
-            ('CC BY-SA 3.0', lazy_gettext('Allow commercial use of this review(<a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">CC BY-SA 3.0 license</a>)')),  # noqa: E501
-            ('CC BY-NC-SA 3.0', lazy_gettext('Do not allow commercial use of this review, unless approved by MetaBrainz Foundation (<a href="https://creativecommons.org/licenses/by-nc-sa/3.0/" target="_blank">CC BY-NC-SA 3.0 license</a>)')),  # noqa: E501
-        ],
-        validators=[validators.InputRequired(message=lazy_gettext("You need to choose a license"))])
     remember_license = BooleanField(lazy_gettext("Remember this license choice for further preference"))
     language = SelectField(lazy_gettext("You need to accept the license agreement!"), choices=languages)
     rating = IntegerField(lazy_gettext("Rating"), widget=Input(input_type='number'), validators=[validators.Optional()])
 
-    def __init__(self, default_license_id='CC BY-SA 3.0', default_language='en', **kwargs):
-        kwargs.setdefault('license_choice', default_license_id)
+    def __init__(self, default_license_id='CC BY-SA 4.0', default_language='en', **kwargs):
         kwargs.setdefault('language', default_language)
         FlaskForm.__init__(self, **kwargs)
 

--- a/critiquebrainz/frontend/forms/review.py
+++ b/critiquebrainz/frontend/forms/review.py
@@ -36,7 +36,7 @@ class ReviewEditForm(FlaskForm):
     language = SelectField(lazy_gettext("You need to accept the license agreement!"), choices=languages)
     rating = IntegerField(lazy_gettext("Rating"), widget=Input(input_type='number'), validators=[validators.Optional()])
 
-    def __init__(self, default_license_id='CC BY-SA 4.0', default_language='en', **kwargs):
+    def __init__(self, default_language='en', **kwargs):
         kwargs.setdefault('language', default_language)
         FlaskForm.__init__(self, **kwargs)
 

--- a/critiquebrainz/frontend/templates/profile/edit.html
+++ b/critiquebrainz/frontend/templates/profile/edit.html
@@ -23,16 +23,6 @@
         <label class="col-sm-2 control-label">{{ form.email.label.text }}</label>
         <div class="col-sm-4">{{ form.email(class="form-control") }}</div>
       </div>
-      <div class="form-group">
-        <label class="col-sm-2 control-label">{{ form.license_choice.label.text }}</label>
-        <div class="col-sm-6">
-          {% for choice in form.license_choice %}
-            <div class="radio">
-              <label>{{ choice }}{{ choice.label.text | safe }}</label>
-            </div>
-          {% endfor %}
-        </div>
-      </div>
     </fieldset>
     <div class="form-group">
       <div class="col-sm-offset-2 col-sm-10">

--- a/critiquebrainz/frontend/templates/review/modify/base.html
+++ b/critiquebrainz/frontend/templates/review/modify/base.html
@@ -36,25 +36,15 @@
     </div>
     <hr />
     {% if review is not defined or review.is_draft %}
-      <div class="form-group">
-        <div class="col-sm-12">
-          {% for choice in form.license_choice %}
-            <div class="radio">
-              <label>{{ choice }}{{ choice.label.text | safe }}</label>
-            </div>
-          {% endfor %}
-          <br /><small class="text-warning"><em>{{ _('You cannot change the license after the review is published.') }}</em></small>
-          {% if not current_user.license_choice %}
-              <br /><br />
-              <div class="checkbox">
-                <label>{{ form.remember_license }}{{ form.remember_license.label.text }}</label>
-              </div>
-          {% endif %}
-        </div>
-      </div>
+      {% if review is defined and review['license'] %}
+        <span>{{ _('You will be posting this review under ') }}<a href="{{ review['license']['info_url'] }}" target="_blank">{{review['license']['id']}}</a> license.</span>
+      {% else %}
+        <span>{{ _('You will be posting this review under ') }}<a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">CC BY-SA 4.0</a> license.</span>
+      {% endif %}
     {% endif %}
     {% block license_agreement_input %}{% endblock %}
   </form>
+  <br/>
   {% block buttons %}{% endblock %}
 {% endblock %}
 

--- a/critiquebrainz/frontend/templates/review/modify/write.html
+++ b/critiquebrainz/frontend/templates/review/modify/write.html
@@ -15,8 +15,7 @@
         <label id="agreement">
           {{ form.agreement }}
           {{ _('You acknowledge and agree that your contributed reviews to CritiqueBrainz are licensed under a
-            Creative Commons Attribution-ShareAlike 3.0 Unported or Creative Commons Attribution-ShareAlike-NonCommercial
-            license as per your choice above. You agree to license your work under this license.
+            Creative Commons Attribution-ShareAlike 4.0 International license. You agree to license your work under this license.
             You represent and warrant that you own or control all rights in and to the work, that nothing in the work
             infringes the rights of any third-party, and that you have the permission to use and to license the work
             under the selected Creative Commons license. Finally, you give the MetaBrainz Foundation permission to license

--- a/critiquebrainz/frontend/views/profile.py
+++ b/critiquebrainz/frontend/views/profile.py
@@ -16,15 +16,13 @@ def edit():
     if form.validate_on_submit():
         db_users.update(current_user.id, user_new_info={
             "display_name": form.display_name.data,
-            "email": form.email.data,
-            "license_choice": form.license_choice.data,
+            "email": form.email.data
         })
         flash.success(gettext("Profile updated."))
         return redirect(url_for('user.reviews', user_ref= current_user.user_ref))
 
     form.display_name.data = current_user.display_name
     form.email.data = current_user.email
-    form.license_choice.data = current_user.license_choice
     return render_template('profile/edit.html', form=form)
 
 

--- a/critiquebrainz/frontend/views/test/test_comment.py
+++ b/critiquebrainz/frontend/views/test/test_comment.py
@@ -37,7 +37,7 @@ class CommentViewsTestCase(FrontendTestCase):
             "display_name": u"Commenter",
         }))
         self.license = db_license.create(
-            id="CC BY-SA 3.0",
+            id="CC BY-SA 4.0",
             full_name="Test License.",
         )
         self.review = db_review.create(

--- a/critiquebrainz/frontend/views/test/test_profile.py
+++ b/critiquebrainz/frontend/views/test/test_profile.py
@@ -9,7 +9,7 @@ class ProfileViewsTestCase(FrontendTestCase):
     def setUp(self):
         super(ProfileViewsTestCase, self).setUp()
         self.license = db_license.create(
-            id="CC BY-SA 3.0",
+            id="CC BY-SA 4.0",
             full_name="Created so we can fill the form correctly.",
         )
         self.user = User(db_users.get_or_create(1, "Tester", new_user_data={
@@ -19,8 +19,7 @@ class ProfileViewsTestCase(FrontendTestCase):
     def test_edit(self):
         data = dict(
             display_name="Some User",
-            email='someuser@somesite.com',
-            license_choice=self.license["id"]
+            email='someuser@somesite.com'
         )
 
         response = self.client.post('/profile/edit', data=data,

--- a/critiquebrainz/frontend/views/test/test_rate.py
+++ b/critiquebrainz/frontend/views/test/test_rate.py
@@ -33,7 +33,7 @@ class RateViewsTestCase(FrontendTestCase):
             "display_name": u"Reviewer",
         }))
         self.license = db_license.create(
-            id="CC BY-SA 3.0",
+            id="CC BY-SA 4.0",
             full_name="Test License.",
         )
 

--- a/critiquebrainz/frontend/views/test/test_review.py
+++ b/critiquebrainz/frontend/views/test/test_review.py
@@ -22,7 +22,7 @@ class ReviewViewsTestCase(FrontendTestCase):
             "display_name": u"Hacker!",
         }))
         self.license = db_license.create(
-            id="CC BY-SA 3.0",
+            id="CC BY-SA 4.0",
             full_name="Created so we can fill the form correctly.",
         )
         self.review_text = "Testing! This text should be on the page."
@@ -105,7 +105,6 @@ class ReviewViewsTestCase(FrontendTestCase):
             entity_type='release_group',
             state='draft',
             text=self.review_text,
-            license_choice=self.license["id"],
             language='en',
             agreement='True'
         )
@@ -153,7 +152,6 @@ class ReviewViewsTestCase(FrontendTestCase):
         data = {
             review["entity_type"]: review["entity_id"],
             "state": "draft",
-            "license_choice": self.license["id"],
             "language": 'en',
             "agreement": 'True',
             "text": review["text"],
@@ -186,7 +184,6 @@ class ReviewViewsTestCase(FrontendTestCase):
             release_group="0cef1de0-6ff1-38e1-80cb-ff11ee2c69e2",
             state='publish',
             text=updated_text,
-            license_choice=self.license["id"],
             language='en',
             agreement='True'
         )

--- a/critiquebrainz/frontend/views/test/test_statistics.py
+++ b/critiquebrainz/frontend/views/test/test_statistics.py
@@ -33,7 +33,7 @@ class StatisticsViewsTestCase(FrontendTestCase):
             "display_name": u"Tester",
         }))
         self.license = db_license.create(
-            id="CC BY-SA 3.0",
+            id="CC BY-SA 4.0",
             full_name="Test License.",
         )
 

--- a/critiquebrainz/ws/review/test/views_test.py
+++ b/critiquebrainz/ws/review/test/views_test.py
@@ -21,7 +21,7 @@ class ReviewViewsTestCase(WebServiceTestCase):
             "display_name": "test hacker",
         }))
         self.license = db_license.create(
-            id="CC BY-SA 3.0",
+            id="CC BY-SA 4.0",
             full_name="Created so we can fill the form correctly.",
         )
         self.review = dict(

--- a/critiquebrainz/ws/review/views.py
+++ b/critiquebrainz/ws/review/views.py
@@ -490,7 +490,6 @@ def review_post_handler(user):
     :json string entity_type: One of the supported reviewable entities. 'release_group' or 'event' etc.
     :json string text: Text part of review, min length is 25, max is 5000 **(optional)**
     :json integer rating: Rating part of review, min is 1, max is 5 **(optional)**
-    :json string license_choice: license ID
     :json string language: language code (ISO 639-1), default is ``en`` **(optional)**
     :json boolean is_draft: whether the review should be saved as a draft or not, default is ``False`` **(optional)**
 
@@ -506,7 +505,6 @@ def review_post_handler(user):
         entity_type = Parser.string('json', 'entity_type', valid_values=ENTITY_TYPES)
         text = Parser.string('json', 'text', min=min_review_length, max=REVIEW_TEXT_MAX_LENGTH, optional=True)
         rating = Parser.int('json', 'rating', min=REVIEW_RATING_MIN, max=REVIEW_RATING_MAX, optional=True)
-        license_choice = Parser.string('json', 'license_choice')
         language = Parser.string('json', 'language', min=2, max=3, optional=True) or 'en'
         if text is None and rating is None:
             raise InvalidRequest(desc='Review must have either text or rating')
@@ -515,18 +513,17 @@ def review_post_handler(user):
         if db_review.list_reviews(inc_drafts=True, inc_hidden=True, entity_id=entity_id, user_id=user.id)[1]:
             raise InvalidRequest(desc='You have already published a review for this {entity_name}'.format(
                 entity_name=db_review.ENTITY_TYPES_MAPPING[entity_type]))
-        return entity_id, entity_type, text, rating, license_choice, language, is_draft
+        return entity_id, entity_type, text, rating, language, is_draft
 
     if user.is_review_limit_exceeded:
         raise LimitExceeded('You have exceeded your limit of reviews per day.')
-    entity_id, entity_type, text, rating, license_choice, language, is_draft = fetch_params()
+    entity_id, entity_type, text, rating, language, is_draft = fetch_params()
     review = db_review.create(
         user_id=user.id,
         entity_id=entity_id,
         entity_type=entity_type,
         text=text,
         rating=rating,
-        license_id=license_choice,
         language=language,
         is_draft=is_draft,
     )


### PR DESCRIPTION
CB-394

This PR:
1. Disables CC BY-NC-SA license for future reviews.
2. Upgrades to CC BY-SA 4.0 license. So all new reviews will be published under CC BY-SA 4.0 license.