### PR TITLE
Update Sentry-SDK to 1.45.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ Jinja2==3.1.6
 werkzeug==3.0.6
 Flask-DebugToolbar@git+https://github.com/amCap1712/flask-debugtoolbar.git@f42bb238cd3fbc79c51b93c341164c2be820025e
 Flask-UUID==0.2
-sentry-sdk[flask]==1.37.1
+sentry-sdk[flask]==1.45.1
 redis==4.4.4
 msgpack==0.5.6
 requests==2.32.4


### PR DESCRIPTION
This is a security fix backport, fixing the dependabot alert  https://github.com/metabrainz/critiquebrainz/security/dependabot/62 and associated ticket https://tickets.metabrainz.org/browse/SEC-1412