### PR TITLE
Update CI unit tests results workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ jobs:
   test:
     name: Run test suite
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +39,7 @@ jobs:
       run: ./test.sh
 
     - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1.11
+      uses: EnricoMi/publish-unit-test-result-action@v2
       if: ${{ always() }}
       with:
         files: reports/tests.xml


### PR DESCRIPTION
I noticed this test workflow has been consistently failing* even thought the testing step succeeds. The action that is supposed to publish the test results is failing due to permissions issues.

I'm now adding  the required permissions to allow the workflow to write checks and comments on pull requests, as well as updating to a newer version of the action.

* see failures like so: https://github.com/metabrainz/critiquebrainz/actions/runs/6559728119/job/17815889047?pr=494#step:9:31