### PR TITLE
Add error logging in URL relationship parsers for artist, label.

### DIFF
--- a/critiquebrainz/frontend/external/relationships/artist.py
+++ b/critiquebrainz/frontend/external/relationships/artist.py
@@ -3,6 +3,7 @@ Relationship processor for artist entity.
 """
 import urllib.parse
 
+from flask import current_app
 from flask_babel import lazy_gettext
 
 
@@ -84,7 +85,10 @@ def _url(url_list):
                     # TODO(roman): Process other types here
                     pass
             except Exception:  # FIXME(roman): Too broad exception clause.
-                # TODO(roman): Log error.
-                pass
+                current_app.logger.error(
+                    "Failed to process artist URL relation of type '%s'.",
+                    relation.get('type', 'unknown'),
+                    exc_info=True,
+                )
 
     return sorted(external_urls, key=lambda k: k['name'])

--- a/critiquebrainz/frontend/external/relationships/label.py
+++ b/critiquebrainz/frontend/external/relationships/label.py
@@ -3,6 +3,7 @@ Relationship processor for label entity.
 """
 import urllib.parse
 
+from flask import current_app
 from flask_babel import lazy_gettext
 
 
@@ -71,7 +72,10 @@ def _url(url_list):
                     # TODO(roman): Process other types here
                     pass
             except Exception:  # FIXME(roman): Too broad exception clause.
-                # TODO(roman): Log error.
-                pass
+                current_app.logger.error(
+                    "Failed to process label URL relation of type '%s'.",
+                    relation.get('type', 'unknown'),
+                    exc_info=True,
+                )
 
     return sorted(external_urls, key=lambda k: k['name'])

--- a/critiquebrainz/frontend/external/relationships/release_group.py
+++ b/critiquebrainz/frontend/external/relationships/release_group.py
@@ -3,6 +3,7 @@ Relationship processor for release group entity.
 """
 import urllib.parse
 
+from flask import current_app
 from flask_babel import lazy_gettext
 
 
@@ -50,7 +51,10 @@ def _url(url_list):
                     # TODO(roman): Process other types here
                     pass
             except Exception:  # FIXME(roman): Too broad exception clause.
-                # TODO(roman): Log error.
-                pass
+                current_app.logger.error(
+                    "Failed to process release group URL relation of type '%s'.",
+                    relation.get('type', 'unknown'),
+                    exc_info=True,
+                )
 
     return sorted(external_urls, key=lambda k: k['name'])


### PR DESCRIPTION
Replacing silent pass in exception handlers with current_app.logger.error() calls that log the relation type and full traceback. This resolves the TODO comments left by roman in all three relationship processor files.

Files changed:
- critiquebrainz/frontend/external/relationships/artist.py
- critiquebrainz/frontend/external/relationships/label.py
- critiquebrainz/frontend/external/relationships/release_group.py