### PR TITLE
CB-458 - Link to ‘how to write a review’ guide

### DIFF
--- a/critiquebrainz/frontend/templates/index/about.html
+++ b/critiquebrainz/frontend/templates/index/about.html
@@ -8,25 +8,25 @@
 <h3>{{ _('What is CritiqueBrainz?') }}</h3>
 <p>
   {{ _('<strong>CritiqueBrainz is a repository for Creative Commons licensed music and book reviews.</strong>
-  Here you can read what others have written about an album or event and write your own review!
-  It is based on data from MusicBrainz - open music encyclopedia and BookBrainz - open book encyclopedia.') }}
+  It is based on data from MusicBrainz and BookBrainz, open music and book encyclopedias.’) }}
 </p>
 
 <h3>{{ _('What is it for?') }}</h3>
 <p>
-  {{ _('Projects like Wikipedia, MusicBrainz and BookBrainz are good at aggregating information about
-  music and books, but not suited for expressing opinions about it. That\'s not their purpose.
-  CritiqueBrainz fills the gap between music and book critics and raw data.') }}
+  {{ _('Projects like Wikipedia, MusicBrainz and BookBrainz are good at aggregating information
+  about music and books, but their purpose is not suited to expressing opinions.
+  CritiqueBrainz fills the gap between raw data and music and book critics.’) }}
 </p>
 <p>
-  {{ _('This is an open platform. That means everyone - including you - can participate
-  and contribute. If you are good at writing and want to share your thoughts about
-  an album - feel free to write a new review. If that\'s not your thing and you just
-  want to read opinions - that\'s fine too.') }}
+  {{ _(‘This is an open platform. That means everyone can participate and contribute.
+  If you want to share your thoughts, you can rate and/or review an album or a book.
+  If you would like, you can read our guide on
+  <a href=”https://wiki.musicbrainz.org/How_to_write_Good_Critiquebrainz_Reviews”>How to Write Good CritiqueBrainz Reviews</a>.
+  If you just want to read opinions, that\’s fine too.’) }}
 </p>
 <p>
-  {{ _('After reading a review you can mark it as useful or not. That will help other
-  music and book enthusiasts like you find good reviews.') }}
+  {{ _(‘After reading a review you can mark it as useful or not. This helps other
+  music and book enthusiasts find good reviews.') }}
 </p>
 
 <h3>{{ _('Code of Conduct') }}</h3>
@@ -50,6 +50,5 @@
  above, for why this may have happened. For further discussion contact
  <a href="https://metabrainz.org/contact">MetaBrainz support</a>.') }}
 </p>
-
 
 {% endblock %}


### PR DESCRIPTION
Added a link to the ‘how to write a good critiquebrainz review’ wiki page.

Also tidied up and shortened the text slightly, in preparation for adding a new section on LLM in the guidelines (and we don’t want this page to be too intimidating, as discussed in CB-88)