### PR TITLE
Use confidential=False when showing data in template

### DIFF
--- a/critiquebrainz/db/review.py
+++ b/critiquebrainz/db/review.py
@@ -717,7 +717,7 @@ def get_popular_reviews_for_index():
                     "rating": review["rating"],
                     "review_id": review["id"],
                 }
-            reviews = [to_dict(review, confidential=True) for review in reviews]
+            reviews = [to_dict(review, confidential=False) for review in reviews]
 
         cache.set(cache_key, reviews, 1 * 60 * 60, namespace=REVIEW_CACHE_NAMESPACE)  # 1 hour
     shuffle(reviews)

--- a/critiquebrainz/db/test/review_test.py
+++ b/critiquebrainz/db/test/review_test.py
@@ -206,7 +206,8 @@ class ReviewTestCase(DataTestCase):
         self.assertEqual(count, 1)
         self.assertEqual(len(reviews), 1)
 
-    @mock.patch('brainzutils.cache.get')
+
+    @mock.patch('critiquebrainz.db.review.cache.get')
     def test_get_popular(self, cache_get):
         cache_get.return_value = None
         reviews = db_review.get_popular_reviews_for_index()
@@ -233,14 +234,34 @@ class ReviewTestCase(DataTestCase):
             rating=review["rating"],
             is_draft=False,
         )
+
+        # User has no associated MusicBrainz account
+        user_3 = User(db_users.get_or_create(3, None, new_user_data={
+            "display_name": "test user 3",
+        }))
+        review2 = db_review.create(
+            entity_id="e7aad618-fa86-3983-9e77-405e21796eca",
+            entity_type="release_group",
+            user_id=user_3.id,
+            text="Another great review",
+            is_draft=False,
+            license_id=self.license["id"],
+        )
+
         reviews = db_review.get_popular_reviews_for_index()
-        self.assertEqual(len(reviews), 1)
-        self.assertEqual(reviews[0]["is_draft"], False)
+        self.assertEqual(len(reviews), 2)
+
+        listed_review_1 = [r for r in reviews if r["id"] == str(review["id"])][0]
+        self.assertEqual(listed_review_1["is_draft"], False)
+        self.assertEqual(listed_review_1["user"]["user_ref"], "Tester")
+
+        listed_review_2 = [r for r in reviews if r["id"] == str(review2["id"])][0]
+        self.assertEqual(listed_review_2["user"]["user_ref"], user_3.id)
 
         # A hidden review should not be in popular reviews
         db_review.set_hidden_state(review["id"], is_hidden=True)
         reviews = db_review.get_popular_reviews_for_index()
-        self.assertEqual(len(reviews), 0)
+        self.assertEqual(len(reviews), 1)
 
     def test_set_hidden_state(self):
         review = db_review.create(

--- a/critiquebrainz/db/user.py
+++ b/critiquebrainz/db/user.py
@@ -113,13 +113,13 @@ class User(AdminMixin):
             created=self.created,
             karma=self.karma,
             user_type=self.user_type.label,
+            musicbrainz_username=self.musicbrainz_username,
+            user_ref=self.user_ref,
         )
 
         if confidential is True:
             response.update(dict(
                 email=self.email,
-                musicbrainz_username=self.musicbrainz_username,
-                user_ref=self.user_ref,
                 license_choice=self.license_choice,
             ))
 

--- a/critiquebrainz/frontend/templates/macros.html
+++ b/critiquebrainz/frontend/templates/macros.html
@@ -141,7 +141,7 @@
 {% endmacro %}
 
 {% macro review_credit(review) %}
-  {% set user_string = '<a href="%s">%s</a>'|safe % (url_for('user.reviews', user_ref= review.user.user_ref), review.user.display_name) %}
+  {% set user_string = '<a href="%s">%s</a>'|safe % (url_for('user.reviews', user_ref=review.user.user_ref), review.user.display_name) %}
   {{ _('Review by %(user)s', user=user_string) }}
 {% endmacro %}
 


### PR DESCRIPTION
A user's musicbrainz user, or user_ref isn't private data, and show should always show when rendering a user object.
For security, don't pass email address to the template