### PR TITLE
Improve uWSGI and consul-template interactions on reloading

### DIFF
--- a/docker/uwsgi/consul-template-uwsgi.conf
+++ b/docker/uwsgi/consul-template-uwsgi.conf
@@ -3,7 +3,7 @@ template {
     destination = "/code/consul_config.py"
 }
 exec {
-    command = "uwsgi --die-on-term /etc/uwsgi/uwsgi.ini"
+    command = ["uwsgi", "/etc/uwsgi/uwsgi.ini"]
     splay = "60s"
     reload_signal = "SIGHUP"
     kill_signal = "SIGTERM"

--- a/docker/uwsgi/uwsgi.ini
+++ b/docker/uwsgi/uwsgi.ini
@@ -11,7 +11,6 @@ processes = 20
 disable-logging = true
 ; increase buffer size for requests that send a lot of mbids in query params
 buffer-size = 8192
-; when uwsgi gets a sighup, quit completely and let runit restart us
-exit-on-reload = true
 need-app = true
-log-x-forwarded-for=true
+log-x-forwarded-for = true
+die-on-term = true


### PR DESCRIPTION
We fixed the `bind(): Address already in use [core/socket.c line 769]` error in LB using `exit-on-reload = true` in uWSGI configuration. However, this prevents graceful reloading.

I did some further investigation as noted in metabrainz/artwork-redirect#46 and have a better fix in mind now.

For the command field in exec block of consul template configuration, use array format. This executes the command directly without spawning a shell wrapper or setting a process group id. Both of which will interfere with forwarding signals to the uWSGI process.