### PR TITLE
Change socket to http in uwsgi.ini

### DIFF
--- a/docker/uwsgi/uwsgi.ini
+++ b/docker/uwsgi/uwsgi.ini
@@ -1,6 +1,6 @@
 [uwsgi]
 master = true
-http = 0.0.0.0:13032
+socket = 0.0.0.0:13032
 module = manage
 callable = application
 chdir = /code/

--- a/docker/uwsgi/uwsgi.ini
+++ b/docker/uwsgi/uwsgi.ini
@@ -1,4 +1,6 @@
 [uwsgi]
+uid = www-data
+gid = www-data
 master = true
 socket = 0.0.0.0:13032
 module = manage
@@ -9,3 +11,7 @@ processes = 20
 disable-logging = true
 ; increase buffer size for requests that send a lot of mbids in query params
 buffer-size = 8192
+; when uwsgi gets a sighup, quit completely and let runit restart us
+exit-on-reload = true
+need-app = true
+log-x-forwarded-for=true

--- a/docker/uwsgi/uwsgi.ini
+++ b/docker/uwsgi/uwsgi.ini
@@ -1,6 +1,6 @@
 [uwsgi]
 master = true
-socket = 0.0.0.0:13032
+http = 0.0.0.0:13032
 module = manage
 callable = application
 chdir = /code/


### PR DESCRIPTION
We are trying to resolve issues with uWSGI running in the CB docker containers, which fail with the error `bind(): Address already in use [core/socket.c line 769]`
See this discussion or some background: https://chatlogs.metabrainz.org/libera/metabrainz/2023-11-02/?msg=5243055&page=2

This mimics how we configure the artwork redirect container: https://github.com/metabrainz/artwork-redirect/blob/c632ecfda1c5d5037e20a341f992b35ea7cc5ab8/docker/prod/uwsgi.ini#L3