### PR TITLE
Upgrade base python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/python:3.10-20220315 as critiquebrainz-base
+FROM metabrainz/python:3.11-20231006 as critiquebrainz-base
 
 ENV PYTHONUNBUFFERED 1
 
@@ -39,7 +39,7 @@ RUN mkdir -p /etc/apt/keyrings \
 
 RUN pip install --upgrade pip==21.0.1
 
-RUN pip install --no-cache-dir uWSGI==2.0.20
+RUN pip install --no-cache-dir uWSGI==2.0.23
 
 RUN mkdir /code
 WORKDIR /code


### PR DESCRIPTION
To fix uWSGI and consul template errors, we need a newer version of consul template. So upgrade the base python image which comes with the newer version of consul template. Also, need to upgrade python to 3.11 and uWSGI to a compatible version as a result.