### PR TITLE
Implement webhook handlers for user update and deletion 

### DIFF
--- a/critiquebrainz/db/test/webhook_handlers_test.py
+++ b/critiquebrainz/db/test/webhook_handlers_test.py
@@ -1,0 +1,104 @@
+from unittest import TestCase, mock
+
+from critiquebrainz.db import webhook_handlers
+
+
+class WebhookHandlersTestCase(TestCase):
+
+    @mock.patch("critiquebrainz.db.webhook_handlers.db_users")
+    def test_handle_user_updated_updates_username_and_email(self, db_users):
+        user = {
+            "id": "cb-user-id",
+            "display_name": "old_name",
+            "musicbrainz_username": "old_name",
+            "email": "old@example.com",
+        }
+        updated_user = dict(user, musicbrainz_username="new_name", display_name="new_name")
+        db_users.get_by_mb_row_id.return_value = user
+        db_users.update_username.return_value = updated_user
+
+        webhook_handlers.handle_user_updated({
+            "user_id": 1,
+            "new": {
+                "name": "new_name",
+                "email": "new@example.com",
+            },
+            "old": {
+                "name": "old_name",
+                "email": None,
+            },
+        }, "delivery-id")
+
+        db_users.get_by_mb_row_id.assert_called_once_with(1)
+        db_users.update_username.assert_called_once_with(user, "new_name")
+        db_users.update.assert_called_once_with("cb-user-id", {"email": "new@example.com"})
+
+    @mock.patch("critiquebrainz.db.webhook_handlers.db_users")
+    def test_handle_user_updated_updates_email_only(self, db_users):
+        user = {
+            "id": "cb-user-id",
+            "display_name": "old_name",
+            "musicbrainz_username": "old_name",
+            "email": None,
+        }
+        db_users.get_by_mb_row_id.return_value = user
+
+        webhook_handlers.handle_user_updated({
+            "user_id": 1,
+            "new": {
+                "email": "new@example.com",
+            },
+            "old": {
+                "email": None,
+            },
+        }, "delivery-id")
+
+        db_users.get_by_mb_row_id.assert_called_once_with(1)
+        db_users.update_username.assert_not_called()
+        db_users.update.assert_called_once_with("cb-user-id", {"email": "new@example.com"})
+
+    @mock.patch("critiquebrainz.db.webhook_handlers.db_users")
+    def test_handle_user_updated_returns_when_no_relevant_changes(self, db_users):
+        webhook_handlers.handle_user_updated({
+            "user_id": 1,
+            "new": {
+                "irrelevant": "value",
+            },
+        }, "delivery-id")
+
+        db_users.get_by_mb_row_id.assert_not_called()
+        db_users.update_username.assert_not_called()
+        db_users.update.assert_not_called()
+
+    @mock.patch("critiquebrainz.db.webhook_handlers.db_users")
+    def test_handle_user_updated_returns_when_user_is_missing(self, db_users):
+        db_users.get_by_mb_row_id.return_value = None
+
+        webhook_handlers.handle_user_updated({
+            "user_id": 1,
+            "new": {
+                "name": "new_name",
+            },
+        }, "delivery-id")
+
+        db_users.get_by_mb_row_id.assert_called_once_with(1)
+        db_users.update_username.assert_not_called()
+        db_users.update.assert_not_called()
+
+    @mock.patch("critiquebrainz.db.webhook_handlers.db_users")
+    def test_handle_user_deleted_deletes_user(self, db_users):
+        db_users.get_by_mb_row_id.return_value = {"id": "cb-user-id"}
+
+        webhook_handlers.handle_user_deleted({"user_id": 1}, "delivery-id")
+
+        db_users.get_by_mb_row_id.assert_called_once_with(1)
+        db_users.delete.assert_called_once_with("cb-user-id")
+
+    @mock.patch("critiquebrainz.db.webhook_handlers.db_users")
+    def test_handle_user_deleted_returns_when_user_is_missing(self, db_users):
+        db_users.get_by_mb_row_id.return_value = None
+
+        webhook_handlers.handle_user_deleted({"user_id": 1}, "delivery-id")
+
+        db_users.get_by_mb_row_id.assert_called_once_with(1)
+        db_users.delete.assert_not_called()

--- a/critiquebrainz/db/webhook_handlers.py
+++ b/critiquebrainz/db/webhook_handlers.py
@@ -41,29 +41,9 @@ def handle_user_created(payload: dict[str, Any], delivery_id: str) -> None:
         )
         logger.info(f"Successfully created user {payload['name']} (delivery_id: {delivery_id})")
     except Exception as e:
-        logger.error(f"Failed to create user from webhook (delivery_id: {delivery_id}): {e}", exc_info=True)
+        logger.error(
+            f"Failed to create user {payload["user_id"]}({payload['name']}) from webhook (delivery_id: {delivery_id}): {e}", exc_info=True)
         raise
-
-
-def handle_user_verified(payload: dict[str, Any], delivery_id: str) -> None:
-    """Process user.verified webhook event.
-
-    This event is triggered when a user verifies their email address.
-
-    Args:
-        payload: Webhook payload containing:
-            - user_id (int): MusicBrainz row ID of the user
-            - email (str): Verified email address
-            - verified_at (str): ISO 8601 timestamp of verification
-        delivery_id: Unique identifier for this webhook delivery (UUID)
-
-    Note:
-        Implementation pending - CritiqueBrainz doesn't currently track
-        email verification status separately.
-    """
-    logger.info(f"Processing user.verified event (delivery_id: {delivery_id})")
-    logger.warning(f"user.verified handler not yet implemented (delivery_id: {delivery_id})")
-    # TODO: Implement email verification tracking if needed
 
 
 def handle_user_updated(payload: dict[str, Any], delivery_id: str) -> None:
@@ -73,15 +53,41 @@ def handle_user_updated(payload: dict[str, Any], delivery_id: str) -> None:
     on the OAuth provider.
 
     Args:
-        payload: Webhook payload structure TBD by OAuth provider
+        payload: Webhook payload containing:
+            - user_id (int): MusicBrainz row ID of the user
+            - old (dict): Previous values for changed fields
+            - new (dict): New values for changed fields
+            - updated_at (str): ISO 8601 timestamp of the update
         delivery_id: Unique identifier for this webhook delivery (UUID)
-
-    Note:
-        Implementation pending - event structure not yet defined by provider.
     """
     logger.info(f"Processing user.updated event (delivery_id: {delivery_id})")
-    logger.warning(f"user.updated handler not yet implemented (delivery_id: {delivery_id})")
-    # TODO: Implement when OAuth provider adds this event type
+
+    user_id = payload["user_id"]
+    new_data = payload.get("new", {})
+
+    new_username = new_data.get("name")
+    has_email_update = "email" in new_data
+
+    if not new_username and not has_email_update:
+        logger.info(f"No name or email update in user.updated webhook for user_id={user_id}")
+        return
+
+    user = db_users.get_by_mb_row_id(user_id)
+    if not user:
+        logger.error(f"User with musicbrainz_row_id={user_id} not found for user.updated webhook")
+        return
+
+    try:
+        if new_username:
+            user = db_users.update_username(user, new_username)
+
+        if has_email_update:
+            db_users.update(user["id"], {"email": new_data.get("email")})
+
+        logger.info(f"Successfully updated user {user_id} (delivery_id: {delivery_id})")
+    except Exception as e:
+        logger.error(f"Failed to update user {user_id} from webhook (delivery_id: {delivery_id}): {e}", exc_info=True)
+        raise
 
 
 def handle_user_deleted(payload: dict[str, Any], delivery_id: str) -> None:
@@ -91,22 +97,30 @@ def handle_user_deleted(payload: dict[str, Any], delivery_id: str) -> None:
     OAuth provider (GDPR compliance).
 
     Args:
-        payload: Webhook payload structure TBD by OAuth provider
+        payload: Webhook payload containing:
+            - user_id (int): MusicBrainz row ID of the user
         delivery_id: Unique identifier for this webhook delivery (UUID)
-
-    Note:
-        Implementation pending - event structure not yet defined by provider.
     """
     logger.info(f"Processing user.deleted event (delivery_id: {delivery_id})")
-    logger.warning(f"user.deleted handler not yet implemented (delivery_id: {delivery_id})")
-    # TODO: Implement when OAuth provider adds this event type
+
+    user_id = payload["user_id"]
+    user = db_users.get_by_mb_row_id(user_id)
+    if not user:
+        logger.error(f"User with musicbrainz_row_id={user_id} not found for user.deleted webhook")
+        return
+
+    try:
+        db_users.delete(user["id"])
+        logger.info(f"Successfully deleted user {user_id} (delivery_id: {delivery_id})")
+    except Exception as e:
+        logger.error(f"Failed to delete user {user_id} from webhook (delivery_id: {delivery_id}): {e}", exc_info=True)
+        raise
 
 
 # Event handler registry
 # Maps event type strings to their handler functions
 EVENT_HANDLERS = {
     "user.created": handle_user_created,
-    "user.verified": handle_user_verified,
     "user.updated": handle_user_updated,
     "user.deleted": handle_user_deleted,
 }


### PR DESCRIPTION
These were previously TODO items.
Also removes "user.verified" which is no longer in use (we user "user.updated" with the new email).

Of note, the current user deletion routine also deletes all their reviews and ratings.
If we want to change this (like we do in BB/MB, rename to "deleted editor" or something like that, keeping the reviews), that is a departure from the status quo.


