### PR TITLE
Fix single quotes

### DIFF
--- a/critiquebrainz/db/comment.py
+++ b/critiquebrainz/db/comment.py
@@ -102,7 +102,7 @@ def get_by_id(comment_id):
 
         comment = result.mappings().first()
         if not comment:
-            raise db_exceptions.NoDataFoundException('Can\'t find comment with ID: {id}'.format(id=comment_id))
+            raise db_exceptions.NoDataFoundException('Can’t find comment with ID: {id}'.format(id=comment_id))
 
         comment = dict(comment)
         comment['last_revision'] = {

--- a/critiquebrainz/frontend/templates/index/about.html
+++ b/critiquebrainz/frontend/templates/index/about.html
@@ -22,7 +22,7 @@
   If you want to share your thoughts, you can rate and/or review an album or a book.
   If you would like, you can read our guide on
   <a href=”https://wiki.musicbrainz.org/How_to_write_Good_Critiquebrainz_Reviews”>How to Write Good CritiqueBrainz Reviews</a>.
-  If you just want to read opinions, that\'s fine too.') }}
+  If you just want to read opinions, that’s fine too.') }}
 </p>
 <p>
   {{ _('After reading a review you can mark it as useful or not. This helps other

--- a/critiquebrainz/frontend/templates/index/about.html
+++ b/critiquebrainz/frontend/templates/index/about.html
@@ -37,7 +37,7 @@
 
 <h3>{{ _('Guidelines') }}</h3>
 <p>
-  {{ _('Content has to be a \'review\' or a otherwise genuine reflection on the entity.
+  {{ _('Content has to be a “review” or a otherwise genuine reflection on the entity.
  Artists/labels are welcome to reflect on their own work, as long as it meets this requirement
  - primarily promotional or SEO content will be hidden.') }}
 </p>

--- a/critiquebrainz/frontend/templates/index/about.html
+++ b/critiquebrainz/frontend/templates/index/about.html
@@ -8,24 +8,24 @@
 <h3>{{ _('What is CritiqueBrainz?') }}</h3>
 <p>
   {{ _('<strong>CritiqueBrainz is a repository for Creative Commons licensed music and book reviews.</strong>
-  It is based on data from MusicBrainz and BookBrainz, open music and book encyclopedias.’) }}
+  It is based on data from MusicBrainz and BookBrainz, open music and book encyclopedias.') }}
 </p>
 
 <h3>{{ _('What is it for?') }}</h3>
 <p>
   {{ _('Projects like Wikipedia, MusicBrainz and BookBrainz are good at aggregating information
   about music and books, but their purpose is not suited to expressing opinions.
-  CritiqueBrainz fills the gap between raw data and music and book critics.’) }}
+  CritiqueBrainz fills the gap between raw data and music and book critics.') }}
 </p>
 <p>
-  {{ _(‘This is an open platform. That means everyone can participate and contribute.
+  {{ _('This is an open platform. That means everyone can participate and contribute.
   If you want to share your thoughts, you can rate and/or review an album or a book.
   If you would like, you can read our guide on
   <a href=”https://wiki.musicbrainz.org/How_to_write_Good_Critiquebrainz_Reviews”>How to Write Good CritiqueBrainz Reviews</a>.
-  If you just want to read opinions, that\’s fine too.’) }}
+  If you just want to read opinions, that\'s fine too.') }}
 </p>
 <p>
-  {{ _(‘After reading a review you can mark it as useful or not. This helps other
+  {{ _('After reading a review you can mark it as useful or not. This helps other
   music and book enthusiasts find good reviews.') }}
 </p>
 
@@ -45,7 +45,7 @@
   {{ _('Your submissions must be your original work. Do not submit content that you do not hold
   the copyright to, or is not your own. This includes plagiarism and primarily LLM (Large Language
   Model) or AI generated content. You may wish to use LLM as a tool, but be aware that obviously
-  LLM generated content will be removed.’) }}
+  LLM generated content will be removed.') }}
 </p>
 <p>
   {{ _('If you have had a review hidden please check the Code of Conduct and the guidelines,

--- a/critiquebrainz/frontend/templates/index/guidelines.html
+++ b/critiquebrainz/frontend/templates/index/guidelines.html
@@ -18,11 +18,11 @@
   </p>
   <p>
     <strong>{{ _('Write in a comfortable voice') }}</strong>
-    <br />{{ _('A good review probably won\'t sound like an academic paper, and probably won\'t sound like a YouTube
+    <br />{{ _('A good review probably won’t sound like an academic paper, and probably won’t sound like a YouTube
                 comment, but it should sound like <em>you</em>.') }}
   </p>
   <p>
-    <strong>{{ _('Reviews on CritiqueBrainz don\'t have to be in English') }}</strong>
+    <strong>{{ _('Reviews on CritiqueBrainz don’t have to be in English') }}</strong>
     <br />{{ _('You are more than welcome to write review in a language that you prefer to use. Choose a language in
                 which you can express your emotions/thoughts freely.') }}
   </p>
@@ -49,11 +49,11 @@
     </li>
     <li>
       <strong>{{ _('Good reviews are neither too short nor too long') }}</strong>
-      {{ _('It\'s better to make your reviews neither too short nor too long. Try to write something which gives readers
+      {{ _('It’s better to make your reviews neither too short nor too long. Try to write something which gives readers
             a clear image as to what something is like while not being too boring.') }}
     </li>
     <li>
-      <strong>{{ _('Don\'t mention just the factual data.') }}</strong>
+      <strong>{{ _('Don’t mention just the factual data.') }}</strong>
       {{ _('Sometimes people mention only factual data in their reviews which makes a review look more like a press release.') }}
     </li>
   </ul>
@@ -76,13 +76,13 @@
           meaningful? Did it match the music?') }}
         </dd>
         <dd>
-          {{ _('Recording quality matters a lot. If it\'s good it\'s good but if it\'s bad it will flop the whole album. It\'s
+          {{ _('Recording quality matters a lot. If it’s good it’s good but if it’s bad it will flop the whole album. It’s
           always better to note these things and mention about it in your review.') }}
         </dd>
       </dl>
     </li>
     <li>
-      {{ _('Be clear with your conclusion - If it\'s a must hear album give it some direction. It\'s always good to mention
+      {{ _('Be clear with your conclusion - If it’s a must hear album give it some direction. It’s always good to mention
       the genre of the music. You may try to compare it with some other album which has been already released having the
       same genre which will give the readers an idea as to what they can expect.') }}
     </li>
@@ -96,13 +96,13 @@
     </li>
     <li>
       {{ _('Writing about the music played there - You may describe which songs were played in the event. Which were your
-      favourite songs played, you can write about the staging of the band. Were there any things which you didn\'t like?
+      favourite songs played, you can write about the staging of the band. Were there any things which you didn’t like?
       If yes, then why?') }}
     </li>
     <li>
       {{ _('Special moments, effects and surprises - Often there are special moments in every event, you may describe such
       moments that took place. You may also write about special guests(if any) also any special effects in the event
-      which caught everyone\'s attention.') }}
+      which caught everyone’s attention.') }}
     </li>
     <li>
       {{ _('Writing about Event atmosphere - You may always describe about the crowd, how well the artists/band were able to
@@ -113,18 +113,18 @@
   <h4>{{ _('Places') }}</h4>
   <ul>
     <li>
-      {{ _('Description about the location - You may describe where the place is located, whether it\'s located in the heart
+      {{ _('Description about the location - You may describe where the place is located, whether it’s located in the heart
       of the city or is it located on the periphery.') }}
     </li>
     <li>
-      {{ _('Writing about the architecture - If it\'s a musical stadium people want to know about how many people can the
+      {{ _('Writing about the architecture - If it’s a musical stadium people want to know about how many people can the
       place occupy, how well the artist sounds in each corner of the place etc.') }}
     </li>
   </ul>
 
   <p>
     <strong>{{ _('💡 Note:') }}</strong>
-    {{ _('Try to be <strong>honest</strong> while reviewing, simply don\'t follow the trend. Review the album as to what
+    {{ _('Try to be <strong>honest</strong> while reviewing, simply don’t follow the trend. Review the album as to what
     you felt. And try to follow active voice.') }}
   </p>
 
@@ -135,7 +135,7 @@
     <li>{{ _('Overlooking proofreading</strong> the review after finishing it.') }}</li>
     <li>{{ _('Mistakes such as punctuation, typo errors, capitalization etc.') }}</li>
     <li>{{ _('Writing in slangs - Try to write in proper English (or whatever language you prefer).
-              It\'s better not to write reviews in slangs.') }}</li>
+              It’s better not to write reviews in slangs.') }}</li>
   </ul>
 
   <h3>{{ _('Additional material') }}</h3>

--- a/critiquebrainz/frontend/templates/log/action.html
+++ b/critiquebrainz/frontend/templates/log/action.html
@@ -9,9 +9,9 @@
 {% endif %}
 
 {% if action == "hide_review" %}
-  {% set title = _('Hide %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) %}
+  {% set title = _('Hide %(user)s’s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) %}
 {% elif action == "unhide_review" %}
-  {% set title = _('Unhide %(user)s\'s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) %}
+  {% set title = _('Unhide %(user)s’s review of "%(rg)s"', rg=rg_title, user=review.user.display_name) %}
 {% elif action == "block_user" %}
   {% set title = _('Block %(user)s', user=user.display_name) %}
 {% elif action == "unblock_user" %}

--- a/critiquebrainz/frontend/templates/macros.html
+++ b/critiquebrainz/frontend/templates/macros.html
@@ -118,7 +118,7 @@
     {% endif %}
     <div id="mb-call-to-act" class="spotify-player" style="display:none;">
       <span class="text-muted">
-        {{ _('We don\'t have cover art for this release group.') }}
+        {{ _('We don’t have cover art for this release group.') }}
       </span>
       <div style="text-align:center;font-weight:bold;">
         <a style="font-size:16px"; href='https://musicbrainz.org/doc/How_to_Add_Cover_Art' rel='nofollow'>
@@ -158,7 +158,7 @@
       </em>
     {% elif show_add_message %}
       <span class="text-muted">
-        {{ _('We don\'t have a mapping between this release group and Spotify. Please help us find the right album.') }}
+        {{ _('We don’t have a mapping between this release group and Spotify. Please help us find the right album.') }}
       </span>
       <div style="text-align:center;font-weight:bold;">
         <a style="font-size:16px;" href="{{ url_for('mapping.spotify_add', release_group_id=release_group_id) }}" rel="nofollow">

--- a/critiquebrainz/frontend/templates/mapping/spotify.html
+++ b/critiquebrainz/frontend/templates/mapping/spotify.html
@@ -54,7 +54,7 @@
 <hr />
 
 <p>
-  <p>{{ _('If you can\'t find the right album in search results, you can paste a Spotify link there:') }}</p>
+  <p>{{ _('If you can’t find the right album in search results, you can paste a Spotify link there:') }}</p>
   <form class="form-inline" role="form" action="{{ url_for('mapping.spotify_confirm') }}" method="GET">
     <div class="form-group">
       <input type="hidden" name="release_group_id" value="{{ release_group.mbid }}">
@@ -73,7 +73,7 @@
 
 <p>
   <strong>
-    {{ _('It\'s fine if you can\'t find the right album. It might not be available on Spotify yet.') }}
+    {{ _('It’s fine if you can’t find the right album. It might not be available on Spotify yet.') }}
     {{ _('You can <a href="%(link)s">go back to the release group page</a>.', link=url_for('release_group.entity', id=release_group.mbid)) }}
   </strong>
 </p>

--- a/critiquebrainz/frontend/templates/moderators/moderators.html
+++ b/critiquebrainz/frontend/templates/moderators/moderators.html
@@ -5,7 +5,7 @@
 {% block content %}
   <div id="moderators-list">
     <h2>{{ _('Moderators') }}</h2>
-    <p><em>{{ _('These users respond to reports and make sure that spammers don\'t spam.') }}</em></p>
+    <p><em>{{ _('These users respond to reports and make sure that spammers don’t spam.') }}</em></p>
     <ul>
     {% for mod in moderators %}
       <li>

--- a/critiquebrainz/frontend/templates/review/delete_comment.html
+++ b/critiquebrainz/frontend/templates/review/delete_comment.html
@@ -8,7 +8,7 @@
 {% endif %}
 
 {% block title %}
-  {{ _('Edit comment on %(user)s\'s review of "%(entity)s"', entity=entity_title, user=review['user'].display_name) }} - CritiqueBrainz
+  {{ _('Edit comment on %(user)s’s review of "%(entity)s"', entity=entity_title, user=review['user'].display_name) }} - CritiqueBrainz
 {% endblock %}
 
 {% block content %}
@@ -16,7 +16,7 @@
   <hr />
   <form method="POST" role="form">
     <div class="form-group">
-      <p class="lead">{{ _('Are you sure you want to delete your comment on %(user)s\'s review of "%(entity)s"?', entity=entity_title, user=review['user'].display_name) }}</p>
+      <p class="lead">{{ _('Are you sure you want to delete your comment on %(user)s’s review of "%(entity)s"?', entity=entity_title, user=review['user'].display_name) }}</p>
       <p><b>You're deleting:</b></p>
       <blockquote><p><i>{{ comment.text_html|safe }}</i></p></blockquote>
       <p class="text-warning">{{ _('There is no way to undo this action!') }}</p>

--- a/critiquebrainz/frontend/templates/review/entity/base.html
+++ b/critiquebrainz/frontend/templates/review/entity/base.html
@@ -105,7 +105,7 @@
                       {% if vote.vote == True %}
                         <span class="text-success">{{ _('You found this review useful.') }}</span>
                       {% else %}
-                        <span class="text-warning">{{ _('You didn\'t find this review useful.') }}</span>
+                        <span class="text-warning">{{ _('You didn’t find this review useful.') }}</span>
                       {% endif %}
                       <a href="{{ url_for('review.vote_delete', id=review.id) }}" class="btn btn-default btn-xs" title="{{ _('Delete your vote') }}"><span class="glyphicon glyphicon-trash"></span></a>
                     {% endif %}

--- a/critiquebrainz/frontend/templates/review/report.html
+++ b/critiquebrainz/frontend/templates/review/report.html
@@ -9,10 +9,10 @@
   {% set e_title = _('Unknown entity') %}
 {% endif %}
 
-{% block title %}{{ _('Report %(user)s\'s review of "%(title)s"', title=e_title, user=review.user.display_name) }} - CritiqueBrainz{% endblock %}
+{% block title %}{{ _('Report %(user)s’s review of "%(title)s"', title=e_title, user=review.user.display_name) }} - CritiqueBrainz{% endblock %}
 
 {% block content %}
-  <h2>{{ _('Report %(user)s\'s review of "%(title)s"', title=e_title, user=review.user.display_name) }}</h2>
+  <h2>{{ _('Report %(user)s’s review of "%(title)s"', title=e_title, user=review.user.display_name) }}</h2>
   <hr />
 
   {% for field in form.errors %}


### PR DESCRIPTION
# Problem

An ISE (500) was returned instead of the page “About” with the pull requests #488 and #489 not released yet.

# Solution

* Replace curved single quotes `‘’` that were used instead of straight one `'` as string delimiter

# Extra

* Replace straight single quotes `'` that were used instead of typographic apostrophe `’` in strings
* Replace straight single quotes `'` that were used instead of curved quotation marks `“”` in strings