### PR TITLE
Update link to chatrooms in footer

### DIFF
--- a/critiquebrainz/frontend/templates/footer.html
+++ b/critiquebrainz/frontend/templates/footer.html
@@ -22,8 +22,8 @@
       </p>
       <ul class="list-unstyled">
         <li>
-          {{ _("Development IRC: {url|#metabrainz}")|expand({'url':
-          'https://kiwiirc.com/nextclient/irc.libera.chat/?#metabrainz'})|safe }}
+          {{ _("Chat with us: {url|Matrix, IRC, Discord}")|expand({'url':
+          'https://wiki.musicbrainz.org/Communication/ChatBrainz'})|safe }}
         </li>
       </ul>
     </div>

--- a/critiquebrainz/frontend/templates/footer.html
+++ b/critiquebrainz/frontend/templates/footer.html
@@ -23,7 +23,7 @@
       <ul class="list-unstyled">
         <li>
           {{ _("Chat with us: {url|Matrix, IRC, Discord}")|expand({'url':
-          'https://wiki.musicbrainz.org/Communication/ChatBrainz'})|safe }}
+          'https://musicbrainz.org/doc/Communication/ChatBrainz'})|safe }}
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Point to the MB wiki page for all things communications
<img width="1220" alt="image" src="https://github.com/metabrainz/critiquebrainz/assets/6179856/ed8bfe48-b82f-47e3-9701-b6fa32bd504a">
