### PR TITLE
Replace MusicBrainz with MetaBrainz on login page

### DIFF
--- a/critiquebrainz/frontend/templates/login/index.html
+++ b/critiquebrainz/frontend/templates/login/index.html
@@ -4,11 +4,11 @@
 
 {% block content %}
 <h3>{{ _('Sign in') }}</h3>
-<p>{{ _('To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to access your profile data.') }}</p>
+<p>{{ _('To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to access your profile data.') }}</p>
 <hr />
 <div class="well" style="max-width: 600px; margin: 0 auto;">
   <a href="{{ url_for('login.musicbrainz', next=request.args.get('next'), login_hint='login') }}"
-     class="btn btn-primary btn-lg btn-block">{{ _('Sign in with MusicBrainz') }}</a>
+     class="btn btn-primary btn-lg btn-block">{{ _('Sign in with MetaBrainz') }}</a>
   <div style="margin-top: 10px;">
     <p style="text-align: center;">{{ _("Don't have an account?") }}</p>
     <a href="{{ url_for('login.musicbrainz', next=request.args.get('next'), login_hint='register') }}"

--- a/critiquebrainz/frontend/translations/de/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/de/LC_MESSAGES/messages.po
@@ -1243,13 +1243,13 @@ msgstr "Grund:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "Um dich einzuloggen, benutze dein MusicBrainz-Konto und gewähre CritiqueBrainz Zugriff auf deine Profildaten."
+msgstr "Um dich einzuloggen, benutze dein MetaBrainz-Konto und gewähre CritiqueBrainz Zugriff auf deine Profildaten."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Mit MusicBrainz einloggen"
+msgid "Sign in with MetaBrainz"
+msgstr "Mit MetaBrainz einloggen"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/el/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/el/LC_MESSAGES/messages.po
@@ -702,12 +702,12 @@ msgstr ""
 
 #: critiquebrainz/frontend/templates/login/login.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
 msgstr ""
 
 #: critiquebrainz/frontend/templates/login/login.html:11
-msgid "Sign in with MusicBrainz"
+msgid "Sign in with MetaBrainz"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:3

--- a/critiquebrainz/frontend/translations/en/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/en/LC_MESSAGES/messages.po
@@ -1234,13 +1234,13 @@ msgstr "Reason:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to access your profile data."
+msgstr "To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to access your profile data."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Sign in with MusicBrainz"
+msgid "Sign in with MetaBrainz"
+msgstr "Sign in with MetaBrainz"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/eo/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/eo/LC_MESSAGES/messages.po
@@ -702,12 +702,12 @@ msgstr ""
 
 #: critiquebrainz/frontend/templates/login/login.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
 msgstr ""
 
 #: critiquebrainz/frontend/templates/login/login.html:11
-msgid "Sign in with MusicBrainz"
+msgid "Sign in with MetaBrainz"
 msgstr ""
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:3

--- a/critiquebrainz/frontend/translations/es/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/es/LC_MESSAGES/messages.po
@@ -1241,13 +1241,13 @@ msgstr "Motivo:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "Para ingresar, utilice su cuenta MusicBrainz y permita que CritiqueBrainz tenga acceso a los datos de su perfil."
+msgstr "Para ingresar, utilice su cuenta MetaBrainz y permita que CritiqueBrainz tenga acceso a los datos de su perfil."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Iniciar sesión con MusicBrainz"
+msgid "Sign in with MetaBrainz"
+msgstr "Iniciar sesión con MetaBrainz"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/et/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/et/LC_MESSAGES/messages.po
@@ -1234,13 +1234,13 @@ msgstr ""
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "Sisselogimiseks kasuta oma MusicBrainzi kontot ja luba CritiqueBrainzil profiiliandmeid näha."
+msgstr "Sisselogimiseks kasuta oma MetaBrainzi kontot ja luba CritiqueBrainzil profiiliandmeid näha."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Logi sisse MusicBrainzi kaudu"
+msgid "Sign in with MetaBrainz"
+msgstr "Logi sisse MetaBrainzi kaudu"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/fi/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/fi/LC_MESSAGES/messages.po
@@ -1234,13 +1234,13 @@ msgstr "Syy:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "Kirjaudu MusicBrainzin käyttäjätililläsi, ja salli CritiqueBrainzin pääsy profiiliisi."
+msgstr "Kirjaudu MetaBrainzin käyttäjätililläsi, ja salli CritiqueBrainzin pääsy profiiliisi."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Kirjaudu MusicBrainzilla"
+msgid "Sign in with MetaBrainz"
+msgstr "Kirjaudu MetaBrainzilla"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/fr/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/fr/LC_MESSAGES/messages.po
@@ -1240,13 +1240,13 @@ msgstr "Raison :"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "Pour vous connecter, utilisez votre compte MusicBrainz et autorisez CritiqueBrainz à accéder aux données de votre profil."
+msgstr "Pour vous connecter, utilisez votre compte MetaBrainz et autorisez CritiqueBrainz à accéder aux données de votre profil."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Se connecter avec MusicBrainz"
+msgid "Sign in with MetaBrainz"
+msgstr "Se connecter avec MetaBrainz"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/he/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/he/LC_MESSAGES/messages.po
@@ -150,7 +150,7 @@ msgid ""
 "Do not allow commercial use of my reviews, unless approved by MetaBrainz "
 "Foundation (<a href=\"https://creativecommons.org/licenses/by-nc-sa/3.0/\" "
 "target=\"_blank\">CC BY-NC-SA 3.0 license</a>)"
-msgstr "לא לאפשר שימוש מסחרי בביקורת זו אלה אם אושר על ידי קרן מוזיקבריינז (<a href=\"https://creativecommons.org/licenses/by-sa/3.0/\" target=\"_blank\">רישיון CC BY-NC-SA 3.0 </a>)"
+msgstr "לא לאפשר שימוש מסחרי בביקורת זו אלה אם אושר על ידי קרן מטאבריינז (<a href=\"https://creativecommons.org/licenses/by-sa/3.0/\" target=\"_blank\">רישיון CC BY-NC-SA 3.0 </a>)"
 
 #: critiquebrainz/frontend/forms/profile_apps.py:7
 msgid "Application name"
@@ -236,7 +236,7 @@ msgid ""
 "Do not allow commercial use of this review, unless approved by MetaBrainz "
 "Foundation (<a href=\"https://creativecommons.org/licenses/by-nc-sa/3.0/\" "
 "target=\"_blank\">CC BY-NC-SA 3.0 license</a>)"
-msgstr "לא לאפשר שימוש מסחרי בביקורת זו אלה אם אושר על ידי קרן מוזיקבריינז (<a href=\"https://creativecommons.org/licenses/by-sa/3.0/\" target=\"_blank\">רישיון CC BY-NC-SA 3.0 </a>)"
+msgstr "לא לאפשר שימוש מסחרי בביקורת זו אלה אם אושר על ידי קרן מטאבריינז (<a href=\"https://creativecommons.org/licenses/by-sa/3.0/\" target=\"_blank\">רישיון CC BY-NC-SA 3.0 </a>)"
 
 #: critiquebrainz/frontend/forms/review.py:40
 msgid "You need to choose a license"
@@ -1238,11 +1238,11 @@ msgstr "סיבה:"
 msgid ""
 "To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr ""
+msgstr "לכניסה, ניתן להשתמש בחשבון מטאבריינז ולאפשר לקריטיקבריינז גישה לפרופיל שלכם."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
 msgid "Sign in with MetaBrainz"
-msgstr ""
+msgstr "כניסה עם מטאבריינז"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"
@@ -1860,7 +1860,7 @@ msgid ""
 "            infringes the rights of any third-party, and that you have the permission to use and to license the work\n"
 "            under the selected Creative Commons license. Finally, you give the MetaBrainz Foundation permission to license\n"
 "            this content for commercial use outside of Creative Commons licenses in order to support the operations of the organization."
-msgstr "אתם מאשרים ומסכימים כי הביקורות שתרמתם לקריטיקבריינז מורשות תחת רישיון\n Creative Commons Attribution-ShareAlike 3.0 Unported או Creative Commons Attribution-ShareAlike-NonCommercial\n לפי בחירתכם לעיל. אתם מסכימים להרשות את עבודתכם במסגרת רישיון זה.\nאתם מצהירים ומתחייבים שכל הזכויות בעבודה ולגביה בבעלותכם או\nבשליטתכם , וכי שום דבר בעבודה אינו מפר זכויות של צד ג' כלשהו, וכי \nיש לכם הרשאה להשתמש בעבודה ולרשותה תחת הרישיון שנבחר על ידי Creative Commons. \nלסיום, אתם נותנים לקרן מוזיקבריינז אישור להרשות תוכן זה לשימוש מסחרי\nמעבר לרישיונות Creative Commons על מנת לתמוך בפעילות הארגון."
+msgstr "אתם מאשרים ומסכימים כי הביקורות שתרמתם לקריטיקבריינז מורשות תחת רישיון\n Creative Commons Attribution-ShareAlike 3.0 Unported או Creative Commons Attribution-ShareAlike-NonCommercial\n לפי בחירתכם לעיל. אתם מסכימים להרשות את עבודתכם במסגרת רישיון זה.\nאתם מצהירים ומתחייבים שכל הזכויות בעבודה ולגביה בבעלותכם או\nבשליטתכם , וכי שום דבר בעבודה אינו מפר זכויות של צד ג' כלשהו, וכי \nיש לכם הרשאה להשתמש בעבודה ולרשותה תחת הרישיון שנבחר על ידי Creative Commons. \nלסיום, אתם נותנים לקרן מטאבריינז אישור להרשות תוכן זה לשימוש מסחרי\nמעבר לרישיונות Creative Commons על מנת לתמוך בפעילות הארגון."
 
 #: critiquebrainz/frontend/templates/search/index.html:5
 msgid "Search results"

--- a/critiquebrainz/frontend/translations/he/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/he/LC_MESSAGES/messages.po
@@ -1236,13 +1236,13 @@ msgstr "סיבה:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "לכניסה, ניתן להשתמש בחשבון מוזיקבריינז ולאפשר לקריטיקבריינז גישה לפרופיל שלכם."
+msgstr ""
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "כניסה עם מוזיקבריינז"
+msgid "Sign in with MetaBrainz"
+msgstr ""
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/hr/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/hr/LC_MESSAGES/messages.po
@@ -1236,13 +1236,13 @@ msgstr "Razlog:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "Kako bi se prijavili, koristite svoj MusicBrainz račun i dopustite CritiqueBrainzu pristup vašim profilnim podatcima."
+msgstr "Kako bi se prijavili, koristite svoj MetaBrainz račun i dopustite CritiqueBrainzu pristup vašim profilnim podatcima."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Prijavi se pomoću MusicBrainza"
+msgid "Sign in with MetaBrainz"
+msgstr "Prijavi se pomoću MetaBrainza"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/it/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/it/LC_MESSAGES/messages.po
@@ -1235,13 +1235,13 @@ msgstr "Motivo:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "Per effettuare l'accesso, utilizza il tuo account MusicBrainz e autorizza CritiqueBrainz ad accedere ai dati del tuo profilo."
+msgstr "Per effettuare l'accesso, utilizza il tuo account MetaBrainz e autorizza CritiqueBrainz ad accedere ai dati del tuo profilo."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Accedi con MusicBrainz"
+msgid "Sign in with MetaBrainz"
+msgstr "Accedi con MetaBrainz"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/nb/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/nb/LC_MESSAGES/messages.po
@@ -1238,13 +1238,13 @@ msgstr "Begrunnelse:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "For å logge inn, bruk MusicBrainz-kontoen din, og tildel CritiqueBrainz tilgang til profildataene dine."
+msgstr "For å logge inn, bruk MetaBrainz-kontoen din, og tildel CritiqueBrainz tilgang til profildataene dine."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Logg inn med MusicBrainz"
+msgid "Sign in with MetaBrainz"
+msgstr "Logg inn med MetaBrainz"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/nl/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/nl/LC_MESSAGES/messages.po
@@ -1236,13 +1236,13 @@ msgstr "Reden:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "Gebruik je MusicBrainz-account om in te loggen, en geef CritiqueBrainz toestemming om je profielgegevens in te zien."
+msgstr "Gebruik je MetaBrainz-account om in te loggen, en geef CritiqueBrainz toestemming om je profielgegevens in te zien."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Inloggen met MusicBrainz"
+msgid "Sign in with MetaBrainz"
+msgstr "Inloggen met MetaBrainz"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/pl/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/pl/LC_MESSAGES/messages.po
@@ -1237,13 +1237,13 @@ msgstr "Powód:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "Aby się zalogować użyj konta MusicBrainz i zezwól CritiqueBrainz na dostęp do swoich danych."
+msgstr "Aby się zalogować użyj konta MetaBrainz i zezwól CritiqueBrainz na dostęp do swoich danych."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Zaloguj się z MusicBrainz"
+msgid "Sign in with MetaBrainz"
+msgstr "Zaloguj się z MetaBrainz"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/ru/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/ru/LC_MESSAGES/messages.po
@@ -1243,13 +1243,13 @@ msgstr "Причина:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
-msgstr "Для регистрации, используйте свою учетную запись в MusicBrainz и разрешите доступ CritiqueBrainz к данным вашего профиля."
+msgstr "Для регистрации, используйте свою учетную запись в MetaBrainz и разрешите доступ CritiqueBrainz к данным вашего профиля."
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Зарегистрируйтесь с MusicBrainz"
+msgid "Sign in with MetaBrainz"
+msgstr "Зарегистрируйтесь с MetaBrainz"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"

--- a/critiquebrainz/frontend/translations/sv/LC_MESSAGES/messages.po
+++ b/critiquebrainz/frontend/translations/sv/LC_MESSAGES/messages.po
@@ -1236,13 +1236,13 @@ msgstr "Orsak:"
 
 #: critiquebrainz/frontend/templates/login/index.html:7
 msgid ""
-"To sign in, use your MusicBrainz account, and authorize CritiqueBrainz to "
+"To sign in, use your MetaBrainz account, and authorize CritiqueBrainz to "
 "access your profile data."
 msgstr ""
 
 #: critiquebrainz/frontend/templates/login/index.html:11
-msgid "Sign in with MusicBrainz"
-msgstr "Logga in med MusicBrainz"
+msgid "Sign in with MetaBrainz"
+msgstr "Logga in med MetaBrainz"
 
 #: critiquebrainz/frontend/templates/mapping/confirm.html:4
 msgid "New Spotify mapping confirmation"


### PR DESCRIPTION
For Hebrew, the translations were removed, since I'm unable to do the transliterations myself.